### PR TITLE
newlines part 2!

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -104,7 +104,7 @@ class BinderHub(Application):
     )
 
     builder_image_spec = Unicode(
-        'yuvipanda/builderhub-builder:v0.1.16',
+        'jupyter/repo2docker:0.2.0',
         help="""
         The builder image to be used for doing builds
         """,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -49,7 +49,7 @@ class Build:
             self.git_url,
             '--ref', self.ref,
             '--image', self.image_name,
-            '--push', '--no-clean', '--no-run'
+            '--push', '--no-clean', '--no-run', '--json-logs',
         ]
 
     def progress(self, kind, obj):

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -114,9 +114,9 @@ class BuildHandler(web.RequestHandler):
 
             if progress['kind'] == 'pod.phasechange':
                 if progress['payload'] == 'Pending':
-                    event = {'message': 'Waiting for build to start...', 'phase': 'waiting'}
+                    event = {'message': 'Waiting for build to start...\n', 'phase': 'waiting'}
                 elif progress['payload'] == 'Deleted':
-                    event = {'phase': 'completed', 'message': 'Build completed, launching...', 'imageName': image_name}
+                    event = {'phase': 'completed', 'message': 'Build completed, launching...\n', 'imageName': image_name}
                     done = True
                 elif progress['payload'] == 'Running':
                     if not log_thread.is_alive():

--- a/binderhub/index.html
+++ b/binderhub/index.html
@@ -19,7 +19,7 @@
     <body>
         <div id="main" class="container">
             <div class="row">
-                <div class="col-md-8 col-md-offset-2">
+                <div class="col-lg-10 col-lg-offset-1">
                     <div id="logo-container">
                         <img id="logo" src="/static/logo.svg" width="375px"  />
                         <h3>Turn a GitHub repo into a collection of interactive notebooks</h3>

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -3,22 +3,24 @@ $(function(){
     var failed = false;
     var log = new Terminal({
         convertEol: true,
-        disableStdin: true
+        disableStdin: true,
     });
-    log.open(document.getElementById('log'));
+
+    log.open(document.getElementById('log'), false);
+    $(window).resize(function() {
+        log.fit();
+    });
 
     $('#toggle-logs').click(function() {
         var $panelBody = $('#log-container .panel-body');
         if ($panelBody.hasClass('hidden')) {
             $('#toggle-logs button').text('hide');
             $panelBody.removeClass('hidden');
-
         } else {
             $('#toggle-logs button').text('show');
             $panelBody.addClass('hidden');
         }
 
-        log.fit();
         return false;
     });
 
@@ -34,11 +36,11 @@ $(function(){
         $('#phase-waiting').removeClass('hidden');
         $('.on-build').removeClass('hidden');
 
-
         source.addEventListener('message', function(e){
+            log.fit();
             var data = JSON.parse(e.data);
             if (data.message !== undefined) {
-                log.writeln(data.message);
+                log.write(data.message);
             } else {
                 log.writeln(JSON.stringify(data));
             }


### PR DESCRIPTION
- [x] This will need https://github.com/jupyter/repo2docker/pull/14 to be merged, pushed, and tagged, and updated in `builder_image_spec`

Move newline handling to server side:  Don’t append newlines to every message with writeln. This allows proper handling of carriage returns coming from builder messages.

Also widen the default view a bit so that 80 cols fit.