### PR TITLE
[WIP] throw error if URL isn't right

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -71,6 +71,13 @@ class BuildHandler(web.RequestHandler):
         provider = self.settings['repo_providers'][provider_prefix](config=self.settings['traitlets_config'], spec=spec)
 
         ref = yield provider.get_resolved_ref()
+        if ref is None:
+            # If get_resolved_ref yields None, it means we couldn't resolve.
+            self.emit({
+                'phase': 'failed',
+                'message': 'Could not resolve repository URL. Check that it is correct.\n'
+            })
+            return
         build_name = self._generate_build_name(provider.get_build_slug(), ref).replace('_', '-')
 
         # We gonna send out event streams!


### PR DESCRIPTION
This is an attempt at raising an error if the build parameters somebody gives isn't correct. I suspect that I'm missing something here, as I couldn't get this error to pop up on my local build. Then again I'm pretty sure that my local build is broken in a more fundamental way than this error because I can't get minikube to work.

Let me know if this is generally the right direction though.