### PR TITLE
launch via Hub API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ and run binderhub on the host system.
 
     ```python
     c.BinderHub.use_registry = False
-    c.BinderHub.hub_login_url = 'http://<minikube-ip>:<proxy-public-port>/hub/tmplogin'
+    c.BinderHub.hub_url = 'http://<minikube-ip>:<proxy-public-port>/'
     ```
 6. install binderhub:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,9 @@ and run binderhub on the host system.
     ```python
     c.BinderHub.use_registry = False
     c.BinderHub.hub_url = 'http://<minikube-ip>:<proxy-public-port>/'
+    c.BinderHub.hub_api_token = 'aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4'
     ```
+
 6. install binderhub:
 
         python3 -m pip install -e .

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -117,13 +117,13 @@ class BinderHub(Application):
         help="""
         The base URL of the JupyterHub instance where users will run.
 
-        Must end in '/'
         e.g. https://hub.mybinder.org/
         """,
         config=True,
     )
     @validate('hub_url')
     def _add_slash(self, proposal):
+        """trait validator to ensure hub_url ends with a trailing slash"""
         if proposal.value is not None and not proposal.value.endswith('/'):
             return proposal.value + '/'
         return proposal.value

--- a/binderhub/redirect.py
+++ b/binderhub/redirect.py
@@ -38,7 +38,7 @@ class RedirectHandler(BaseHandler):
         e.g. minrk-binder-example-abc123
         """
         # use image for first part of the username
-        prefix = image.split(':')[0]
+        prefix = image.split(':')[0].replace('/', '-')
         if len(prefix) > 32:
             # if it's long, truncate
             prefix = '{}-{}'.format(prefix[:15], prefix[-15:])

--- a/binderhub/redirect.py
+++ b/binderhub/redirect.py
@@ -1,16 +1,91 @@
 """
 Handler for URL redirection
 """
-from tornado import web, gen
+import base64
+import json
+import random
+import string
+import uuid
+from urllib.parse import quote
+
+from tornado.log import app_log
+from tornado import web
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
+from tornado.httputil import url_concat
 
 from .base import BaseHandler
 
+# Add a random lowercase alphanumeric suffix to usernames to avoid collisions
+SUFFIX_CHARS = string.ascii_lowercase + string.digits
+# 36**8 ~= 2**41
+SUFFIX_LENGTH = 8
 
 class RedirectHandler(BaseHandler):
     """Handler for URL redirects."""
+    async def api_request(self, url, *args, **kwargs):
+        """Make an API request to JupyterHub"""
+        headers = kwargs.setdefault('headers', {})
+        headers.update({'Authorization': 'token %s' % self.settings['hub_api_token']})
+        req = HTTPRequest(self.settings['hub_url'] + 'hub/api/' + url, *args, **kwargs)
+        resp = await AsyncHTTPClient().fetch(req)
+        # TODO: handle errors
+        return resp
 
-    def get(self):
-        if self.settings['hub_login_url'] is None:
-            raise web.HTTPError(500, "No hub configured!")
-        url = self.settings['hub_login_url'] + '?' + self.request.query
-        self.redirect(url)
+    def username_from_image(self, image):
+        """Generate a username for an image
+
+        e.g. minrk-binder-example-abc123
+        """
+        # use image for first part of the username
+        prefix = image.split(':')[0]
+        if len(prefix) > 32:
+            # if it's long, truncate
+            prefix = '{}-{}'.format(prefix[:15], prefix[-15:])
+        # add a random suffix to avoid collisions for users on the same image
+        return '{}-{}'.format(prefix, ''.join(random.choices(SUFFIX_CHARS, k=SUFFIX_LENGTH)))
+
+    async def get(self):
+        image = self.get_argument('image')
+        filepath = self.get_argument('filepath')
+        if not image:
+            raise web.HTTPError(400, "image argument is required")
+        username = self.username_from_image(image)
+
+        # create a new user
+        app_log.info("Creating user %s for image %s", username, image)
+        try:
+            await self.api_request('users/%s' % username, body=b'', method='POST')
+        except HTTPError as e:
+            app_log.error("Error creating user %s: %s\n%s",
+                username, e, e.response.body,
+            )
+            raise web.HTTPError(500, "Failed to create temporary user for %s" % image)
+
+        # generate a token
+        token = base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=\n')
+
+        # start server
+        app_log.info("Starting server for user %s with image %s", username, image)
+        try:
+            await self.api_request(
+                'users/%s/server' % username,
+                method='POST',
+                body=json.dumps({
+                    'token': token,
+                    'image': image,
+                }).encode('utf8'),
+            )
+        except HTTPError as e:
+            app_log.error("Error starting server for %s: %s\n%s",
+                username, e, e.response.body,
+            )
+            raise web.HTTPError(500, "Failed to launch image %s" % image)
+
+        url = self.settings['hub_url'] + 'user/%s/' % username
+        if filepath:
+            url = url + 'tree/%s' % quote(filepath)
+
+        app_log.info("Redirecting to %s", url)
+        # redirect with token
+        self.redirect(url_concat(url, {'token': token}))
+

--- a/binderhub/redirect.py
+++ b/binderhub/redirect.py
@@ -36,9 +36,14 @@ class RedirectHandler(BaseHandler):
         """Generate a username for an image
 
         e.g. minrk-binder-example-abc123
+        from gcr.io/minrk-binder-example:sha...
         """
         # use image for first part of the username
-        prefix = image.split(':')[0].replace('/', '-')
+        prefix = image.split(':')[0]
+        if '/' in prefix:
+            # Strip 'docker-repo/' off because it's an implementation detail.
+            # Only keep the image name, which has source repo info.
+            prefix = prefix.split('/')[1]
         if len(prefix) > 32:
             # if it's long, truncate
             prefix = '{}-{}'.format(prefix[:15], prefix[-15:])
@@ -50,6 +55,9 @@ class RedirectHandler(BaseHandler):
         filepath = self.get_argument('filepath')
         if not image:
             raise web.HTTPError(400, "image argument is required")
+
+        # TODO: validate the image argument?
+
         username = self.username_from_image(image)
 
         # create a new user

--- a/binderhub/redirect.py
+++ b/binderhub/redirect.py
@@ -16,8 +16,9 @@ from tornado.httputil import url_concat
 from .base import BaseHandler
 
 # Add a random lowercase alphanumeric suffix to usernames to avoid collisions
+# Set of characters from which to generate a suffix
 SUFFIX_CHARS = string.ascii_lowercase + string.digits
-# 36**8 ~= 2**41
+# Set length of suffix. Number of combinations = SUFFIX_CHARS**SUFFIX_LENGTH = 36**8 ~= 2**41
 SUFFIX_LENGTH = 8
 
 class RedirectHandler(BaseHandler):

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -48,6 +48,9 @@ First create a file called ``secret.yaml``. In it, put the following code::
     jupyterhub:
       hub:
         cookieSecret: "<openssl rand -hex 32>"
+        services:
+          binder:
+            apiToken: "<openssl rand -hex 32>"
       proxy:
         secretToken: "<openssl rand -hex 32>"
     registry:

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -3,6 +3,8 @@
 
 hub:
   cookieSecret: "36091e950f98f033aeae2520e2fe4c8599bc391598f910e510ad670765fbc1ff"
+  db:
+    type: "sqlite-memory"
   extraConfig: |
     import json
     import urllib

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -5,6 +5,9 @@ hub:
   cookieSecret: "36091e950f98f033aeae2520e2fe4c8599bc391598f910e510ad670765fbc1ff"
   db:
     type: "sqlite-memory"
+  services:
+    binder:
+      apiToken: "aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4"
   extraConfig: |
     # disable login (users created exclusively via API)
     c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
@@ -32,19 +35,6 @@ hub:
 
     # launch jupyter notebook instead of jupyterhub-singleuser
     c.JupyterHub.spawner_class = BinderSpawner
-
-    # disable all XSS protections:
-    # FIXME: Make this more secure before allowing any authenticated state into binder
-    c.BinderSpawner.args.append('--NotebookApp.disable_check_xsrf=True')
-    c.BinderSpawner.args.append('--NotebookApp.allow_origin="*"')
-    c.BinderSpawner.args.append("--NotebookApp.tornado_settings={'headers': {'Content-Security-Policy': ''}}")
-
-    # add binder API token!
-    c.JupyterHub.services.append({
-        'name': 'binder',
-        'admin': True,
-        'api_token': 'aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4',
-    })
 
     # debug!
     c.JupyterHub.log_level = 10

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -6,45 +6,51 @@ hub:
   db:
     type: "sqlite-memory"
   extraConfig: |
-    import json
-    import urllib
-    from tmpauthenticator import TmpAuthenticator
+    # disable login (users created exclusively via API)
+    c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
+
+    # image & token are set via spawn options
     from kubespawner import KubeSpawner
-    from jupyterhub.utils import url_path_join
-    class DynamicImageAuth(TmpAuthenticator):
-        def process_user(self, user, handler):
-            # We take all the url params and put them into a `url_options` field
-            # Not using `user_options` since that seems to be cleared by JupyterHub.
-            arguments = { k: handler.get_argument(k) for k in handler.request.arguments }
-            user.spawner.url_options = arguments
-            return user
 
-        def pre_spawn_start(self, user, spawner):
-            # Support for each runtime parameter is set up here!
-            # FIXME: Make sure we only run authorized images!
-            spawner.singleuser_image_spec = spawner.url_options['image']
+    class BinderSpawner(KubeSpawner):
+      def get_args(self):
+          return [
+              '--ip=0.0.0.0',
+              '--port=%i' % self.port,
+              '--NotebookApp.base_url=%s' % self.server.base_url,
+              '--NotebookApp.token=%s' % self.user_options['token'],
+          ] + self.args
 
-            # Detect if we're pointing to a particular file!
-            # FIXME:
-            filepath = spawner.url_options.get('filepath', None)
-            if filepath:
-                parts = urllib.parse.urlparse(filepath)
-                if parts.path.endswith('.ipynb'):
-                    parts = parts._replace(path=url_path_join('/notebooks', parts.path))
-                else:
-                    parts = parts._replace(path=url_path_join('/edit', parts.path))
-                spawner.default_url = urllib.parse.urlunparse(parts)
+      def start(self):
+          if 'token' not in self.user_options:
+            raise web.HTTPError(400, "token required")
+          if 'image' not in self.user_options:
+            raise web.HTTPError(400, "image required")
 
+          self.singleuser_image_spec = self.user_options['image']
+          return super().start()
 
-    c.JupyterHub.authenticator_class = DynamicImageAuth
-    c.DynamicImageAuth.force_new_server = True
-    c.KubeSpawner.args.append('--NotebookApp.disable_check_xsrf=True')
-    c.KubeSpawner.args.append('--NotebookApp.allow_origin="*"')
-    # FIXME: Make this more secure?
-    c.KubeSpawner.args.append('--NotebookApp.tornado_settings={}'.format(json.dumps({'headers': {'Content-Security-Policy': ' '}})))
+    # launch jupyter notebook instead of jupyterhub-singleuser
+    c.JupyterHub.spawner_class = BinderSpawner
+
+    # disable all XSS protections:
+    # FIXME: Make this more secure before allowing any authenticated state into binder
+    c.BinderSpawner.args.append('--NotebookApp.disable_check_xsrf=True')
+    c.BinderSpawner.args.append('--NotebookApp.allow_origin="*"')
+    c.BinderSpawner.args.append("--NotebookApp.tornado_settings={'headers': {'Content-Security-Policy': ''}}")
+
+    # add binder API token!
+    c.JupyterHub.services.append({
+        'name': 'binder',
+        'admin': True,
+        'api_token': 'aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4',
+    })
+
+    # debug!
     c.JupyterHub.log_level = 10
 
 singleuser:
+  cmd: jupyter-notebook
   storage:
     type: none
   memory:

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -7,6 +7,7 @@ hub:
     type: "sqlite-memory"
   services:
     binder:
+      admin: true
       apiToken: "aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4"
   extraConfig: |
     # disable login (users created exclusively via API)


### PR DESCRIPTION
- use null authenticator to disable all login to the Hub itself
- create users via POST hub/api/users/:user
- spawn servers via POST hub/api/users/:user/server with image and token in user_options body
- spawns jupyter-notebook with token access (requires notebook 4.3), not jupyterhub-singleuser (closes #103)

<del>This *should* work with jupyterhub 0.7, but I've been testing with 0.8 via https://github.com/jupyterhub/helm-chart/pull/79</del> This now requires v0.5.x jupyterhub chart for the service tokens, but it isn't technically sensitive to the Hub version.

Questions:

- [x] where should I put the BinderSpawner bit? Publish a package or leave it in the extraConfig like this? **extraConfig for now**
- [x] Binder itself needs an API token to pass to the Hub. **passed via binder-secret to binder and hub-secret to hub**
- [x] It would be much nicer if I could write a regular `jupyterhub_config.py` Python config file, rather than writing Python in yaml. Is there a way to 'include' a local file with helm? **helm doesn't support it yet**

cc @willingc