### PR TITLE
import binderhub helm-chart

### DIFF
--- a/helm-chart/Makefile
+++ b/helm-chart/Makefile
@@ -1,18 +1,13 @@
 VERSION=$(shell git rev-parse --short HEAD)
 IMAGE_PREFIX=jupyterhub/k8s
-PUSH_IMAGES=no
-BUILD_ARGS=
 
-images: build-images push-images
-build-images: build-image/hub build-image/singleuser-sample build-image/binderhub
-push-images: push-image/hub push-image/singleuser-sample push-image/binderhub
+.PHONY: images push-images package-chart
 
-build-image/%:
-	cd images/$(@F) && \
-	docker build -t $(IMAGE_PREFIX)-$(@F):v$(VERSION) . $(BUILD_ARGS)
+images:
+	python build.py build
 
-push-image/%:
-	docker push $(IMAGE_PREFIX)-$(@F):v$(VERSION)
+push-images:
+	python build.py build --push
 
-package-chart:
-	helm package jupyterhub
+package-chart: .PHONY
+	helm package binderhub

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,7 +1,7 @@
-# [JupyterHub Helm Chart](https://github.com/jupyterhub/helm-chart)
+# BinderHub Helm Chart
 
 
-A [helm][] [chart][] for deploying [JupyterHub] instances on [Kubernetes].
+A [helm][] [chart][] for deploying [BinderHub] instances on [Kubernetes].
 
 **[Zero to JupyterHub with Kubernetes]** provides detailed instructions for using this project within a JupyerHub deployment.
 
@@ -34,10 +34,7 @@ Fundamental elements of a chart including:
 
 Docker images for applications including:
 
-- `builder`
-- `hub`
-- `proxy`
-- `singleuser-sample`
+- `binderhub`
 
 ### `Makefile`
 
@@ -45,7 +42,7 @@ Useful for compiling custom charts.
 
 ## Usage
 
-To build and push Docker images in the `images` directory:
+To build Docker images in the `images` directory:
 
     make images
 
@@ -54,6 +51,7 @@ To create chart metadata and package chart for use:
     make chart
 
 
+[BinderHub]: https://binderhub.readthedocs.io/en/latest/
 [JupyterHub]: https://jupyterhub.readthedocs.io/en/latest/
 [Kubernetes]: https://kubernetes.io
 [helm]: https://helm.sh/

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.5.0-2140cd6"
-  repository: "https://minrk.github.io/helm-chart"
+  version: "0.5.0-fc53f60"
+  repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
   version: "0.5.0-2140cd6"
-  repository: "https://jupyterhub.github.io/helm-chart"
+  repository: "https://minrk.github.io/helm-chart"

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: jupyterhub
+  version: "0.5.0-2140cd6"
+  repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -1,14 +1,3 @@
-{{ if .Values.registry.enabled -}}
-kind: Secret
-apiVersion: v1
-metadata:
-  name: binder-secret
-type: Opaque
-data:
-  config.json: |
-    {{ b64enc (printf "{\"auths\": { \"https://%s\": { \"email\": \"not@val.id\", \"auth\": \"%s\" } } }" .Values.registry.host (b64enc (printf "%s:%s" .Values.registry.username .Values.registry.password) ) ) }}
----
-{{- end }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -78,6 +67,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: JUPYTERHUB_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: binder-secret
+              key: "binder.hub-token"
         ports:
           - containerPort: 8585
             name: binder

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -1,0 +1,11 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: binder-secret
+type: Opaque
+data:
+  {{ if .Values.registry.enabled -}}
+  config.json: |
+    {{ b64enc (printf "{\"auths\": { \"https://%s\": { \"email\": \"not@val.id\", \"auth\": \"%s\" } } }" .Values.registry.host (b64enc (printf "%s:%s" .Values.registry.username .Values.registry.password) ) ) }}
+  {{- end }}
+  binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -7,7 +7,7 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: vbd57123
 
-repo2dockerImage: jupyter/repo2docker:v0.2.10
+repo2dockerImage: jupyter/repo2docker:v0.4.1
 
 googleAnalyticsCode: null
 

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -5,7 +5,7 @@ resources:
 
 image:
   name: jupyterhub/k8s-binderhub
-  tag: vbd57123
+  tag: 8022f73
 
 repo2dockerImage: jupyter/repo2docker:v0.4.1
 

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -28,44 +28,40 @@ hub:
 jupyterhub:
   hub:
     extraConfig: |
-      import json
-      import urllib
-      from tmpauthenticator import TmpAuthenticator
+      # disable login (users created exclusively via API)
+      c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
+
+      # image & token are set via spawn options
       from kubespawner import KubeSpawner
-      from jupyterhub.utils import url_path_join
-      class DynamicImageAuth(TmpAuthenticator):
-          def process_user(self, user, handler):
-              # We take all the url params and put them into a `url_options` field
-              # Not using `user_options` since that seems to be cleared by JupyterHub.
-              arguments = { k: handler.get_argument(k) for k in handler.request.arguments }
-              user.spawner.url_options = arguments
-              return user
 
-          def pre_spawn_start(self, user, spawner):
-              # Support for each runtime parameter is set up here!
-              # FIXME: Make sure we only run authorized images!
-              spawner.singleuser_image_spec = spawner.url_options['image']
+      class BinderSpawner(KubeSpawner):
+        def get_args(self):
+            return [
+                '--ip=0.0.0.0',
+                '--port=%i' % self.port,
+                '--NotebookApp.base_url=%s' % self.server.base_url,
+                '--NotebookApp.token=%s' % self.user_options['token'],
+            ] + self.args
 
-              # Detect if we're pointing to a particular file!
-              # FIXME:
-              filepath = spawner.url_options.get('filepath', None)
-              if filepath:
-                  parts = urllib.parse.urlparse(filepath)
-                  if parts.path.endswith('.ipynb'):
-                      parts = parts._replace(path=url_path_join('/notebooks', parts.path))
-                  else:
-                      parts = parts._replace(path=url_path_join('/edit', parts.path))
-                  spawner.default_url = urllib.parse.urlunparse(parts)
+        def start(self):
+            if 'token' not in self.user_options:
+              raise web.HTTPError(400, "token required")
+            if 'image' not in self.user_options:
+              raise web.HTTPError(400, "image required")
 
+            self.singleuser_image_spec = self.user_options['image']
+            return super().start()
 
-      c.JupyterHub.authenticator_class = DynamicImageAuth
-      c.DynamicImageAuth.force_new_server = True
-      c.KubeSpawner.args.append('--NotebookApp.disable_check_xsrf=True')
-      c.KubeSpawner.args.append('--NotebookApp.allow_origin="*"')
-      # FIXME: Make this more secure?
-      c.KubeSpawner.args.append('--NotebookApp.tornado_settings={}'.format(json.dumps({'headers': {'Content-Security-Policy': ' '}})))
+      c.JupyterHub.spawner_class = BinderSpawner
+
+    services:
+      binder:
+        admin: true
+        apiToken: null
 
   singleuser:
+    # start jupyter notebook
+    cmd: jupyter-notebook
     storage:
       type: none
     memory:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -9,21 +9,21 @@ image:
 
 repo2dockerImage: jupyter/repo2docker:v0.4.1
 
-googleAnalyticsCode: null
+googleAnalyticsCode:
 
 registry:
   enabled: false
   prefix: binderhub-local/
   host: gcr.io
   username: _json_key
-  password: null
+  password:
 
 service:
   type: LoadBalancer
-  nodePort: null
+  nodePort:
 
 hub:
-  url: null
+  url:
 
 jupyterhub:
   hub:
@@ -57,7 +57,7 @@ jupyterhub:
     services:
       binder:
         admin: true
-        apiToken: null
+        apiToken:
 
   singleuser:
     # start jupyter notebook
@@ -65,7 +65,7 @@ jupyterhub:
     storage:
       type: none
     memory:
-      guarantee: null
+      guarantee:
   prePuller:
     enabled: false
 

--- a/helm-chart/build.py
+++ b/helm-chart/build.py
@@ -2,7 +2,10 @@
 import os
 import subprocess
 import argparse
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML()
+yaml.indent(offset=2)
 
 NAME = 'binderhub'
 
@@ -40,24 +43,24 @@ def build_images(prefix, images, commit_range=None, push=False):
 
 def build_values(prefix):
     with open(NAME + '/values.yaml') as f:
-        values = yaml.safe_load(f)
+        values = yaml.load(f)
 
     values['image']['name'] = prefix + NAME
     values['image']['tag'] = last_git_modified('images/' + NAME)
 
     with open(NAME + '/values.yaml', 'w') as f:
-        yaml.dump(values, f, default_flow_style=False)
+        yaml.dump(values, f)
 
 
 def build_chart():
     version = last_git_modified('.')
     with open(NAME + '/Chart.yaml') as f:
-        chart = yaml.safe_load(f)
+        chart = yaml.load(f)
 
     chart['version'] = chart['version'] + '-' + version
 
     with open(NAME + '/Chart.yaml', 'w') as f:
-        yaml.dump(chart, f, default_flow_style=False)
+        yaml.dump(chart, f)
 
 def publish_pages():
     version = last_git_modified('.')

--- a/helm-chart/build.py
+++ b/helm-chart/build.py
@@ -66,7 +66,7 @@ def publish_pages():
     version = last_git_modified('.')
     subprocess.check_call([
         'git', 'clone', '--no-checkout',
-        'git@github.com:jupyterhub/binderhub', 'gh-pages'],
+        'git@github.com:jupyterhub/helm-chart', 'gh-pages'],
         env=dict(os.environ, GIT_SSH_COMMAND='ssh -i travis')
     )
     subprocess.check_call(['git', 'checkout', 'gh-pages'], cwd='gh-pages')
@@ -76,7 +76,7 @@ def publish_pages():
     ])
     subprocess.check_call([
         'helm', 'repo', 'index', '.',
-        '--url', 'https://jupyterhub.github.io/binderhub'
+        '--url', 'https://jupyterhub.github.io/helm-chart'
     ], cwd='gh-pages')
     subprocess.check_call(['git', 'add', '.'], cwd='gh-pages')
     subprocess.check_call([

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,14 +1,7 @@
-FROM ubuntu:17.04
+FROM python:3.6-alpine@sha256:00320c25fa72df54c7ef0181c9e55f59f58b1facb943cb825e4c65fb572ac74b
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends \
-            git \
-            python3 \
-            python3-setuptools \
-            python3-pip && \
-    apt-get clean
-
-RUN pip3 install --no-cache-dir git+https://github.com/jupyterhub/binderhub.git@1d6f130b3b
+# FIXME: temporary ref pending binderhub#110
+RUN pip install --no-cache-dir https://github.com/minrk/binderhub/archive/b5d005a.zip
 ADD binderhub_config.py /etc
 
 WORKDIR /etc

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.6-alpine@sha256:00320c25fa72df54c7ef0181c9e55f59f58b1facb943cb825e4c65fb572ac74b
 
 # FIXME: temporary ref pending binderhub#110
-RUN pip install --no-cache-dir https://github.com/minrk/binderhub/archive/b5d005a.zip
+RUN pip install --no-cache-dir https://github.com/jupyterhub/binderhub/archive/master.zip
 ADD binderhub_config.py /etc
 
 WORKDIR /etc

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -26,6 +26,7 @@ c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 c.BinderHub.use_registry = get_config('binder.use-registry', True)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
-c.BinderHub.hub_login_url = get_config('binder.hub-url') + '/hub/tmplogin'
+c.BinderHub.hub_url = get_config('binder.hub-url')
+c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 
 c.BinderHub.google_analytics_code = get_config('binder.google-analytics-code', None)

--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -8,9 +8,12 @@ service:
 
 jupyterhub:
   hub:
-      cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
-      db:
-        type: sqlite-memory
+    cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
+    db:
+      type: sqlite-memory
+    services:
+      binder:
+        apiToken: 0c18e3dcb7c55b8c7740f1d7ee6977510ce3cb22221669278ee03f3c2259ab6b
 
   proxy:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255

--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -1,3 +1,8 @@
+resources:
+  requests:
+    cpu: 0.2
+    memory: 100Mi
+
 hub:
   url: http://192.168.99.100:30949
 
@@ -8,6 +13,10 @@ service:
 
 jupyterhub:
   hub:
+    resources:
+      requests:
+        cpu: 0.2
+        memory: 100Mi
     cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
     db:
       type: sqlite-memory


### PR DESCRIPTION
binderhub helm-chart is now included here

initial import was done with

    git subtree add helm-chart github.com/jupyterhub/helm-chart v0.5.x --squash

so history is not preserved except by reference.

The main question when doing this is how does the helm chart version related to the binderhub version. Are they the same? Are they versioned separately? If separately, how do we handle that wrt git tags, etc.

- [x] update jupyterhub dependency url when https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/195 is merged
- [x] Where should this chart be published? To the same `jupyterhub/helm-chart` gh-pages repo that jupyterhub is published to?

includes #110