### PR TITLE
Allow binderhub to read pod logs

### DIFF
--- a/helm-chart/binderhub/templates/rbac.yaml
+++ b/helm-chart/binderhub/templates/rbac.yaml
@@ -7,6 +7,9 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
   verbs: ["get", "watch", "list", "create", "delete"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Additional permission here that isn't needed for jupyterhub