### PR TITLE
build.py: include python package changes when setting image, chart versions

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -8,7 +8,7 @@ rbac:
 
 image:
   name: jupyterhub/k8s-binderhub
-  tag: 8022f73
+  tag: local
 
 repo2dockerImage: jupyter/repo2docker:v0.4.1
 

--- a/helm-chart/build.py
+++ b/helm-chart/build.py
@@ -59,10 +59,11 @@ def build_chart():
     with open(os.path.join(CHARTPATH, 'Chart.yaml')) as f:
         chart = yaml.load(f)
 
-    chart['version'] = chart['version'] + '-' + version
+    chart['version'] = chart['version'].split('-')[0] + '-' + version
 
     with open(os.path.join(CHARTPATH, 'Chart.yaml'), 'w') as f:
         yaml.dump(chart, f)
+
 
 def publish_pages():
     version = last_git_modified('.')

--- a/helm-chart/build.py
+++ b/helm-chart/build.py
@@ -7,55 +7,78 @@ from ruamel.yaml import YAML
 yaml = YAML()
 yaml.indent(offset=2)
 
-BASEPATH = os.path.dirname(__file__)
+BASEPATH = os.path.abspath(os.path.dirname(__file__))
 CHARTPATH = os.path.join(BASEPATH, 'binderhub')
+ROOTPATH = os.path.dirname(BASEPATH)
 NAME = 'binderhub'
+PYPKGPATH = os.path.join(ROOTPATH, NAME)
+SETUP_PY = os.path.join(ROOTPATH, 'setup.py')
 
-def last_git_modified(path):
+IMAGE_PATH = os.path.join(BASEPATH, 'images', NAME)
+# IMAGE_FILES should be all paths that contribute to the binderhub image
+# namely, the Python package itself and the image directory
+IMAGE_FILES = [SETUP_PY, PYPKGPATH, IMAGE_PATH]
+
+# CHART_FILES should be all files that contribute to the chart
+# namely, all image files plus the chart itself
+CHART_FILES = IMAGE_FILES + [CHARTPATH]
+
+def last_git_modified(paths):
+    """Return the short hash of the last commit on one or more paths"""
+    if isinstance(paths, str):
+        paths = [paths]
     return subprocess.check_output([
         'git',
         'log',
         '-n', '1',
         '--pretty=format:%h',
-        path
-    ]).decode('utf-8')
+        '--',
+    ] + list(paths)).decode('utf-8')
 
-def image_touched(image, commit_range):
+
+def path_changed(paths, commit_range):
+    """Have the path(s) changed during the given commit range?"""
+    if isinstance(paths, str):
+        paths = [paths]
     return subprocess.check_output([
-        'git', 'diff', '--name-only', commit_range, os.path.join(BASEPATH, 'images', image)
-    ]).decode('utf-8').strip() != ''
+        'git', 'diff', '--name-only', commit_range, '--',
+    ] + paths).decode('utf-8').strip() != ''
+
 
 def build_images(prefix, images, commit_range=None, push=False):
     for image in images:
+        image_path = os.path.join(BASEPATH, 'images', image)
         if commit_range:
-            if not image_touched(image, commit_range):
+            if path_changed(IMAGE_FILES, commit_range):
                 print("Skipping {}, not touched in {}".format(image, commit_range))
                 continue
-        image_path = os.path.join(BASEPATH, 'images', image)
-        tag = last_git_modified(image_path)
+        tag = last_git_modified(IMAGE_FILES)
         image_spec = '{}{}:{}'.format(prefix, image, tag)
 
         subprocess.check_call([
-            'docker', 'build', '-t', image_spec, image_path
+            'docker', 'build', '-t', image_spec,
+            '--build-arg', 'BINDERHUB_VERSION=%s' % tag,
+            image_path
         ])
         if push:
             subprocess.check_call([
                 'docker', 'push', image_spec
             ])
 
+
 def build_values(prefix):
     with open(os.path.join(CHARTPATH, 'values.yaml')) as f:
         values = yaml.load(f)
 
     values['image']['name'] = prefix + NAME
-    values['image']['tag'] = last_git_modified(os.path.join(BASEPATH, 'images/',  NAME))
+    values['image']['tag'] = last_git_modified(IMAGE_FILES)
 
     with open(os.path.join(CHARTPATH, 'values.yaml'), 'w') as f:
         yaml.dump(values, f)
 
 
 def build_chart():
-    version = last_git_modified('.')
+    version = last_git_modified([BASEPATH] + IMAGE_FILES)
     with open(os.path.join(CHARTPATH, 'Chart.yaml')) as f:
         chart = yaml.load(f)
 

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.6-alpine@sha256:00320c25fa72df54c7ef0181c9e55f59f58b1facb943cb825e4c65fb572ac74b
 
+ARG BINDERHUB_VERSION
 RUN pip install --no-cache-dir \
-    https://github.com/jupyterhub/binderhub/archive/dafb7f12b09.zip
+    https://github.com/jupyterhub/binderhub/archive/${BINDERHUB_VERSION}.zip
 ADD binderhub_config.py /etc
 
 WORKDIR /etc


### PR DESCRIPTION
- path_changed, last_git_changed accept lists of paths
- include Python package files in git consideration for both image
- specify BINDERHUB_VERSION in image via `--build-arg` rather than manual changes
- fix bug where chart version would get `0.1.0-hash-hash-hash-hash` after building multiple times

closes #143