### PR TITLE
Don't include revision number in configmap name

### DIFF
--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: binder-config-{{ default .Release.Revision .Values.revisionOverride }}
+  name: binder-config
 data:
   binder.use-registry: {{ .Values.registry.enabled | quote }}
   {{ if .Values.registry.enabled -}}

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: binder-config-{{ default .Release.Revision .Values.revisionOverride }}
+          name: binder-config
       {{ if .Values.registry.enabled -}}
       - name: docker-secret
         secret:


### PR DESCRIPTION
This causes the deployment pod to restart unnecessarily