### PR TITLE
bump jupyterhub chart

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.5.0-11545aa"
+  version: "0.5.0-d1edb2e"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
d1edb2e is later than 11545aa, despite having been published to helm-chart earlier.