### PR TITLE
add GitHub auth support

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -62,6 +62,27 @@ spec:
             secretKeyRef:
               name: binder-secret
               key: "binder.hub-token"
+        {{ if .Values.github.clientId -}}
+        - name: GITHUB_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: binder-secret
+              key: "github.client-id"
+        {{- end }}
+        {{ if .Values.github.clientSecret -}}
+        - name: GITHUB_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: binder-secret
+              key: "github.client-secret"
+        {{- end }}
+        {{ if .Values.github.accessToken -}}
+        - name: GITHUB_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: binder-secret
+              key: "github.access-token"
+        {{- end }}
         ports:
           - containerPort: 8585
             name: binder

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -9,3 +9,12 @@ data:
     {{ b64enc (printf "{\"auths\": { \"https://%s\": { \"email\": \"not@val.id\", \"auth\": \"%s\" } } }" .Values.registry.host (b64enc (printf "%s:%s" .Values.registry.username .Values.registry.password) ) ) }}
   {{- end }}
   binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
+  {{ if .Values.github.clientId -}}
+  github.client-id: {{ .Values.github.clientId | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.github.clientSecret -}}
+  github.client-secret: {{ .Values.github.clientSecret | b64enc | quote }}
+  {{- end }}
+  {{ if .Values.github.accessToken -}}
+  github.access-token: {{ .Values.github.accessToken | b64enc | quote }}
+  {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -28,6 +28,13 @@ service:
     prometheus.io/scrape: "true"
   nodePort:
 
+github:
+  # either id + secret...
+  clientId:
+  clientSecret:
+  # ...or access_token
+  accessToken:
+
 hub:
   url:
 


### PR DESCRIPTION
- [x] support client_id, client_secret in github provider
- [x] better error when rate limit exceeded
- [x] support env in helm chart

Once this lands, we can add the secrets for https://github.com/jupyterhub/mybinder.org-deploy/issues/58
