### PR TITLE
adding URL to docs

### DIFF
--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -29,7 +29,7 @@
   {% block footer %}
   <div class="container">
     <div class="row text-center">
-      <h3>questions? join the <a href="https://gitter.im/jupyterhub/binder">chat</a>, see the <a href="https://github.com/jupyterhub/binderhub">code</a></h3>
+      <h3>questions?<br />join the <a href="https://gitter.im/jupyterhub/binder">chat</a>, read the <a href="https://mybinder.readthedocs.io/en/latest/">docs</a>, see the <a href="https://github.com/jupyterhub/binderhub">code</a></h3>
     </div>
   </div>
   {% endblock footer %}


### PR DESCRIPTION
adds a URL for the binder user documentation on the front page, so it now looks like:

![image](https://user-images.githubusercontent.com/1839645/31289941-8d0bb9a4-aa7f-11e7-9ef6-9f848badddb4.png)
