### PR TITLE
Prevent points from overlapping with text.

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -137,6 +137,9 @@ h4 {
 
 #how-it-works div.row {
     margin: 32px;
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
 }
 
 .point {
@@ -146,7 +149,6 @@ h4 {
     width: 40px;
     height: 40px;
     padding: 2px 9px;
-    position: absolute;
     font-weight: 800;
     font-family: 'ClearSans-Bold';
 }


### PR DESCRIPTION
On narrower browser windows the instruction points are overlapping. This fixes that.
Before:
![point_overlap](https://user-images.githubusercontent.com/5728311/31363057-cb61d61e-ad10-11e7-9ae7-5a3dbac28248.png)
After:
![point_nonoverlap](https://user-images.githubusercontent.com/5728311/31363060-cfed848a-ad10-11e7-9242-2bfd7004d268.png)
