### PR TITLE
Restore cross-origin access

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -59,6 +59,7 @@ jupyterhub:
                 '--port=%i' % self.port,
                 '--NotebookApp.base_url=%s' % self.server.base_url,
                 '--NotebookApp.token=%s' % self.user_options['token'],
+                '--NotebookApp.allow_origin=*',
             ] + self.args
 
         def start(self):

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -27,6 +27,7 @@ hub:
               '--port=%i' % self.port,
               '--NotebookApp.base_url=%s' % self.server.base_url,
               '--NotebookApp.token=%s' % self.user_options['token'],
+              '--NotebookApp.allow_origin=*',
           ] + self.args
 
       def start(self):


### PR DESCRIPTION
Still leave out disabling of xsrf, csp that was here before.

Since we are now using token auth, XSRF + token auth allows CORS to still be safe as only sites with access to tokens will be allowed access to notebook servers. Only disabling CORS and auth together makes things truly unsafe.

closes #177