### PR TITLE
Fix typo in localtest sample binderhub_config.py

### DIFF
--- a/testing/localonly/binderhub_config.py
+++ b/testing/localonly/binderhub_config.py
@@ -1,2 +1,2 @@
 c.BinderHub.use_registry = False
-c.BinderHub.builder_required = True
+c.BinderHub.builder_required = False


### PR DESCRIPTION
This makes it work again for people who have never installed
kubernetes tools on their local machine