### PR TITLE
Make it possible to enable CORS

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -19,7 +19,7 @@ from .builder import BuildHandler
 from .launcher import Launcher
 from .registry import DockerRegistry
 from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
-from .repoproviders import RepoProvider, GitHubRepoProvider
+from .repoproviders import GitHubRepoProvider
 from .metrics import MetricsHandler
 
 TEMPLATE_PATH = [os.path.join(os.path.dirname(__file__), 'templates')]
@@ -186,6 +186,15 @@ class BinderHub(Application):
         """
     )
 
+    tornado_settings = Dict(
+        config=True,
+        help="""
+        additional settings to pass through to tornado.
+
+        can include things like additional headers, etc.
+        """
+    )
+
 
     def initialize(self, *args, **kwargs):
         """Load configuration settings."""
@@ -219,7 +228,7 @@ class BinderHub(Application):
             hub_api_token=self.hub_api_token,
         )
 
-        self.tornado_settings = {
+        self.tornado_settings.update({
             "docker_push_secret": self.docker_push_secret,
             "docker_image_prefix": self.docker_image_prefix,
             "static_path": os.path.join(os.path.dirname(__file__), "static"),
@@ -237,7 +246,7 @@ class BinderHub(Application):
             'traitlets_config': self.config,
             'google_analytics_code': self.google_analytics_code,
             'jinja2_env': jinja_env,
-        }
+        })
 
         self.tornado_app = tornado.web.Application([
             (r'/metrics', MetricsHandler),

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -195,7 +195,6 @@ class BinderHub(Application):
         """
     )
 
-
     def initialize(self, *args, **kwargs):
         """Load configuration settings."""
         super().initialize(*args, **kwargs)

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -9,6 +9,14 @@ class BaseHandler(web.RequestHandler):
     def template_namespace(self):
         return dict(static_url=self.static_url)
 
+    def set_default_headers(self):
+        headers = self.settings.get('headers', {})
+        # Allow any origin by default
+        headers.setdefault('Access-Control-Allow-Origin', '*')
+
+        for header, value in headers.items():
+            self.set_header(header, value)
+
     def get_provider(self, provider_prefix, spec):
         """Construct a provider object"""
         providers = self.settings['repo_providers']

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -11,9 +11,6 @@ class BaseHandler(web.RequestHandler):
 
     def set_default_headers(self):
         headers = self.settings.get('headers', {})
-        # Allow any origin by default
-        headers.setdefault('Access-Control-Allow-Origin', '*')
-
         for header, value in headers.items():
             self.set_header(header, value)
 

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   {{ if .Values.googleAnalyticsCode -}}
   binder.google-analytics-code: {{ .Values.googleAnalyticsCode | quote }}
   {{- end }}
+  binder.cors: {{ toJson .Values.cors | quote }}
   binder.registry.prefix: {{ .Values.registry.prefix | quote }}
   binder.repo2docker-image: {{ .Values.repo2dockerImage | quote }}
   binder.hub-url: {{ .Values.hub.url | quote }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -39,10 +39,12 @@ github:
 # once in top-level cors.allowOrigin,
 # and again in jupyterhub.hub.extraConfigMap.cors.allowOrigin
 
-# &cors anchor allows us to remove redundancy in this values.yaml,
-# but it does not extend to user values.yaml.
-# They must still set cors separately for binderhub and notebooks.
-# However, they can use the same anchor pattern in their own values.yaml as well.
+# Using YAML anchors, `&cors` for the first appearance and `*cors` for subsequent
+# appearances, allows us to remove redundancy in this (BinderHub) `values.yaml`.
+# The anchors do not extend beyond this file.
+# As such, users must set `cors` separately for their own user `values.yaml` for notebooks.
+# `cors` will be set separately in the user `values.yaml` and binderhub`values.yaml`.
+# The same anchor pattern (`&cors`, `*cors`) can be used in the user `values.yaml`.
 
 cors: &cors
   allowOrigin:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -25,7 +25,7 @@ service:
   type: LoadBalancer
   labels: {}
   annotations:
-    prometheus.io/scrape: "true"
+    prometheus.io/scrape: 'true'
   nodePort:
 
 github:
@@ -34,6 +34,18 @@ github:
   clientSecret:
   # ...or access_token
   accessToken:
+
+# have to set cors.allowOrigin twice:
+# once in top-level cors.allowOrigin,
+# and again in jupyterhub.hub.extraConfigMap.cors.allowOrigin
+
+# &cors anchor allows us to remove redundancy in this values.yaml,
+# but it does not extend to user values.yaml.
+# They must still set cors separately for binderhub and notebooks.
+# However, they can use the same anchor pattern in their own values.yaml as well.
+
+cors: &cors
+  allowOrigin:
 
 hub:
   url:
@@ -46,6 +58,25 @@ jupyterhub:
     rbac:
       enabled: true
     extraConfig: |
+      import os
+      import sys
+      import yaml
+      def get_config_map(key, default=None):
+          """
+          Find a configmap item of a given name & return it
+
+          Parses everything as YAML, so lists and dicts are available too
+          """
+          path = os.path.join('/etc/jupyterhub/config', key)
+          try:
+              with open(path) as f:
+                  return yaml.safe_load(f)
+          except FileNotFoundError:
+              return default
+
+      # get cors config from config-map
+      cors = get_config_map('custom.cors', {})
+
       # disable login (users created exclusively via API)
       c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
 
@@ -54,13 +85,16 @@ jupyterhub:
 
       class BinderSpawner(KubeSpawner):
         def get_args(self):
-            return [
+            args = [
                 '--ip=0.0.0.0',
                 '--port=%i' % self.port,
                 '--NotebookApp.base_url=%s' % self.server.base_url,
                 '--NotebookApp.token=%s' % self.user_options['token'],
-                '--NotebookApp.allow_origin=*',
-            ] + self.args
+            ]
+            allow_origin = cors.get('allowOrigin')
+            if allow_origin:
+                args.append('--NotebookApp.allow_origin=' + allow_origin)
+            return args + self.args
 
         def start(self):
             if 'token' not in self.user_options:
@@ -73,6 +107,8 @@ jupyterhub:
 
       c.JupyterHub.spawner_class = BinderSpawner
 
+    extraConfigMap:
+      cors: *cors
     services:
       binder:
         admin: true

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -30,3 +30,12 @@ c.BinderHub.hub_url = get_config('binder.hub-url')
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 
 c.BinderHub.google_analytics_code = get_config('binder.google-analytics-code', None)
+
+cors = get_config('binder.cors', {})
+allow_origin = cors.get('allowOrigin')
+if allow_origin:
+    c.BinderHub.tornado_settings.update({
+        'headers': {
+            'Access-Control-Allow-Origin': allow_origin,
+        }
+    })

--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -6,6 +6,9 @@ resources:
     cpu: 0.2
     memory: 100Mi
 
+cors: &cors
+  allowOrigin: '*'
+
 hub:
   url: http://192.168.99.100:30949
 
@@ -27,6 +30,8 @@ jupyterhub:
     services:
       binder:
         apiToken: 0c18e3dcb7c55b8c7740f1d7ee6977510ce3cb22221669278ee03f3c2259ab6b
+    extraConfigMap:
+      cors: *cors
 
   proxy:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255


### PR DESCRIPTION
enables access to the eventsource endpoint from other websites, not just scripts.

closes #177

Potential questions:

- Do we want to enable this by default (as this PR does)? Or should it be more locked down by default and opt-in on the mybinder.org deployment? (**answer: not enabled by default**)

cc @SamLau95

CORS is not enabled by default. To enable CORS from any origin in `values.yaml`:

```yaml
cors: &cors
  allowOrigin: '*'

jupyterhub:
  extraConfigMap:
    cors: *cors
```