### PR TITLE
Make `master` a placeholder.

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -14,7 +14,7 @@ class MainHandler(BaseHandler):
         self.render_template(
             "index.html",
             url=None,
-            ref='master',
+            ref='',
             filepath=None,
             submit=False,
             google_analytics_code=self.settings['google_analytics_code']

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -11,6 +11,8 @@
   pushing -> failed
 */
 
+"use strict";
+
 function Image(provider, spec) {
     this.provider = provider;
     this.spec = spec;
@@ -102,7 +104,7 @@ function updateUrl() {
   repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
   // trim trailing or leading '/' on repo
   repo = repo.replace(/(^\/)|(\/?$)/g, '');
-  var ref = $('#ref').val().trim();
+  var ref = $('#ref').val().trim() || 'master';
   var filepath = $('#filepath').val().trim();
   var url = v2url(repo, ref, filepath);
   // update URL references
@@ -189,7 +191,7 @@ $(function(){
 
     $('#build-form').submit(function() {
         var repo = $('#repository').val().trim();
-        var ref =  $('#ref').val().trim();
+        var ref =  $('#ref').val().trim() || 'master';
         repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
         // trim trailing or leading '/' on repo
         repo = repo.replace(/(^\/)|(\/?$)/g, '');


### PR DESCRIPTION
The `master` form already has `master` as a placeholder; this (should)
make full use of this; by replacing empty branches by master