### PR TITLE
Remove jupyter_alabaster_theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,7 +101,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'jupyter_alabaster_theme'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,7 +45,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'flow_diagram',
-    'jupyter_alabaster_theme',
     'autodoc_traits',
 ]
 

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -3,4 +3,3 @@ graphviz
 pygraphviz==1.4rc1
 sphinx>=1.4, !=1.5.4
 traitlets>=4.1
-jupyter_alabaster_theme

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -9,6 +9,5 @@ dependencies:
 - mne
 - graphviz
 - pip:
-  - jupyter_alabaster_theme
   - recommonmark==0.4.0
   - pygraphviz==1.4rc1


### PR DESCRIPTION
It is not maintained anymore and have  a number of style and navigation
issue. Reverting to RTD is (IMHO) better, in particular because of the
Prev/Next button support; which alabaster does not support even if it
looks lighter ; which I think is important.

-- 

cc @willingc (which I think was pro alabaster), and @minrk for his thoughts as if this get approved I'll send identical PRs to other repositories like maybe JupyterHub.

Thoughts ?