### PR TITLE
Prepare using git-crypt for key management.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+secrets/** filter=git-crypt diff=git-crypt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
     export PUSH="--push"
+    mkdir -p ${HOME}/git-crypt && curl -L https://github.com/AGWA/git-crypt/archive/0.5.0.tar.gz | tar --directory ${HOME}/git-crypt --gzip --file - --extract --strip-components=1 && cd ${HOME}/git-crypt && make 
+    cd - 
   fi
 - "./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
 branches:


### PR DESCRIPTION
Install git-crypt on travis, and setup the gitattributes to encrypt
everything that would end in a `.key`

Move to global variable instead of hardcoding the name of the travis key.

Should we also have all secrets in the subfolder ?