### PR TITLE
support urlpath in addition to filepath

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -40,6 +40,7 @@ class ParameterizedMainHandler(BaseHandler):
             url=provider.get_repo_url(),
             ref=provider.unresolved_ref,
             filepath=self.get_argument('filepath', None),
+            urlpath=self.get_argument('urlpath', None),
             submit=True,
             google_analytics_code=self.settings['google_analytics_code'],
         )

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -27,16 +27,36 @@
         <h4 id="form-header">Build and launch a repository</h4>
         <div class="form-group">
           <label for="repository">GitHub repo or URL</label>
-          <input class="form-control" type="text" id="repository" placeholder="GitHub repository name or link" value="{{ url or "" }}"/>
+          <input class="form-control" type="text" id="repository" placeholder="GitHub repository name or link" value="{{ url or '' }}"/>
         </div>
         <div class="row">
           <div class="form-group col-md-4">
             <label for="ref">Git branch, tag, or commit</label>
-            <input class="form-control" type="text" id="ref" placeholder="master" value="{{ ref or "" }}"/>
+            <input class="form-control" type="text" id="ref" placeholder="master" value="{{ ref or '' }}"/>
           </div>
           <div class="form-group col-md-6">
-            <label for="filepath">Path to a notebook file (Optional)</label>
-            <input class="form-control" type="text" id="filepath" placeholder="Path from repo root to notebook file (optional)" value="{{ filepath or "" }}"/>
+            <label for="filepath"></label>
+            <div class="input-group">
+              <input class="form-control" type="text" id="filepath"
+                placeholder=""
+                value="{{ urlpath or filepath or '' }}"
+              />
+              <div class="input-group-btn" id="url-or-file-btn">
+                <button type="button" class="btn btn-secondary dropdown-toggle"
+                  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                  title="Specify whether the path to open is a URL or a file"
+                >
+                <span id="url-or-file-selected">
+                {{ 'URL' if urlpath else 'File' }}
+                </span>
+                <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                  <li class="dropdown-item"><a href="#">File</a></li>
+                  <li class="dropdown-item"><a href="#">URL</a></li>
+                </ul>
+              </div>
+            </div>
           </div>
           <div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">


### PR DESCRIPTION
allows opening arbitrary URLs in addition to specific files

e.g. `/lab` for JupyterLab

closes #128

From URLs, etc. `urlpath` is treated the same as `filepath`, which should be fine.

I'm least confident about the UX part of choosing whether the path to open is a file or URL.

GIF:

![binder](https://user-images.githubusercontent.com/151929/32277886-34b19798-bf14-11e7-8779-d8680140319e.gif)


