### PR TITLE
Add sidebar enhancements to docs

### DIFF
--- a/doc/_templates/navigation.html
+++ b/doc/_templates/navigation.html
@@ -1,0 +1,16 @@
+{# Custom template for navigation.html
+
+   alabaster theme does not provide blocks for titles to
+   be overridden so this custom theme handles title and
+   toctree for sidebar
+#}
+<h3>{{ _('Table of Contents') }}</h3>
+{{ toctree(includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse) }}
+{% if theme_extra_nav_links %}
+<hr />
+<ul>
+    {% for text, uri in theme_extra_nav_links.items() %}
+    <li class="toctree-l1"><a href="{{ uri }}">{{ text }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}

--- a/doc/_templates/relations.html
+++ b/doc/_templates/relations.html
@@ -1,0 +1,17 @@
+{# Custom template for relations.html
+
+   alabaster theme does not provide previous/next page by default
+#}
+<div class="relations">
+<h3>Navigation</h3>
+<ul>
+  <li><a href="{{ pathto(master_doc) }}">Documentation Home</a><ul>
+  {%- if prev %}
+  <li><a href="{{ prev.link|e }}" title="Previous">Previous topic</a></li>
+  {%- endif %}
+  {%- if next %}
+  <li><a href="{{ next.link|e }}" title="Next">Next topic</a></li>
+  {%- endif %}
+  </ul>
+</ul>
+</div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,12 +54,9 @@ templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
-
-# Support markdown via recommonmark:
 source_suffix = ['.rst', '.md']
 
+# Support markdown via recommonmark:
 from recommonmark.parser import CommonMarkParser
 source_parsers = {
     '.md': CommonMarkParser,
@@ -115,8 +112,22 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'show_related': True,
+    'description': "A project to build and serve Binders",
+    'github_user': 'jupyterhub',
+    'github_repo': 'binderhub',
+}
 
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',
+        'sourcelink.html',
+        'searchbox.html'
+    ]
+}
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
@@ -178,6 +189,3 @@ texinfo_documents = [
      author, 'BinderHub', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-    


### PR DESCRIPTION
This PR improves the alabaster sidebar:
- adds persistent project title
- adds brief project description
- adds github badge
- renames contents from Navigation to Table of Contents
- adds navigation for previous, next topics

Rendered versions below. cc/ @Carreau @choldgraf

**Current sidebar**
<img width="463" alt="screenshot 2017-11-06 14 02 54" src="https://user-images.githubusercontent.com/2680980/32466460-e5a050a4-c2fb-11e7-8e6a-0cb1d5252dab.png">

**Enhanced sidebar** [Rendered on my test project](http://test-binderhub.readthedocs.io/en/rel-links/)
<img width="359" alt="screenshot 2017-11-06 14 07 17" src="https://user-images.githubusercontent.com/2680980/32466461-e5be2a52-c2fb-11e7-854f-0a81ae5f4d2c.png">
