### PR TITLE
Rework dependencies of docs env.

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,8 +6,15 @@ dependencies:
 - traitlets>=4.1
 - sphinx>=1.4, !=1.5.4
 - sphinx_rtd_theme
-- mne
 - graphviz
+- recommonmark==0.4.0
+- pip
 - pip:
-  - recommonmark==0.4.0
   - pygraphviz==1.4rc1
+  - CommonMark<0.6
+  - mne # conda refuse to install as mayvi is 2.5 only
+  # hopefully already installed by pip install -e the package
+  - docker
+  - kubernetes
+  - tornado
+  - prometheus_client


### PR DESCRIPTION
I can't get it to work on my machine because of pygraphviz which refuses to install, 
and there is an actual dependency on MNE to create the flow diagram, which I suspect does not require Mayavi to actually do the diagram; but with conda that forces us to use Python 2.7 by indirect dependency. 

The diagram generated is this one : http://binderhub.readthedocs.io/en/latest/diagram.html

I think @choldgraf wrote the code to do that. Maybe instead of regenerating it everytime we should/could make the diagram once and store it in this repository. 