### PR TITLE
Update conda doc build and Python version for autodoc f-strings

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -4,10 +4,13 @@ channels:
 dependencies:
 - python=3.5
 - traitlets>=4.1
+- tornado>=4.1
 - sphinx>=1.4, !=1.5.4
 - sphinx_rtd_theme
-- mne
 - graphviz
 - pip:
   - recommonmark==0.4.0
   - pygraphviz==1.4rc1
+  - docker
+  - kubernetes==3.*
+  - prometheus_client

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,7 +2,7 @@ name: binderhub
 channels:
   - conda-forge
 dependencies:
-- python=3.5
+- python=3.6
 - traitlets>=4.1
 - tornado>=4.1
 - sphinx>=1.4, !=1.5.4


### PR DESCRIPTION
Closes #246 

This PR replaces #248, and it changes the following:

- updates the build dependencies in `environment.yml`
- removes mne
- bumps python to 3.6 since we use f-strings in build.py and autodoc needs a compatible version

cc/ @Carreau @choldgraf 

[Rendered docs](http://test-binderhub.readthedocs.io/en/doc-build/)