### PR TITLE
New Copy and Paste UI for Build Dropdown

### DIFF
--- a/binderhub/static/images/caretdown-white.svg
+++ b/binderhub/static/images/caretdown-white.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18 18" style="enable-background:new 0 0 18 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:none;}
+</style>
+<path class="st0" d="M5.2,7.5L9,11.2l3.8-3.8H5.2V7.5z"/>
+<path class="st1" d="M0,0h18v18H0V0z"/>
+</svg>

--- a/binderhub/static/images/clipboard.svg
+++ b/binderhub/static/images/clipboard.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{display:inline;fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
+	.st2{fill:#FFFFFF;}
+	.st3{fill:#FFFFFF;stroke:#000000;stroke-width:12;stroke-miterlimit:10;}
+</style>
+<g id="grid" class="st0">
+	<line class="st1" x1="11" y1="0" x2="11" y2="22"/>
+	<path class="st1" d="M21.5,11"/>
+	<path class="st1" d="M0.4,11"/>
+	<line class="st1" x1="0" y1="22" x2="22" y2="0"/>
+	<line class="st1" x1="11" y1="0" x2="22" y2="11"/>
+	<line class="st1" x1="0" y1="11" x2="11" y2="22"/>
+	<line class="st1" x1="22" y1="11" x2="11" y2="22"/>
+	<line class="st1" x1="11" y1="0" x2="0" y2="11"/>
+	<line class="st1" x1="14.3" y1="0" x2="14.3" y2="22"/>
+	<line class="st1" x1="7.7" y1="0" x2="7.7" y2="22"/>
+	<line class="st1" x1="3.3" y1="0" x2="3.3" y2="22"/>
+	<line class="st1" x1="18.7" y1="0" x2="18.7" y2="22"/>
+	<line class="st1" x1="22" y1="11" x2="0" y2="11"/>
+	<line class="st1" x1="22" y1="14.3" x2="0" y2="14.3"/>
+	<line class="st1" x1="22" y1="7.7" x2="0" y2="7.7"/>
+	<line class="st1" x1="22" y1="3.3" x2="0" y2="3.3"/>
+	<line class="st1" x1="22" y1="18.7" x2="0" y2="18.7"/>
+	<line class="st1" x1="2.2" y1="0" x2="2.2" y2="22"/>
+	<line class="st1" x1="19.8" y1="0" x2="19.8" y2="22"/>
+	<line class="st1" x1="0" y1="19.8" x2="22" y2="19.8"/>
+	<line class="st1" x1="0" y1="2.2" x2="22" y2="2.2"/>
+	<line class="st1" x1="17.6" y1="0" x2="17.6" y2="22"/>
+	<line class="st1" x1="11" y1="1.6" x2="20.3" y2="11"/>
+	<line class="st1" x1="1.6" y1="11" x2="11" y2="20.3"/>
+	<line class="st1" x1="20.3" y1="11" x2="11" y2="20.3"/>
+	<line class="st1" x1="11" y1="1.6" x2="1.6" y2="11"/>
+	<line class="st1" x1="0" y1="0" x2="22" y2="22"/>
+	<line class="st1" x1="6.6" y1="0" x2="6.6" y2="22"/>
+	<line class="st1" x1="15.4" y1="0" x2="15.4" y2="22"/>
+	<line class="st1" x1="0" y1="15.4" x2="22" y2="15.4"/>
+	<line class="st1" x1="0" y1="6.6" x2="22" y2="6.6"/>
+	<line class="st1" x1="20.9" y1="22" x2="0" y2="1.1"/>
+	<line class="st1" x1="1.1" y1="0" x2="22" y2="20.9"/>
+	<path class="st1" d="M22,22"/>
+	<path class="st1" d="M0,0"/>
+	<line class="st1" x1="0" y1="20.9" x2="20.9" y2="0"/>
+	<line class="st1" x1="22" y1="1.1" x2="1.1" y2="22"/>
+	<line class="st1" x1="4.4" y1="0" x2="4.4" y2="22"/>
+	<line class="st1" x1="22" y1="17.6" x2="0" y2="17.6"/>
+	<line class="st1" x1="22" y1="4.4" x2="0" y2="4.4"/>
+	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5563 11.0003)" class="st1" width="6.2" height="6.2"/>
+	<line class="st1" x1="0" y1="16.5" x2="22" y2="16.5"/>
+	<line class="st1" x1="16.5" y1="22" x2="16.5" y2="0"/>
+	<line class="st1" x1="5.5" y1="22" x2="5.5" y2="0"/>
+	<line class="st1" x1="22" y1="5.5" x2="0" y2="5.5"/>
+	<line class="st1" x1="12.1" y1="0" x2="12.1" y2="22"/>
+	<line class="st1" x1="13.2" y1="0" x2="13.2" y2="22"/>
+	<line class="st1" x1="8.8" y1="22" x2="8.8" y2="0"/>
+	<line class="st1" x1="9.9" y1="22" x2="9.9" y2="0"/>
+	<line class="st1" x1="0" y1="7.7" x2="22" y2="7.7"/>
+	<line class="st1" x1="0" y1="14.3" x2="22" y2="14.3"/>
+	<line class="st1" x1="0" y1="9.9" x2="22" y2="9.9"/>
+	<line class="st1" x1="0" y1="8.8" x2="22" y2="8.8"/>
+	<line class="st1" x1="22" y1="13.2" x2="0" y2="13.2"/>
+	<line class="st1" x1="22" y1="12.1" x2="0" y2="12.1"/>
+	<line class="st1" x1="1.1" y1="0" x2="1.1" y2="22"/>
+	<line class="st1" x1="20.9" y1="0" x2="20.9" y2="22"/>
+	<line class="st1" x1="0" y1="1.1" x2="22" y2="1.1"/>
+	<line class="st1" x1="0" y1="20.9" x2="22" y2="20.9"/>
+</g>
+<polygon class="st2" points="16.4,8.4 5.6,8.4 5.6,4 6.9,4 6.9,7 15.1,7 15.1,4 16.4,4 "/>
+<path class="st2" d="M17.2,20.9H4.8c-1.4,0-2.6-1.2-2.6-2.6V5.9c0-1.4,1.2-2.6,2.6-2.6h3.4C8.4,2,9.6,0.9,11,0.9s2.6,1,2.8,2.4h3.4
+	c1.4,0,2.6,1.2,2.6,2.6v12.5C19.8,19.8,18.6,20.9,17.2,20.9z M4.8,4.7c-0.7,0-1.2,0.5-1.2,1.2v12.5c0,0.7,0.5,1.2,1.2,1.2h12.5
+	c0.7,0,1.2-0.5,1.2-1.2V5.9c0-0.7-0.5-1.2-1.2-1.2h-4.8V3.8c0-0.8-0.7-1.5-1.5-1.5S9.5,3,9.5,3.8v0.9H4.8z"/>
+<path class="st3" d="M2.9,8.4"/>
+<rect x="6.3" y="10.9" class="st2" width="9.5" height="1.4"/>
+<rect x="6.3" y="14.9" class="st2" width="9.5" height="1.4"/>
+</svg>

--- a/binderhub/static/images/copy-icon-black.svg
+++ b/binderhub/static/images/copy-icon-black.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{display:inline;fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
+	.st2{fill:#FFFFFF;stroke:#000000;stroke-width:12;stroke-miterlimit:10;}
+</style>
+<g id="grid" class="st0">
+	<line class="st1" x1="11" y1="0" x2="11" y2="22"/>
+	<path class="st1" d="M21.5,11"/>
+	<path class="st1" d="M0.4,11"/>
+	<line class="st1" x1="0" y1="22" x2="22" y2="0"/>
+	<line class="st1" x1="11" y1="0" x2="22" y2="11"/>
+	<line class="st1" x1="0" y1="11" x2="11" y2="22"/>
+	<line class="st1" x1="22" y1="11" x2="11" y2="22"/>
+	<line class="st1" x1="11" y1="0" x2="0" y2="11"/>
+	<line class="st1" x1="14.3" y1="0" x2="14.3" y2="22"/>
+	<line class="st1" x1="7.7" y1="0" x2="7.7" y2="22"/>
+	<line class="st1" x1="3.3" y1="0" x2="3.3" y2="22"/>
+	<line class="st1" x1="18.7" y1="0" x2="18.7" y2="22"/>
+	<line class="st1" x1="22" y1="11" x2="0" y2="11"/>
+	<line class="st1" x1="22" y1="14.3" x2="0" y2="14.3"/>
+	<line class="st1" x1="22" y1="7.7" x2="0" y2="7.7"/>
+	<line class="st1" x1="22" y1="3.3" x2="0" y2="3.3"/>
+	<line class="st1" x1="22" y1="18.7" x2="0" y2="18.7"/>
+	<line class="st1" x1="2.2" y1="0" x2="2.2" y2="22"/>
+	<line class="st1" x1="19.8" y1="0" x2="19.8" y2="22"/>
+	<line class="st1" x1="0" y1="19.8" x2="22" y2="19.8"/>
+	<line class="st1" x1="0" y1="2.2" x2="22" y2="2.2"/>
+	<line class="st1" x1="17.6" y1="0" x2="17.6" y2="22"/>
+	<line class="st1" x1="11" y1="1.6" x2="20.3" y2="11"/>
+	<line class="st1" x1="1.6" y1="11" x2="11" y2="20.3"/>
+	<line class="st1" x1="20.3" y1="11" x2="11" y2="20.3"/>
+	<line class="st1" x1="11" y1="1.6" x2="1.6" y2="11"/>
+	<line class="st1" x1="0" y1="0" x2="22" y2="22"/>
+	<line class="st1" x1="6.6" y1="0" x2="6.6" y2="22"/>
+	<line class="st1" x1="15.4" y1="0" x2="15.4" y2="22"/>
+	<line class="st1" x1="0" y1="15.4" x2="22" y2="15.4"/>
+	<line class="st1" x1="0" y1="6.6" x2="22" y2="6.6"/>
+	<line class="st1" x1="20.9" y1="22" x2="0" y2="1.1"/>
+	<line class="st1" x1="1.1" y1="0" x2="22" y2="20.9"/>
+	<path class="st1" d="M22,22"/>
+	<path class="st1" d="M0,0"/>
+	<line class="st1" x1="0" y1="20.9" x2="20.9" y2="0"/>
+	<line class="st1" x1="22" y1="1.1" x2="1.1" y2="22"/>
+	<line class="st1" x1="4.4" y1="0" x2="4.4" y2="22"/>
+	<line class="st1" x1="22" y1="17.6" x2="0" y2="17.6"/>
+	<line class="st1" x1="22" y1="4.4" x2="0" y2="4.4"/>
+	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5565 10.9997)" class="st1" width="6.2" height="6.2"/>
+	<line class="st1" x1="0" y1="16.5" x2="22" y2="16.5"/>
+	<line class="st1" x1="16.5" y1="22" x2="16.5" y2="0"/>
+	<line class="st1" x1="5.5" y1="22" x2="5.5" y2="0"/>
+	<line class="st1" x1="22" y1="5.5" x2="0" y2="5.5"/>
+	<line class="st1" x1="12.1" y1="0" x2="12.1" y2="22"/>
+	<line class="st1" x1="13.2" y1="0" x2="13.2" y2="22"/>
+	<line class="st1" x1="8.8" y1="22" x2="8.8" y2="0"/>
+	<line class="st1" x1="9.9" y1="22" x2="9.9" y2="0"/>
+	<line class="st1" x1="0" y1="7.7" x2="22" y2="7.7"/>
+	<line class="st1" x1="0" y1="14.3" x2="22" y2="14.3"/>
+	<line class="st1" x1="0" y1="9.9" x2="22" y2="9.9"/>
+	<line class="st1" x1="0" y1="8.8" x2="22" y2="8.8"/>
+	<line class="st1" x1="22" y1="13.2" x2="0" y2="13.2"/>
+	<line class="st1" x1="22" y1="12.1" x2="0" y2="12.1"/>
+	<line class="st1" x1="1.1" y1="0" x2="1.1" y2="22"/>
+	<line class="st1" x1="20.9" y1="0" x2="20.9" y2="22"/>
+	<line class="st1" x1="0" y1="1.1" x2="22" y2="1.1"/>
+	<line class="st1" x1="0" y1="20.9" x2="22" y2="20.9"/>
+</g>
+<polygon points="16.4,8.4 5.6,8.4 5.6,4 6.9,4 6.9,7 15.1,7 15.1,4 16.4,4 "/>
+<path d="M17.2,20.9H4.8c-1.4,0-2.6-1.2-2.6-2.6V5.9c0-1.4,1.2-2.6,2.6-2.6h3.4C8.4,2,9.6,0.9,11,0.9s2.6,1,2.8,2.4h3.4
+	c1.4,0,2.6,1.2,2.6,2.6v12.5C19.8,19.8,18.6,20.9,17.2,20.9z M4.8,4.7c-0.7,0-1.2,0.5-1.2,1.2v12.5c0,0.7,0.5,1.2,1.2,1.2h12.5
+	c0.7,0,1.2-0.5,1.2-1.2V5.9c0-0.7-0.5-1.2-1.2-1.2h-4.8V3.8c0-0.8-0.7-1.5-1.5-1.5S9.5,3,9.5,3.8v0.9H4.8z"/>
+<path class="st2" d="M2.9,8.4"/>
+<rect x="6.3" y="10.9" width="9.5" height="1.4"/>
+<rect x="6.3" y="14.9" width="9.5" height="1.4"/>
+</svg>

--- a/binderhub/static/images/copy-icon-black.svg
+++ b/binderhub/static/images/copy-icon-black.svg
@@ -48,7 +48,7 @@
 	<line class="st1" x1="4.4" y1="0" x2="4.4" y2="22"/>
 	<line class="st1" x1="22" y1="17.6" x2="0" y2="17.6"/>
 	<line class="st1" x1="22" y1="4.4" x2="0" y2="4.4"/>
-	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5565 10.9997)" class="st1" width="6.2" height="6.2"/>
+	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5562 10.9997)" class="st1" width="6.2" height="6.2"/>
 	<line class="st1" x1="0" y1="16.5" x2="22" y2="16.5"/>
 	<line class="st1" x1="16.5" y1="22" x2="16.5" y2="0"/>
 	<line class="st1" x1="5.5" y1="22" x2="5.5" y2="0"/>

--- a/binderhub/static/images/copy-icon-black.svg
+++ b/binderhub/static/images/copy-icon-black.svg
@@ -5,7 +5,8 @@
 <style type="text/css">
 	.st0{display:none;}
 	.st1{display:inline;fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
-	.st2{fill:#FFFFFF;stroke:#000000;stroke-width:12;stroke-miterlimit:10;}
+	.st2{fill:#4F4F4F;}
+	.st3{fill:#FFFFFF;stroke:#000000;stroke-width:12;stroke-miterlimit:10;}
 </style>
 <g id="grid" class="st0">
 	<line class="st1" x1="11" y1="0" x2="11" y2="22"/>
@@ -48,7 +49,7 @@
 	<line class="st1" x1="4.4" y1="0" x2="4.4" y2="22"/>
 	<line class="st1" x1="22" y1="17.6" x2="0" y2="17.6"/>
 	<line class="st1" x1="22" y1="4.4" x2="0" y2="4.4"/>
-	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5562 10.9997)" class="st1" width="6.2" height="6.2"/>
+	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5561 10.9999)" class="st1" width="6.2" height="6.2"/>
 	<line class="st1" x1="0" y1="16.5" x2="22" y2="16.5"/>
 	<line class="st1" x1="16.5" y1="22" x2="16.5" y2="0"/>
 	<line class="st1" x1="5.5" y1="22" x2="5.5" y2="0"/>
@@ -68,11 +69,11 @@
 	<line class="st1" x1="0" y1="1.1" x2="22" y2="1.1"/>
 	<line class="st1" x1="0" y1="20.9" x2="22" y2="20.9"/>
 </g>
-<polygon points="16.4,8.4 5.6,8.4 5.6,4 6.9,4 6.9,7 15.1,7 15.1,4 16.4,4 "/>
-<path d="M17.2,20.9H4.8c-1.4,0-2.6-1.2-2.6-2.6V5.9c0-1.4,1.2-2.6,2.6-2.6h3.4C8.4,2,9.6,0.9,11,0.9s2.6,1,2.8,2.4h3.4
+<polygon class="st2" points="16.4,8.4 5.6,8.4 5.6,4 6.9,4 6.9,7 15.1,7 15.1,4 16.4,4 "/>
+<path class="st2" d="M17.2,20.9H4.8c-1.4,0-2.6-1.2-2.6-2.6V5.9c0-1.4,1.2-2.6,2.6-2.6h3.4C8.4,2,9.6,0.9,11,0.9s2.6,1,2.8,2.4h3.4
 	c1.4,0,2.6,1.2,2.6,2.6v12.5C19.8,19.8,18.6,20.9,17.2,20.9z M4.8,4.7c-0.7,0-1.2,0.5-1.2,1.2v12.5c0,0.7,0.5,1.2,1.2,1.2h12.5
 	c0.7,0,1.2-0.5,1.2-1.2V5.9c0-0.7-0.5-1.2-1.2-1.2h-4.8V3.8c0-0.8-0.7-1.5-1.5-1.5S9.5,3,9.5,3.8v0.9H4.8z"/>
-<path class="st2" d="M2.9,8.4"/>
-<rect x="6.3" y="10.9" width="9.5" height="1.4"/>
-<rect x="6.3" y="14.9" width="9.5" height="1.4"/>
+<path class="st3" d="M2.9,8.4"/>
+<rect x="6.3" y="10.9" class="st2" width="9.5" height="1.4"/>
+<rect x="6.3" y="14.9" class="st2" width="9.5" height="1.4"/>
 </svg>

--- a/binderhub/static/images/copy-icon-white.svg
+++ b/binderhub/static/images/copy-icon-white.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{display:inline;fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
+	.st2{fill:#FFFFFF;}
+	.st3{fill:#FFFFFF;stroke:#000000;stroke-width:12;stroke-miterlimit:10;}
+</style>
+<g id="grid" class="st0">
+	<line class="st1" x1="11" y1="0" x2="11" y2="22"/>
+	<path class="st1" d="M21.5,11"/>
+	<path class="st1" d="M0.4,11"/>
+	<line class="st1" x1="0" y1="22" x2="22" y2="0"/>
+	<line class="st1" x1="11" y1="0" x2="22" y2="11"/>
+	<line class="st1" x1="0" y1="11" x2="11" y2="22"/>
+	<line class="st1" x1="22" y1="11" x2="11" y2="22"/>
+	<line class="st1" x1="11" y1="0" x2="0" y2="11"/>
+	<line class="st1" x1="14.3" y1="0" x2="14.3" y2="22"/>
+	<line class="st1" x1="7.7" y1="0" x2="7.7" y2="22"/>
+	<line class="st1" x1="3.3" y1="0" x2="3.3" y2="22"/>
+	<line class="st1" x1="18.7" y1="0" x2="18.7" y2="22"/>
+	<line class="st1" x1="22" y1="11" x2="0" y2="11"/>
+	<line class="st1" x1="22" y1="14.3" x2="0" y2="14.3"/>
+	<line class="st1" x1="22" y1="7.7" x2="0" y2="7.7"/>
+	<line class="st1" x1="22" y1="3.3" x2="0" y2="3.3"/>
+	<line class="st1" x1="22" y1="18.7" x2="0" y2="18.7"/>
+	<line class="st1" x1="2.2" y1="0" x2="2.2" y2="22"/>
+	<line class="st1" x1="19.8" y1="0" x2="19.8" y2="22"/>
+	<line class="st1" x1="0" y1="19.8" x2="22" y2="19.8"/>
+	<line class="st1" x1="0" y1="2.2" x2="22" y2="2.2"/>
+	<line class="st1" x1="17.6" y1="0" x2="17.6" y2="22"/>
+	<line class="st1" x1="11" y1="1.6" x2="20.3" y2="11"/>
+	<line class="st1" x1="1.6" y1="11" x2="11" y2="20.3"/>
+	<line class="st1" x1="20.3" y1="11" x2="11" y2="20.3"/>
+	<line class="st1" x1="11" y1="1.6" x2="1.6" y2="11"/>
+	<line class="st1" x1="0" y1="0" x2="22" y2="22"/>
+	<line class="st1" x1="6.6" y1="0" x2="6.6" y2="22"/>
+	<line class="st1" x1="15.4" y1="0" x2="15.4" y2="22"/>
+	<line class="st1" x1="0" y1="15.4" x2="22" y2="15.4"/>
+	<line class="st1" x1="0" y1="6.6" x2="22" y2="6.6"/>
+	<line class="st1" x1="20.9" y1="22" x2="0" y2="1.1"/>
+	<line class="st1" x1="1.1" y1="0" x2="22" y2="20.9"/>
+	<path class="st1" d="M22,22"/>
+	<path class="st1" d="M0,0"/>
+	<line class="st1" x1="0" y1="20.9" x2="20.9" y2="0"/>
+	<line class="st1" x1="22" y1="1.1" x2="1.1" y2="22"/>
+	<line class="st1" x1="4.4" y1="0" x2="4.4" y2="22"/>
+	<line class="st1" x1="22" y1="17.6" x2="0" y2="17.6"/>
+	<line class="st1" x1="22" y1="4.4" x2="0" y2="4.4"/>
+	<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5565 10.9997)" class="st1" width="6.2" height="6.2"/>
+	<line class="st1" x1="0" y1="16.5" x2="22" y2="16.5"/>
+	<line class="st1" x1="16.5" y1="22" x2="16.5" y2="0"/>
+	<line class="st1" x1="5.5" y1="22" x2="5.5" y2="0"/>
+	<line class="st1" x1="22" y1="5.5" x2="0" y2="5.5"/>
+	<line class="st1" x1="12.1" y1="0" x2="12.1" y2="22"/>
+	<line class="st1" x1="13.2" y1="0" x2="13.2" y2="22"/>
+	<line class="st1" x1="8.8" y1="22" x2="8.8" y2="0"/>
+	<line class="st1" x1="9.9" y1="22" x2="9.9" y2="0"/>
+	<line class="st1" x1="0" y1="7.7" x2="22" y2="7.7"/>
+	<line class="st1" x1="0" y1="14.3" x2="22" y2="14.3"/>
+	<line class="st1" x1="0" y1="9.9" x2="22" y2="9.9"/>
+	<line class="st1" x1="0" y1="8.8" x2="22" y2="8.8"/>
+	<line class="st1" x1="22" y1="13.2" x2="0" y2="13.2"/>
+	<line class="st1" x1="22" y1="12.1" x2="0" y2="12.1"/>
+	<line class="st1" x1="1.1" y1="0" x2="1.1" y2="22"/>
+	<line class="st1" x1="20.9" y1="0" x2="20.9" y2="22"/>
+	<line class="st1" x1="0" y1="1.1" x2="22" y2="1.1"/>
+	<line class="st1" x1="0" y1="20.9" x2="22" y2="20.9"/>
+</g>
+<polygon class="st2" points="16.4,8.4 5.6,8.4 5.6,4 6.9,4 6.9,7 15.1,7 15.1,4 16.4,4 "/>
+<path class="st2" d="M17.2,20.9H4.8c-1.4,0-2.6-1.2-2.6-2.6V5.9c0-1.4,1.2-2.6,2.6-2.6h3.4C8.4,2,9.6,0.9,11,0.9s2.6,1,2.8,2.4h3.4
+	c1.4,0,2.6,1.2,2.6,2.6v12.5C19.8,19.8,18.6,20.9,17.2,20.9z M4.8,4.7c-0.7,0-1.2,0.5-1.2,1.2v12.5c0,0.7,0.5,1.2,1.2,1.2h12.5
+	c0.7,0,1.2-0.5,1.2-1.2V5.9c0-0.7-0.5-1.2-1.2-1.2h-4.8V3.8c0-0.8-0.7-1.5-1.5-1.5S9.5,3,9.5,3.8v0.9H4.8z"/>
+<path class="st3" d="M2.9,8.4"/>
+<rect x="6.3" y="10.9" class="st2" width="9.5" height="1.4"/>
+<rect x="6.3" y="14.9" class="st2" width="9.5" height="1.4"/>
+</svg>

--- a/binderhub/static/images/markdown-icon.svg
+++ b/binderhub/static/images/markdown-icon.svg
@@ -9,8 +9,9 @@
 	.st3{fill:none;}
 	.st4{font-family:'ArialMT';}
 	.st5{font-size:12px;}
-	.st6{font-family:'ClearSans-Bold';}
-	.st7{font-size:13.5903px;}
+	.st6{fill:#4F4F4F;}
+	.st7{font-family:'ClearSans-Bold';}
+	.st8{font-size:13.5903px;}
 </style>
 <g id="Layer_1_1_" class="st0">
 	<g class="st1">
@@ -57,7 +58,7 @@
 		<text class="st4 st5">  </text>
 		<text transform="matrix(1 0 0 1 4.2539 4.4)" class="st4 st5"> </text>
 		<text class="st4 st5"> </text>
-		<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5563 10.9998)" class="st2" width="6.2" height="6.2"/>
+		<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5562 10.9999)" class="st2" width="6.2" height="6.2"/>
 		<line class="st2" x1="0" y1="16.5" x2="22" y2="16.5"/>
 		<line class="st2" x1="16.5" y1="22" x2="16.5" y2="0"/>
 		<line class="st2" x1="5.5" y1="22" x2="5.5" y2="0"/>
@@ -79,7 +80,7 @@
 	</g>
 </g>
 <g id="Layer_2">
-	<text transform="matrix(1 0 0 1 4.968 13.1999)" class="st6 st7">m</text>
-	<polygon points="6,15.4 11,20.3 16,15.4 	"/>
+	<text transform="matrix(1 0 0 1 4.968 13.1999)" class="st6 st7 st8">m</text>
+	<polygon class="st6" points="6,15.4 11,20.3 16,15.4 	"/>
 </g>
 </svg>

--- a/binderhub/static/images/markdown-icon.svg
+++ b/binderhub/static/images/markdown-icon.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{display:inline;}
+	.st2{fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
+	.st3{fill:none;}
+	.st4{font-family:'ArialMT';}
+	.st5{font-size:12px;}
+	.st6{font-family:'ClearSans-Bold';}
+	.st7{font-size:13.5903px;}
+</style>
+<g id="Layer_1_1_" class="st0">
+	<g class="st1">
+		<line class="st2" x1="11" y1="0" x2="11" y2="22"/>
+		<path class="st2" d="M21.5,11"/>
+		<path class="st2" d="M0.4,11"/>
+		<line class="st2" x1="0" y1="22" x2="22" y2="0"/>
+		<line class="st2" x1="11" y1="0" x2="22" y2="11"/>
+		<line class="st2" x1="0" y1="11" x2="11" y2="22"/>
+		<line class="st2" x1="22" y1="11" x2="11" y2="22"/>
+		<line class="st2" x1="11" y1="0" x2="0" y2="11"/>
+		<line class="st2" x1="14.3" y1="0" x2="14.3" y2="22"/>
+		<line class="st2" x1="7.7" y1="0" x2="7.7" y2="22"/>
+		<line class="st2" x1="3.3" y1="0" x2="3.3" y2="22"/>
+		<line class="st2" x1="18.7" y1="0" x2="18.7" y2="22"/>
+		<line class="st2" x1="22" y1="11" x2="0" y2="11"/>
+		<line class="st2" x1="22" y1="14.3" x2="0" y2="14.3"/>
+		<line class="st2" x1="22" y1="7.7" x2="0" y2="7.7"/>
+		<line class="st2" x1="22" y1="3.3" x2="0" y2="3.3"/>
+		<line class="st2" x1="22" y1="18.7" x2="0" y2="18.7"/>
+		<line class="st2" x1="2.2" y1="0" x2="2.2" y2="22"/>
+		<line class="st2" x1="19.8" y1="0" x2="19.8" y2="22"/>
+		<line class="st2" x1="0" y1="19.8" x2="22" y2="19.8"/>
+		<line class="st2" x1="0" y1="2.2" x2="22" y2="2.2"/>
+		<line class="st2" x1="17.6" y1="0" x2="17.6" y2="22"/>
+		<line class="st2" x1="11" y1="1.6" x2="20.3" y2="11"/>
+		<line class="st2" x1="1.6" y1="11" x2="11" y2="20.3"/>
+		<line class="st2" x1="20.3" y1="11" x2="11" y2="20.3"/>
+		<line class="st2" x1="11" y1="1.6" x2="1.6" y2="11"/>
+		<line class="st2" x1="0" y1="0" x2="22" y2="22"/>
+		<line class="st2" x1="6.6" y1="0" x2="6.6" y2="22"/>
+		<line class="st2" x1="15.4" y1="0" x2="15.4" y2="22"/>
+		<line class="st2" x1="0" y1="15.4" x2="22" y2="15.4"/>
+		<line class="st2" x1="0" y1="6.6" x2="22" y2="6.6"/>
+		<line class="st2" x1="20.9" y1="22" x2="0" y2="1.1"/>
+		<line class="st2" x1="1.1" y1="0" x2="22" y2="20.9"/>
+		<path class="st2" d="M22,22"/>
+		<path class="st2" d="M0,0"/>
+		<line class="st2" x1="0" y1="20.9" x2="20.9" y2="0"/>
+		<line class="st2" x1="22" y1="1.1" x2="1.1" y2="22"/>
+		<line class="st2" x1="4.4" y1="0" x2="4.4" y2="22"/>
+		<line class="st2" x1="22" y1="17.6" x2="0" y2="17.6"/>
+		<path id="SVGID_x5F_1_x5F_" class="st3" d="M22,4.4H0"/>
+		<text class="st4 st5">  </text>
+		<text transform="matrix(1 0 0 1 4.2539 4.4)" class="st4 st5"> </text>
+		<text class="st4 st5"> </text>
+		<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5563 10.9998)" class="st2" width="6.2" height="6.2"/>
+		<line class="st2" x1="0" y1="16.5" x2="22" y2="16.5"/>
+		<line class="st2" x1="16.5" y1="22" x2="16.5" y2="0"/>
+		<line class="st2" x1="5.5" y1="22" x2="5.5" y2="0"/>
+		<line class="st2" x1="22" y1="5.5" x2="0" y2="5.5"/>
+		<line class="st2" x1="12.1" y1="0" x2="12.1" y2="22"/>
+		<line class="st2" x1="13.2" y1="0" x2="13.2" y2="22"/>
+		<line class="st2" x1="8.8" y1="22" x2="8.8" y2="0"/>
+		<line class="st2" x1="9.9" y1="22" x2="9.9" y2="0"/>
+		<line class="st2" x1="0" y1="7.7" x2="22" y2="7.7"/>
+		<line class="st2" x1="0" y1="14.3" x2="22" y2="14.3"/>
+		<line class="st2" x1="0" y1="9.9" x2="22" y2="9.9"/>
+		<line class="st2" x1="0" y1="8.8" x2="22" y2="8.8"/>
+		<line class="st2" x1="22" y1="13.2" x2="0" y2="13.2"/>
+		<line class="st2" x1="22" y1="12.1" x2="0" y2="12.1"/>
+		<line class="st2" x1="1.1" y1="0" x2="1.1" y2="22"/>
+		<line class="st2" x1="20.9" y1="0" x2="20.9" y2="22"/>
+		<line class="st2" x1="0" y1="1.1" x2="22" y2="1.1"/>
+		<line class="st2" x1="0" y1="20.9" x2="22" y2="20.9"/>
+	</g>
+</g>
+<g id="Layer_2">
+	<text transform="matrix(1 0 0 1 4.968 13.1999)" class="st6 st7">m</text>
+	<polygon points="6,15.4 11,20.3 16,15.4 	"/>
+</g>
+</svg>

--- a/binderhub/static/images/rst-icon.svg
+++ b/binderhub/static/images/rst-icon.svg
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
 <style type="text/css">
 	.st0{display:none;}
 	.st1{display:inline;}
 	.st2{fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
 	.st3{fill:none;}
-	.st4{font-family:'ClearSans-Bold';}
-	.st5{font-size:13.5903px;}
+	.st4{font-family:'ArialMT';}
+	.st5{font-size:12px;}
+	.st6{fill:#4F4F4F;}
+	.st7{font-family:'ClearSans-Bold';}
+	.st8{font-size:13.5903px;}
 </style>
-<g id="Layer_1" class="st0">
+<g id="Layer_1_1_" class="st0">
 	<g class="st1">
 		<line class="st2" x1="11" y1="0" x2="11" y2="22"/>
 		<path class="st2" d="M21.5,11"/>
@@ -52,10 +55,10 @@
 		<line class="st2" x1="4.4" y1="0" x2="4.4" y2="22"/>
 		<line class="st2" x1="22" y1="17.6" x2="0" y2="17.6"/>
 		<path id="SVGID_x5F_1_x5F_" class="st3" d="M22,4.4H0"/>
-		<text>		<textPath  xlink:href="#SVGID_x5F_1_x5F_" startOffset="80.6641%">
-		</textPath>
-</text>
-		<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5564 10.9999)" class="st2" width="6.2" height="6.2"/>
+		<text class="st4 st5">  </text>
+		<text transform="matrix(1 0 0 1 4.2539 4.4)" class="st4 st5"> </text>
+		<text class="st4 st5"> </text>
+		<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5563 10.9998)" class="st2" width="6.2" height="6.2"/>
 		<line class="st2" x1="0" y1="16.5" x2="22" y2="16.5"/>
 		<line class="st2" x1="16.5" y1="22" x2="16.5" y2="0"/>
 		<line class="st2" x1="5.5" y1="22" x2="5.5" y2="0"/>
@@ -77,6 +80,6 @@
 	</g>
 </g>
 <g id="Layer_2">
-	<text transform="matrix(1 0 0 1 0.1523 14.3)" class="st4 st5">.rst</text>
+	<text transform="matrix(1 0 0 1 0.1523 14.3)" class="st6 st7 st8">.rst</text>
 </g>
 </svg>

--- a/binderhub/static/images/rst-icon.svg
+++ b/binderhub/static/images/rst-icon.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{display:none;}
+	.st1{display:inline;}
+	.st2{fill:none;stroke:#9E9E9E;stroke-width:2.000000e-02;stroke-miterlimit:10;}
+	.st3{fill:none;}
+	.st4{font-family:'ClearSans-Bold';}
+	.st5{font-size:13.5903px;}
+</style>
+<g id="Layer_1" class="st0">
+	<g class="st1">
+		<line class="st2" x1="11" y1="0" x2="11" y2="22"/>
+		<path class="st2" d="M21.5,11"/>
+		<path class="st2" d="M0.4,11"/>
+		<line class="st2" x1="0" y1="22" x2="22" y2="0"/>
+		<line class="st2" x1="11" y1="0" x2="22" y2="11"/>
+		<line class="st2" x1="0" y1="11" x2="11" y2="22"/>
+		<line class="st2" x1="22" y1="11" x2="11" y2="22"/>
+		<line class="st2" x1="11" y1="0" x2="0" y2="11"/>
+		<line class="st2" x1="14.3" y1="0" x2="14.3" y2="22"/>
+		<line class="st2" x1="7.7" y1="0" x2="7.7" y2="22"/>
+		<line class="st2" x1="3.3" y1="0" x2="3.3" y2="22"/>
+		<line class="st2" x1="18.7" y1="0" x2="18.7" y2="22"/>
+		<line class="st2" x1="22" y1="11" x2="0" y2="11"/>
+		<line class="st2" x1="22" y1="14.3" x2="0" y2="14.3"/>
+		<line class="st2" x1="22" y1="7.7" x2="0" y2="7.7"/>
+		<line class="st2" x1="22" y1="3.3" x2="0" y2="3.3"/>
+		<line class="st2" x1="22" y1="18.7" x2="0" y2="18.7"/>
+		<line class="st2" x1="2.2" y1="0" x2="2.2" y2="22"/>
+		<line class="st2" x1="19.8" y1="0" x2="19.8" y2="22"/>
+		<line class="st2" x1="0" y1="19.8" x2="22" y2="19.8"/>
+		<line class="st2" x1="0" y1="2.2" x2="22" y2="2.2"/>
+		<line class="st2" x1="17.6" y1="0" x2="17.6" y2="22"/>
+		<line class="st2" x1="11" y1="1.6" x2="20.3" y2="11"/>
+		<line class="st2" x1="1.6" y1="11" x2="11" y2="20.3"/>
+		<line class="st2" x1="20.3" y1="11" x2="11" y2="20.3"/>
+		<line class="st2" x1="11" y1="1.6" x2="1.6" y2="11"/>
+		<line class="st2" x1="0" y1="0" x2="22" y2="22"/>
+		<line class="st2" x1="6.6" y1="0" x2="6.6" y2="22"/>
+		<line class="st2" x1="15.4" y1="0" x2="15.4" y2="22"/>
+		<line class="st2" x1="0" y1="15.4" x2="22" y2="15.4"/>
+		<line class="st2" x1="0" y1="6.6" x2="22" y2="6.6"/>
+		<line class="st2" x1="20.9" y1="22" x2="0" y2="1.1"/>
+		<line class="st2" x1="1.1" y1="0" x2="22" y2="20.9"/>
+		<path class="st2" d="M22,22"/>
+		<path class="st2" d="M0,0"/>
+		<line class="st2" x1="0" y1="20.9" x2="20.9" y2="0"/>
+		<line class="st2" x1="22" y1="1.1" x2="1.1" y2="22"/>
+		<line class="st2" x1="4.4" y1="0" x2="4.4" y2="22"/>
+		<line class="st2" x1="22" y1="17.6" x2="0" y2="17.6"/>
+		<path id="SVGID_x5F_1_x5F_" class="st3" d="M22,4.4H0"/>
+		<text>		<textPath  xlink:href="#SVGID_x5F_1_x5F_" startOffset="80.6641%">
+		</textPath>
+</text>
+		<rect x="7.9" y="7.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 -4.5564 10.9999)" class="st2" width="6.2" height="6.2"/>
+		<line class="st2" x1="0" y1="16.5" x2="22" y2="16.5"/>
+		<line class="st2" x1="16.5" y1="22" x2="16.5" y2="0"/>
+		<line class="st2" x1="5.5" y1="22" x2="5.5" y2="0"/>
+		<line class="st2" x1="22" y1="5.5" x2="0" y2="5.5"/>
+		<line class="st2" x1="12.1" y1="0" x2="12.1" y2="22"/>
+		<line class="st2" x1="13.2" y1="0" x2="13.2" y2="22"/>
+		<line class="st2" x1="8.8" y1="22" x2="8.8" y2="0"/>
+		<line class="st2" x1="9.9" y1="22" x2="9.9" y2="0"/>
+		<line class="st2" x1="0" y1="7.7" x2="22" y2="7.7"/>
+		<line class="st2" x1="0" y1="14.3" x2="22" y2="14.3"/>
+		<line class="st2" x1="0" y1="9.9" x2="22" y2="9.9"/>
+		<line class="st2" x1="0" y1="8.8" x2="22" y2="8.8"/>
+		<line class="st2" x1="22" y1="13.2" x2="0" y2="13.2"/>
+		<line class="st2" x1="22" y1="12.1" x2="0" y2="12.1"/>
+		<line class="st2" x1="1.1" y1="0" x2="1.1" y2="22"/>
+		<line class="st2" x1="20.9" y1="0" x2="20.9" y2="22"/>
+		<line class="st2" x1="0" y1="1.1" x2="22" y2="1.1"/>
+		<line class="st2" x1="0" y1="20.9" x2="22" y2="20.9"/>
+	</g>
+</g>
+<g id="Layer_2">
+	<text transform="matrix(1 0 0 1 0.1523 14.3)" class="st4 st5">.rst</text>
+</g>
+</svg>

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -33,6 +33,17 @@ form {
     font-family: "ClearSans-Light", sans-serif;
 }
 
+hr {
+    border: 0;
+    clear:both;
+    display:block;
+    width: 100%;               
+    padding:0;
+    margin: 5px 0 5px 0;
+    border-top: 1px solid #cecece;
+    
+  }
+
 p > a {
     cursor: pointer;
     color: rgb(120,120,120);
@@ -188,11 +199,6 @@ h4 {
 .rst-li{
     width:100%;
     list-style-type:none;
-}
-
-hr{
-    border-top: 1px solid #8c8b8b;
-
 }
 
 .icon{

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -129,6 +129,21 @@ h4 {
     font-family: "Roboto Mono", monospace;
 }
 
+.url, .badges{
+    background-color: #ffffff;
+    box-shadow: 2px 2px 1px #888888;
+    border-radius: 4px;
+    
+}
+
+.url{
+    margin-bottom:20px;
+}
+
+.badges{
+    margin-bottom:40px;
+}
+
 .bluedropdown{
     background-color:#579ACA;
     border-radius: 4px 4px 0px 0px;
@@ -142,6 +157,13 @@ h4 {
 
 #caret{
     width:20px;
+}
+
+#greyline{
+    Stroke: Solid;
+    Align: Center;
+    Width: 1px;
+    color: #CECECE
 }
 
 #how-it-works {

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -131,15 +131,23 @@ h4 {
 
 .url, .badges{
     background-color: #ffffff;
-    box-shadow: 2px 2px 1px #888888;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+    border: 1px solid #ccc;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
     border-radius: 4px;
     display: flex;
     flex-direction: column;
-    align-items: flex-start
+    align-items: flex-end;
 }
+
 
 .url{
     margin-bottom:20px;
+}
+
+.url li {
+    list-style-type: none;
+    padding: 0 12px 0 12px;
 }
 
 .badges{
@@ -156,14 +164,32 @@ h4 {
 .bluedropdown label{
     color:white;
     padding: 6px 12px;
+    margin:0px;
 }
 
 .markdown-row{
     width:100%;
+    padding: 0 12px 0 12px;
 }
 
 .rst-row{
     width:100%;
+    padding: 0 12px 0 12px;
+}
+
+.markdown-li{
+    width:100%;
+    list-style-type: none;
+}
+
+.rst-li{
+    width:100%;
+    list-style-type:none;
+}
+
+hr{
+    border-top: 1px solid #8c8b8b;
+
 }
 
 .icon{
@@ -172,6 +198,10 @@ h4 {
     padding:4px;
 }
 #caret{
+    width:20px;
+}
+
+#copyicon{
     width:20px;
 }
 

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -157,9 +157,12 @@ h4 {
 
 .snippet-row{
     flex-direction:row;
-    height: 35px;
+    max-height: 35px;
 }
 
+.icon{
+    max-height:35px;
+}
 #caret{
     width:20px;
 }

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -19,7 +19,7 @@
     display: none;
 }
 
-#url-badge-snippet, #markdown-badge-snippet, #rst-badge-snippet, {
+#basic-url-snippet, #markdown-badge-snippet, #rst-badge-snippet, {
   max-width: 200px;
   font-size: 75%;
 }
@@ -193,15 +193,11 @@ h4 {
     width: 100%;
 }
 
-#url-badge-snippet, #markdown-badge-snippet, #rst-badge-snippet{
+#basic-url-snippet, #markdown-badge-snippet, #rst-badge-snippet{
     width:90%;
     float:left;
     margin: 12px 0 12px 12px;
     padding: 7px;
-}
-
-.url li a, .markdown-li a, .rst-li a{
-    display:none
 }
 
 

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -85,8 +85,14 @@ p > a:hover {
     padding-bottom: 24px;
 }
 
-#submit{
-width:175%;
+.btn-submit{
+    background-color:rgb(243, 162, 83);
+    box-shadow: 1px 1px rgba(0,0,0,.075);
+    width:220%;
+    color:white;
+    border:none;
+    height:35px;
+    border-radius: 4px;
 }
 
 .jumbotron {

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -129,6 +129,21 @@ h4 {
     font-family: "Roboto Mono", monospace;
 }
 
+.bluedropdown{
+    background-color:#579ACA;
+    border-radius: 4px 4px 0px 0px;
+    height:35px;
+}
+
+.bluedropdown label{
+    color:white;
+    padding: 6px 12px;
+}
+
+#caret{
+    width:20px;
+}
+
 #how-it-works {
     line-height: 1.5;
     font-weight: bold;

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -166,6 +166,10 @@ h4 {
     margin-bottom:40px;
 }
 
+.badges li{
+    list-style-type: none;
+}
+
 .bluedropdown{
     background-color:#579ACA;
     border-radius: 4px 4px 0px 0px;
@@ -185,10 +189,10 @@ h4 {
     width: 100%;
 }
 
-#markdown-badge-snippet, #rst-badge-snippet{
+#url-badge-snippet, #markdown-badge-snippet, #rst-badge-snippet{
     width:90%;
     float:left;
-    margin-left: 12px;
+    margin: 12px 0 12px 12px;
     padding: 7px;
 }
 
@@ -200,6 +204,7 @@ h4 {
 .icon{
     max-width: 30px;
     padding:4px;
+    margin-top: 13px;
 }
 
 #caret{

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -133,7 +133,9 @@ h4 {
     background-color: #ffffff;
     box-shadow: 2px 2px 1px #888888;
     border-radius: 4px;
-    
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start
 }
 
 .url{
@@ -148,6 +150,7 @@ h4 {
     background-color:#579ACA;
     border-radius: 4px 4px 0px 0px;
     height:35px;
+    width: 100%;
 }
 
 .bluedropdown label{
@@ -155,13 +158,18 @@ h4 {
     padding: 6px 12px;
 }
 
-.snippet-row{
-    flex-direction:row;
-    max-height: 35px;
+.markdown-row{
+    width:100%;
+}
+
+.rst-row{
+    width:100%;
 }
 
 .icon{
-    max-height:35px;
+    max-height:30px;
+    max-width: 30px;
+    padding:4px;
 }
 #caret{
     width:20px;

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -148,6 +148,7 @@ h4 {
 .url li {
     list-style-type: none;
     padding: 0 12px 0 12px;
+    height:30px;
 }
 
 .badges{
@@ -167,14 +168,13 @@ h4 {
     margin:0px;
 }
 
-.markdown-row{
-    width:100%;
-    padding: 0 12px 0 12px;
+.markdown-row, .rst-row{
+    align-items: flex-end;
+    width:10%;
 }
 
-.rst-row{
-    width:100%;
-    padding: 0 12px 0 12px;
+.icon-row{
+    padding:5px 0 5px 0;
 }
 
 .markdown-li{

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -181,28 +181,27 @@ h4 {
 }
 
 
-.icon-row{
-    padding:5px 0 5px 0;
+.markdown-row{
+    width: 100%;
 }
 
-.markdown-li{
-    list-style-type: none;
+#markdown-badge-snippet, #rst-badge-snippet{
+    width:90%;
+    float:left;
+    margin-left: 12px;
+    padding: 7px;
 }
 
 .url li a, .markdown-li a, .rst-li a{
     display:none
 }
 
-.rst-li{
-    width:100%;
-    list-style-type:none;
-}
 
 .icon{
-    max-height:30px;
     max-width: 30px;
     padding:4px;
 }
+
 #caret{
     width:20px;
     background-color: none;

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -180,9 +180,6 @@ h4 {
     width: 95%;
 }
 
-.markdown-row, .rst-row{
-    width:9%;
-}
 
 .icon-row{
     padding:5px 0 5px 0;
@@ -208,6 +205,7 @@ h4 {
 }
 #caret{
     width:20px;
+    background-color: none;
 }
 
 #copyicon{

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -37,11 +37,11 @@ hr {
     border: 0;
     clear:both;
     display:block;
-    width: 100%;               
+    width: 100%;
     padding:0;
     margin: 5px 0 5px 0;
     border-top: 1px solid #cecece;
-    
+
   }
 
 p > a {
@@ -195,7 +195,7 @@ h4 {
 }
 
 
-.markdown-row{
+.badge-snippet-row{
     width: 100%;
 }
 
@@ -209,8 +209,9 @@ h4 {
 
 .icon{
     max-width: 30px;
-    padding:4px;
+    padding:3px;
     margin-top: 13px;
+    margin-left: 4px;
 }
 
 #caret{
@@ -282,4 +283,30 @@ div.front {
 
 h4.logo-subtext {
   margin-top: -60px;
+}
+
+#badge-url {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+}
+
+.url-row {
+  height: 100%;
+  width: 100%;
+  display: table;
+}
+
+#badge-snippets {
+  width: 100%;
+}
+
+#basic-url-snippet {
+  width: 95%;
+}
+
+.badge-snippet-row pre {
+  float: right !important;
+  margin-right: 20px !important;
+  margin-left: 8px !important;
 }

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -85,6 +85,10 @@ p > a:hover {
     padding-bottom: 24px;
 }
 
+#submit{
+width:175%;
+}
+
 .jumbotron {
     background: rgb(235, 236, 237);
 }

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -166,11 +166,11 @@ h4 {
     color:white;
     padding: 6px 12px;
     margin:0px;
+    width: 95%;
 }
 
 .markdown-row, .rst-row{
-    align-items: flex-end;
-    width:10%;
+    width:9%;
 }
 
 .icon-row{
@@ -178,8 +178,11 @@ h4 {
 }
 
 .markdown-li{
-    width:100%;
     list-style-type: none;
+}
+
+.url li a, .markdown-li a, .rst-li a{
+    display:none
 }
 
 .rst-li{

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -19,7 +19,7 @@
     display: none;
 }
 
-#badge-snippet {
+#url-badge-snippet, #markdown-badge-snippet, #rst-badge-snippet, {
   max-width: 200px;
   font-size: 75%;
 }

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -155,6 +155,11 @@ h4 {
     padding: 6px 12px;
 }
 
+.snippet-row{
+    flex-direction:row;
+    height: 35px;
+}
+
 #caret{
     width:20px;
 }

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -138,6 +138,14 @@ function updateUrl() {
   return url;
 }
 
+function updateUrlDiv() {
+  url = updateUrl()
+  $('#badge-url').text(url);
+  $('#badge-url').attr('href', url)
+  $('#markdown-badge-snippet').text(markdownBadge(url));
+  $('#rst-badge-snippet').text(rstBadge(url));
+}
+
 
 var BADGE_URL = window.location.origin + '/badge.svg'
 
@@ -156,6 +164,7 @@ function rstBadge(url) {
 $(function(){
     var failed = false;
     var logsVisible = false;
+    var snippetsVisible = false;
     var log = new Terminal({
         convertEol: true,
         disableStdin: true
@@ -164,63 +173,20 @@ $(function(){
     // setup badge dropdown
     updateUrl();
 
-    // start the url badge invisible
-    $('#basic-url-snippet').hide();
-    $('#launch-buttons').on('hidden.bs.dropdown', function () {
-      // hide the badge snippet when dismissing the dropdown
-      $('#basic-url-snippet').hide();
+    $('#repository').on('keyup paste', function () {
+      updateUrlDiv()
     });
 
-    // start the markdown badge invisible
-    $('#markdown-badge-snippet').hide();
-    $('#launch-buttons').on('hidden.bs.dropdown', function () {
-      // hide the badge snippet when dismissing the dropdown
-      $('#badge-snippet').hide();
-    });
-    $("#url-or-file-btn").find("a").click(function (evt) {
-      $("#url-or-file-selected").text($(this).text());
-      updatePathText();
-    })
-    updatePathText();
-
-    // start the rst badge invisible
-    $('#rst-badge-snippet').hide();
-    $('#launch-buttons').on('hidden.bs.dropdown', function () {
-      // hide the badge snippet when dismissing the dropdown
-      $('#rst-badge-snippet').hide();
+    $('#ref').on('keyup paste', function () {
+      updateUrlDiv()
     });
 
-    // prevent badge text dropdown menu from disappearing on click
-    $('.dropdown-menu#badge-text li').click(function(e) {
-          e.stopPropagation();
-    });
-
-    $('#markdown-badge-toggle').on('click', function () {
-      var url = updateUrl();
-      $('#markdown-badge-snippet')
-        .show()
-        .text(markdownBadge(url));
-
-      return false;
-    });
-
-    $('#rst-badge-toggle').on('click', function () {
-      var url = updateUrl();
-      $('#rst-badge-snippet')
-        .show()
-        .text(rstBadge(url));
-      return false;
-    });
-
-    $('#basic-url-toggle').on('click', function () {
-      var url = updateUrl();
-      $('#basic-url-snippet')
-        .show()
-        .text(url);
-      return false;
+    $('#filepath').on('keyup paste', function () {
+      updateUrlDiv()
     });
 
     log.open(document.getElementById('log'), false);
+
     $(window).resize(function() {
         log.fit();
     });
@@ -240,6 +206,19 @@ $(function(){
         return false;
     });
 
+    $('#toggle-badge-snippet').on('click', function() {
+        var badgeSnippets = $('#badge-snippets');
+        if (badgeSnippets.hasClass('hidden')) {
+            badgeSnippets.removeClass('hidden');
+            snippetsVisible = true;
+        } else {
+            badgeSnippets.addClass('hidden');
+            snippetsVisible = false;
+        }
+
+        return false;
+    });
+
     $('#build-form').submit(function() {
         var repo = $('#repository').val().trim();
         var ref =  $('#ref').val().trim() || 'master';
@@ -253,6 +232,7 @@ $(function(){
         if (window.location.href !== url) {
           window.history.pushState({}, '', url);
         }
+        updateUrlDiv(url);
 
         $('#build-progress .progress-bar').addClass('hidden');
         log.clear();

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -172,6 +172,13 @@ $(function(){
     // setup badge dropdown
     updateUrl();
 
+    $("#url-or-file-btn").find("a").click(function (evt) {
+      $("#url-or-file-selected").text($(this).text());
+      updatePathText();
+      updateUrlDiv();
+    })
+    updatePathText();
+
     $('#repository').on('keyup paste', updateUrlDiv);
 
     $('#ref').on('keyup paste', updateUrlDiv);

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -139,7 +139,7 @@ function updateUrl() {
 }
 
 function updateUrlDiv() {
-  url = updateUrl()
+  var url = updateUrl()
   $('#badge-url').text(url);
   $('#badge-url').attr('href', url)
   $('#markdown-badge-snippet').text(markdownBadge(url));
@@ -164,7 +164,6 @@ function rstBadge(url) {
 $(function(){
     var failed = false;
     var logsVisible = false;
-    var snippetsVisible = false;
     var log = new Terminal({
         convertEol: true,
         disableStdin: true
@@ -173,17 +172,11 @@ $(function(){
     // setup badge dropdown
     updateUrl();
 
-    $('#repository').on('keyup paste', function () {
-      updateUrlDiv()
-    });
+    $('#repository').on('keyup paste', updateUrlDiv);
 
-    $('#ref').on('keyup paste', function () {
-      updateUrlDiv()
-    });
+    $('#ref').on('keyup paste', updateUrlDiv);
 
-    $('#filepath').on('keyup paste', function () {
-      updateUrlDiv()
-    });
+    $('#filepath').on('keyup paste', updateUrlDiv);
 
     log.open(document.getElementById('log'), false);
 
@@ -210,10 +203,8 @@ $(function(){
         var badgeSnippets = $('#badge-snippets');
         if (badgeSnippets.hasClass('hidden')) {
             badgeSnippets.removeClass('hidden');
-            snippetsVisible = true;
         } else {
             badgeSnippets.addClass('hidden');
-            snippetsVisible = false;
         }
 
         return false;

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -164,8 +164,15 @@ $(function(){
     // setup badge dropdown
     updateUrl();
 
-    // start the badge invisible
-    $('#badge-snippet').hide();
+    // start the url badge invisible
+    $('#url-badge-snippet').hide();
+    $('#launch-buttons').on('hidden.bs.dropdown', function () {
+      // hide the badge snippet when dismissing the dropdown
+      $('#url-badge-snippet').hide();
+    });
+
+    // start the markdown badge invisible
+    $('#markdown-badge-snippet').hide();
     $('#launch-buttons').on('hidden.bs.dropdown', function () {
       // hide the badge snippet when dismissing the dropdown
       $('#badge-snippet').hide();
@@ -176,6 +183,13 @@ $(function(){
     })
     updatePathText();
 
+    // start the rst badge invisible
+    $('#rst-badge-snippet').hide();
+    $('#launch-buttons').on('hidden.bs.dropdown', function () {
+      // hide the badge snippet when dismissing the dropdown
+      $('#rst-badge-snippet').hide();
+    });
+
     // prevent badge text dropdown menu from disappearing on click
     $('.dropdown-menu#badge-text li').click(function(e) {
           e.stopPropagation();
@@ -183,7 +197,7 @@ $(function(){
 
     $('#markdown-badge-toggle').on('click', function () {
       var url = updateUrl();
-      $('#badge-snippet')
+      $('#markdown-badge-snippet')
         .show()
         .text(markdownBadge(url));
       return false;
@@ -191,7 +205,7 @@ $(function(){
 
     $('#rst-badge-toggle').on('click', function () {
       var url = updateUrl();
-      $('#badge-snippet')
+      $('#rst-badge-snippet')
         .show()
         .text(rstBadge(url));
       return false;
@@ -199,7 +213,7 @@ $(function(){
 
     $('#basic-url-toggle').on('click', function () {
       var url = updateUrl();
-      $('#badge-snippet')
+      $('#url-badge-snippet')
         .show()
         .text(url);
       return false;

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -165,10 +165,10 @@ $(function(){
     updateUrl();
 
     // start the url badge invisible
-    $('#url-badge-snippet').hide();
+    $('#basic-url-snippet').hide();
     $('#launch-buttons').on('hidden.bs.dropdown', function () {
       // hide the badge snippet when dismissing the dropdown
-      $('#url-badge-snippet').hide();
+      $('#basic-url-snippet').hide();
     });
 
     // start the markdown badge invisible
@@ -200,6 +200,7 @@ $(function(){
       $('#markdown-badge-snippet')
         .show()
         .text(markdownBadge(url));
+
       return false;
     });
 
@@ -213,7 +214,7 @@ $(function(){
 
     $('#basic-url-toggle').on('click', function () {
       var url = updateUrl();
-      $('#url-badge-snippet')
+      $('#basic-url-snippet')
         .show()
         .text(url);
       return false;

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -147,12 +147,12 @@
             </div>
             <div  class="snippet-row">
               <li>markdown</li>
-              <img src="/static/images/copy-icon-black.svg">
+              <img class="icon" src="/static/images/copy-icon-black.svg">
               <li><pre id="badge-snippet"></pre></li>
             </div>
             <div  class="snippet-row"></div>
               <li class="snippet-row"><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-              <img src="/static/images/copy-icon-black.svg">
+              <img class="icon" src="/static/images/copy-icon-black.svg">
               <li><pre id="badge-snippet"></pre></li>
             </div>
             </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -72,9 +72,9 @@
                 <li><pre id="badge-snippet"></pre></li>
                 <li class="dropdown-header">Paste into your README to get</li>
                 <li>
-                  <a id="badge-link">
+                  <!--<a id="badge-link">
                     <img id="badge" src="/static/images/badge.svg">
-                  </a>
+                  </a>-->
                 </li>
               </ul>
             </div>
@@ -112,13 +112,22 @@
           </div>
         </div>
         <div class="url">
-            <label>Copy and share this URL:</label>
+            <div class="bluedropdown">
+              <label>Copy and share this URL:</label>
+              <img id="caret" src="/static/images/caretdown-white.svg">
+            </div>
             <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
         </div>
         <div class="badges">
-            <label>Paste into your README to get badge:</label>
-            <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
-            <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+            <div class="bluedropdown">
+              <label>Paste into your README to get badge:</label>
+              <a id="badge-link">
+                <img id="badge" src="/static/images/badge.svg">
+              </a>
+              <img id="caret" src="/static/images/caretdown-white.svg">
+            </div>
+              <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+              <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
         </div>
       </form>
     </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -58,27 +58,13 @@
               </div>
             </div>
           </div>
-          <!--<div class="form-group col-md-2">
+          
+    <div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">
               <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
-              <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
-                <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu" id="badge-text">
-                <li class="dropdown-header">Grab badge code in your format</li>
-                <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
-                <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
-                <li><pre id="badge-snippet"></pre></li>
-                <li class="dropdown-header">Paste into your README to get</li>
-                <li>
-                  <a id="badge-link">
-                    <img id="badge" src="/static/images/badge.svg">
-                  </a>
-                </li>
-              </ul>
+            </button>
             </div>
-          </div>-->
+          </div>
         </div>
 
         <div id="build-progress" class="progress on-build hidden">
@@ -129,10 +115,6 @@
               <a href="#" id="rst-badge-toggle" title="show rst badge snippet"><span class="caret"></span></a>
                 
               </button>
-            
-
-
-              <!--<a href="#" id="rst-badge-toggle" title="show rst badge snippet" id="markdown-badge-toggle" title="show markdown badge snippet"><img id="caret" src="/static/images/caretdown-white.svg"></a>-->
             </div>
 
             <!--Markdown section-->

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -117,6 +117,7 @@
               <img id="copyicon" src="/static/images/copy-icon-white.svg">
             </div>
             <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+            <pre id="url-badge-snippet"></pre>
         </div>
 
 
@@ -124,8 +125,9 @@
             <div class="bluedropdown">
               <label>Paste into your README to get badge: <img id="badge" src="/static/images/badge.svg"></label>
               <a id="badge-link"></a>
-              <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
-                <span class="caret"></span>
+              <a href="#" id="markdown-badge-toggle" title="show markdown badge snippet"><span class="caret"></span></a>
+              <a href="#" id="rst-badge-toggle" title="show rst badge snippet"><span class="caret"></span></a>
+                
               </button>
             
 
@@ -135,7 +137,7 @@
 
             <!--Markdown section-->
             <div  class="markdown-row">
-            <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+            <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet"></a></li>
                 
              <pre id="markdown-badge-snippet"></pre>
               <img class="icon" src="/static/images/markdown-icon.svg">
@@ -146,8 +148,6 @@
 
             <!--RST section-->
             <div  class="rst-row">
-
-                    <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
 
                 <pre id="rst-badge-snippet"></pre>
               <img class="icon" src="/static/images/rst-icon.svg">

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -58,7 +58,7 @@
               </div>
             </div>
           </div>
-          
+
     <div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">
               <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
@@ -100,10 +100,9 @@
         <div class="url">
             <div class="bluedropdown">
               <label>Copy and share this URL:</label>
-              <img id="copyicon" src="/static/images/copy-icon-white.svg">
+              <a href="#" id="basic-url-toggle" title="show url snippet"><img id="copyicon" src="/static/images/copy-icon-white.svg"></a>
             </div>
-            <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
-            <pre id="url-badge-snippet"></pre>
+            <pre id="basic-url-snippet"></pre>
         </div>
 
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -128,6 +128,7 @@
             </div>
               <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
               <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+            </div>
         </div>
       </form>
     </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -66,15 +66,15 @@
               </button>
               <ul class="dropdown-menu" id="badge-text">
                 <li class="dropdown-header">Grab badge code in your format</li>
-                <!--<li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+                <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
                 <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>-->
+                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
                 <li><pre id="badge-snippet"></pre></li>
                 <li class="dropdown-header">Paste into your README to get</li>
                 <li>
-                  <!--<a id="badge-link">
+                  <a id="badge-link">
                     <img id="badge" src="/static/images/badge.svg">
-                  </a>-->
+                  </a>
                 </li>
               </ul>
             </div>
@@ -112,6 +112,25 @@
           </div>
         </div>
         <div class="url">
+            <div class="btn-group" id="launch-buttons">
+                <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
+                <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" id="badge-text">
+                  <li class="dropdown-header">Grab badge code in your format</li>
+                  <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+                  <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+                  <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+                  <li><pre id="badge-snippet"></pre></li>
+                  <li class="dropdown-header">Paste into your README to get</li>
+                  <li>
+                    <a id="badge-link">
+                      <img id="badge" src="/static/images/badge.svg">
+                    </a>
+                  </li>
+                </ul>
+              </div>
             <div class="bluedropdown">
               <label>Copy and share this URL:</label>
               <img id="caret" src="/static/images/caretdown-white.svg">
@@ -124,10 +143,16 @@
               <a id="badge-link">
                 <img id="badge" src="/static/images/badge.svg">
               </a>
-              <img id="caret" src="/static/images/caretdown-white.svg">
+              <a href="#" id="rst-badge-toggle" title="show rst badge snippet" id="markdown-badge-toggle" title="show markdown badge snippet"><img id="caret" src="/static/images/caretdown-white.svg"></a>
             </div>
-              <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
-              <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+            <li>markdown</li>
+            <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+            <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+            <li><pre id="badge-snippet"></pre></li>
+            <li>
+              <li>markdown</li>
+              <li>rst</li>
+              <li><pre id="badge-snippet"></pre></li>
             </div>
         </div>
       </form>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -59,7 +59,7 @@
             </div>
           </div>
 
-    <div class="form-group col-md-2">
+          <div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">
               <button id="submit" class="btn-submit" type="submit">launch</button>
             </button>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -116,7 +116,7 @@
               <label>Copy and share this URL:</label>
               <img id="copyicon" src="/static/images/copy-icon-white.svg">
             </div>
-            <li><!--<a href="#" id="basic-url-toggle" title="show binder url">url</a>--></li>
+            <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
         </div>
         <div class="badges">
             <div class="bluedropdown">
@@ -128,21 +128,21 @@
             </div>
 
             <div  class="markdown-row">
-              <!--<li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>-->
+              <li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>
               <div class="icon-row">
               <img class="icon" src="/static/images/markdown-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
               </div>
-            </div>
+           
             <div  class="rst-row">
-              <!--<li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>-->
+              <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
               <div class="icon-row">
               <img class="icon" src="/static/images/rst-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
             </div>
+            
             </div>
-            </div>
-
+          </div>
         </div>
       </form>
     </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -137,10 +137,10 @@
             <div  class="markdown-row">
               <li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>
 
-                <div class="btn-group" >
+                <div class="markdown-btn-group" >
                     <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
                 </div>
-                <pre id="badge-snippet"></pre>
+                <pre id="markdown-badge-snippet"></pre>
               <div class="icon-row">
               <img class="icon" src="/static/images/markdown-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
@@ -152,10 +152,10 @@
             <div  class="rst-row">
                 <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
                   
-                  <div class="btn-group" >
+                  <div class="rst-btn-group" >
                     <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
                   </div>
-                  <pre id="badge-snippet"></pre>
+                  <pre id="rst-badge-snippet"></pre>
                 </div>
               <div class="icon-row">
               <img class="icon" src="/static/images/rst-icon.svg">

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -145,15 +145,15 @@
               </a>
               <a href="#" id="rst-badge-toggle" title="show rst badge snippet" id="markdown-badge-toggle" title="show markdown badge snippet"><img id="caret" src="/static/images/caretdown-white.svg"></a>
             </div>
-            <div  class="snippet-row">
-              <li>markdown</li>
+
+            <div  class="markdown-row">
+              <img class="icon" src="/static/images/markdown-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg">
-              <li><pre id="badge-snippet"></pre></li>
             </div>
-            <div  class="snippet-row"></div>
-              <li class="snippet-row"><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+
+            <div  class="rst-row">
+              <img class="icon" src="/static/images/rst-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg">
-              <li><pre id="badge-snippet"></pre></li>
             </div>
             </div>
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -66,9 +66,9 @@
               </button>
               <ul class="dropdown-menu" id="badge-text">
                 <li class="dropdown-header">Grab badge code in your format</li>
-                <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+                <!--<li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
                 <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>-->
                 <li><pre id="badge-snippet"></pre></li>
                 <li class="dropdown-header">Paste into your README to get</li>
                 <li>
@@ -110,6 +110,15 @@
           <div class="panel-body hidden">
             <div id="log"></div>
           </div>
+        </div>
+        <div class="url">
+            <label>Copy and share this URL:</label>
+            <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+        </div>
+        <div class="badges">
+            <label>Paste into your README to get badge:</label>
+            <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+            <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
         </div>
       </form>
     </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -112,28 +112,9 @@
           </div>
         </div>
         <div class="url">
-            <div class="btn-group" id="launch-buttons">
-                <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
-                <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
-                  <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" id="badge-text">
-                  <li class="dropdown-header">Grab badge code in your format</li>
-                  <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
-                  <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-                  <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
-                  <li><pre id="badge-snippet"></pre></li>
-                  <li class="dropdown-header">Paste into your README to get</li>
-                  <li>
-                    <a id="badge-link">
-                      <img id="badge" src="/static/images/badge.svg">
-                    </a>
-                  </li>
-                </ul>
-              </div>
             <div class="bluedropdown">
               <label>Copy and share this URL:</label>
-              <img id="caret" src="/static/images/copy-icon-white.svg">
+              <img id="copyicon" src="/static/images/copy-icon-white.svg">
             </div>
             <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
         </div>
@@ -147,13 +128,14 @@
             </div>
 
             <div  class="markdown-row">
+              <li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>
               <img class="icon" src="/static/images/markdown-icon.svg">
-              <img class="icon" src="/static/images/copy-icon-black.svg">
+              <img class="icon" src="/static/images/copy-icon-black.svg"></li>
             </div>
-
             <div  class="rst-row">
+              <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
               <img class="icon" src="/static/images/rst-icon.svg">
-              <img class="icon" src="/static/images/copy-icon-black.svg">
+              <img class="icon" src="/static/images/copy-icon-black.svg"></li>
             </div>
             </div>
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -156,12 +156,11 @@
                     <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
                   </div>
                   <pre id="rst-badge-snippet"></pre>
-                </div>
               <div class="icon-row">
               <img class="icon" src="/static/images/rst-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
             </div>
-            
+          </div>
             </div>
           </div>
         </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -134,6 +134,8 @@
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
               </div>
            
+              <hr>
+
             <div  class="rst-row">
               <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
               <div class="icon-row">

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -61,7 +61,7 @@
 
     <div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">
-              <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
+              <button id="submit" class="btn-submit" type="submit">launch</button>
             </button>
             </div>
           </div>
@@ -97,11 +97,38 @@
             <div id="log"></div>
           </div>
         </div>
+
+        <!--text
+
+        <div class="form-group col-md-2">
+            <div class="btn-group" id="launch-buttons">
+              <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
+              <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" id="badge-text">
+                <li class="dropdown-header">Grab badge code in your format</li>
+                <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+                <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+                <li><pre id="badge-snippet"></pre></li>
+                <li class="dropdown-header">Paste into your README to get</li>
+                <li>
+                  <a id="badge-link">
+                    <img id="badge" src="/static/images/badge.svg">
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>-->
+
+        <!--url section-->
         <div class="url">
             <div class="bluedropdown">
               <label>Copy and share this URL:</label>
-              <a href="#" id="basic-url-toggle" title="show url snippet"><img id="copyicon" src="/static/images/copy-icon-white.svg"></a>
             </div>
+            <a href="#" id="basic-url-toggle" title="show url snippet">url</a>
             <pre id="basic-url-snippet"></pre>
         </div>
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -98,72 +98,39 @@
           </div>
         </div>
 
-        <!--text
-
-        <div class="form-group col-md-2">
-            <div class="btn-group" id="launch-buttons">
-              <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
-              <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
-                <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu" id="badge-text">
-                <li class="dropdown-header">Grab badge code in your format</li>
-                <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
-                <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-                <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
-                <li><pre id="badge-snippet"></pre></li>
-                <li class="dropdown-header">Paste into your README to get</li>
-                <li>
-                  <a id="badge-link">
-                    <img id="badge" src="/static/images/badge.svg">
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>-->
-
         <!--url section-->
         <div class="url">
             <div class="bluedropdown">
               <label>Copy and share this URL:</label>
             </div>
-            <a href="#" id="basic-url-toggle" title="show url snippet">url</a>
-            <pre id="basic-url-snippet"></pre>
+            <div class="url-row">
+              <pre id="basic-url-snippet"><a href="#" id="badge-url" title="show url snippet">Begin typing to see your URL!</a></pre>
+            </div>
         </div>
-
 
         <div class="badges">
-            <div class="bluedropdown">
-              <label>Paste into your README to get badge: <img id="badge" src="/static/images/badge.svg"></label>
+            <div class="bluedropdown" id="toggle-badge-snippet">
+              <label>Click, then paste into your README to get badge: <img id="badge" src="/static/images/badge.svg"></label>
               <a id="badge-link"></a>
-              <a href="#" id="markdown-badge-toggle" title="show markdown badge snippet"><span class="caret"></span></a>
-              <a href="#" id="rst-badge-toggle" title="show rst badge snippet"><span class="caret"></span></a>
-                
+              <a href="#" title="show badge snippets"><span class="caret"></span></a>
+
               </button>
             </div>
-
-            <!--Markdown section-->
-            <div  class="markdown-row">
-            <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet"></a></li>
-                
-             <pre id="markdown-badge-snippet"></pre>
-              <img class="icon" src="/static/images/markdown-icon.svg">
-              <img class="icon" src="/static/images/copy-icon-black.svg"></li>
-              
-           
+            <div id="badge-snippets" class="hidden">
+              <!--Markdown section-->
+              <div  class="badge-snippet-row">
+                 <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet</pre>
+                 <img class="icon" src="/static/images/markdown-icon.svg">
+              </div>
               <hr>
-
-            <!--RST section-->
-            <div  class="rst-row">
-
-                <pre id="rst-badge-snippet"></pre>
-              <img class="icon" src="/static/images/rst-icon.svg">
-              <img class="icon" src="/static/images/copy-icon-black.svg"></li>
-          </div>
+              <!--RST section-->
+              <div  class="badge-snippet-row">
+                <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet</pre>
+                <img class="icon" src="/static/images/rst-icon.svg">
+              </div>
             </div>
-          </div>
         </div>
+
       </form>
     </div>
   </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -133,27 +133,30 @@
               </div>
             <div class="bluedropdown">
               <label>Copy and share this URL:</label>
-              <img id="caret" src="/static/images/caretdown-white.svg">
+              <img id="caret" src="/static/images/copy-icon-white.svg">
             </div>
             <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
         </div>
         <div class="badges">
             <div class="bluedropdown">
-              <label>Paste into your README to get badge:</label>
+              <label>Paste into your README to get badge: <img id="badge" src="/static/images/badge.svg"></label>
               <a id="badge-link">
-                <img id="badge" src="/static/images/badge.svg">
+                
               </a>
               <a href="#" id="rst-badge-toggle" title="show rst badge snippet" id="markdown-badge-toggle" title="show markdown badge snippet"><img id="caret" src="/static/images/caretdown-white.svg"></a>
             </div>
-            <li>markdown</li>
-            <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-            <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
-            <li><pre id="badge-snippet"></pre></li>
-            <li>
+            <div  class="snippet-row">
               <li>markdown</li>
-              <li>rst</li>
+              <img src="/static/images/copy-icon-black.svg">
               <li><pre id="badge-snippet"></pre></li>
             </div>
+            <div  class="snippet-row"></div>
+              <li class="snippet-row"><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+              <img src="/static/images/copy-icon-black.svg">
+              <li><pre id="badge-snippet"></pre></li>
+            </div>
+            </div>
+
         </div>
       </form>
     </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -135,31 +135,23 @@
 
             <!--Markdown section-->
             <div  class="markdown-row">
-              <li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>
-
-                <div class="markdown-btn-group" >
-                    <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
-                </div>
-                <pre id="markdown-badge-snippet"></pre>
-              <div class="icon-row">
+            <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+                
+             <pre id="markdown-badge-snippet"></pre>
               <img class="icon" src="/static/images/markdown-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
-              </div>
+              
            
               <hr>
 
             <!--RST section-->
             <div  class="rst-row">
-                <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
-                  
-                  <div class="rst-btn-group" >
+
                     <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
-                  </div>
-                  <pre id="rst-badge-snippet"></pre>
-              <div class="icon-row">
+
+                <pre id="rst-badge-snippet"></pre>
               <img class="icon" src="/static/images/rst-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
-            </div>
           </div>
             </div>
           </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -58,7 +58,7 @@
               </div>
             </div>
           </div>
-          <div class="form-group col-md-2">
+          <!--<div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">
               <button id="submit" class="btn btn-warning submit" type="submit">launch</button>
               <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
@@ -78,7 +78,7 @@
                 </li>
               </ul>
             </div>
-          </div>
+          </div>-->
         </div>
 
         <div id="build-progress" class="progress on-build hidden">
@@ -118,17 +118,29 @@
             </div>
             <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
         </div>
+
+
         <div class="badges">
             <div class="bluedropdown">
               <label>Paste into your README to get badge: <img id="badge" src="/static/images/badge.svg"></label>
-              <a id="badge-link">
-                
-              </a>
-              <a href="#" id="rst-badge-toggle" title="show rst badge snippet" id="markdown-badge-toggle" title="show markdown badge snippet"><img id="caret" src="/static/images/caretdown-white.svg"></a>
+              <a id="badge-link"></a>
+              <button id="badge-dropdown" class="btn btn-warning dropdown-toggle" type="button" data-toggle="dropdown">
+                <span class="caret"></span>
+              </button>
+            
+
+
+              <!--<a href="#" id="rst-badge-toggle" title="show rst badge snippet" id="markdown-badge-toggle" title="show markdown badge snippet"><img id="caret" src="/static/images/caretdown-white.svg"></a>-->
             </div>
 
+            <!--Markdown section-->
             <div  class="markdown-row">
               <li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>
+
+                <div class="btn-group" >
+                    <li><a href="#" id="markdown-badge-toggle" title="show markdown badge snippet">markdown</a></li>
+                </div>
+                <pre id="badge-snippet"></pre>
               <div class="icon-row">
               <img class="icon" src="/static/images/markdown-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
@@ -136,8 +148,15 @@
            
               <hr>
 
+            <!--RST section-->
             <div  class="rst-row">
-              <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
+                <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
+                  
+                  <div class="btn-group" >
+                    <li><a href="#" id="rst-badge-toggle" title="show rst badge snippet">rst</a></li>
+                  </div>
+                  <pre id="badge-snippet"></pre>
+                </div>
               <div class="icon-row">
               <img class="icon" src="/static/images/rst-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -110,7 +110,7 @@
 
         <div class="badges">
             <div class="bluedropdown" id="toggle-badge-snippet">
-              <label>Click, then paste into your README to get badge: <img id="badge" src="/static/images/badge.svg"></label>
+              <label>Click, then paste into your README to get badge: <img id="badge" src="{{static_url("images/badge.svg")}}"></label>
               <a id="badge-link"></a>
               <a href="#" title="show badge snippets"><span class="caret"></span></a>
 
@@ -120,13 +120,13 @@
               <!--Markdown section-->
               <div  class="badge-snippet-row">
                  <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet</pre>
-                 <img class="icon" src="/static/images/markdown-icon.svg">
+                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
               </div>
               <hr>
               <!--RST section-->
               <div  class="badge-snippet-row">
                 <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet</pre>
-                <img class="icon" src="/static/images/rst-icon.svg">
+                <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
               </div>
             </div>
         </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -116,7 +116,7 @@
               <label>Copy and share this URL:</label>
               <img id="copyicon" src="/static/images/copy-icon-white.svg">
             </div>
-            <li><a href="#" id="basic-url-toggle" title="show binder url">url</a></li>
+            <li><!--<a href="#" id="basic-url-toggle" title="show binder url">url</a>--></li>
         </div>
         <div class="badges">
             <div class="bluedropdown">
@@ -128,14 +128,18 @@
             </div>
 
             <div  class="markdown-row">
-              <li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>
+              <!--<li class="markdown-li"><a href="#" id="basic-markdown-toggle" title="show binder url">Markdown</a>-->
+              <div class="icon-row">
               <img class="icon" src="/static/images/markdown-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
+              </div>
             </div>
             <div  class="rst-row">
-              <li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>
+              <!--<li class="rst-li"><a href="#" id="basic-rst-toggle" title="show binder url">rst</a>-->
+              <div class="icon-row">
               <img class="icon" src="/static/images/rst-icon.svg">
               <img class="icon" src="/static/images/copy-icon-black.svg"></li>
+            </div>
             </div>
             </div>
 


### PR DESCRIPTION
Hi everyone, following up on Issue #132, here is an addition I designed for two new sections: URL copy and paste and Badge copy and paste. I've also created new icons for this. 

I haven't added the copy and paste features to these new sections, because I'm not sure how to work with that code, but here are the empty sections that we will be able to work with to replace the dropdown on the launch button above. 

![screen shot 2017-11-08 at 12 22 47 pm](https://user-images.githubusercontent.com/27518229/32572676-2fa056ec-c480-11e7-9997-8e0b33dba2dc.png)

I kept all of the current code the same, I just added to it with this new section! 
