### PR TITLE
Add previous and next link to the bottom content in each page.

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,3 +1,28 @@
 img.logo {
   width:100%
 }
+
+.right-next {
+    float: right;
+    max-width: 45%;
+    overflow: auto;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.right-next::after{
+    content: ' »';
+}
+
+.left-prev {
+    float: left;
+    max-width: 45%;
+    overflow: auto;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.left-prev::before{
+    content: '« ';
+}
+

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,0 +1,23 @@
+{% extends '!page.html' %}
+
+{# Custom template for page.html
+
+   Alabaster theme does not provide blocks for prev/next at bottom of each page.
+   This is _in addition_ to the prev/next in the  sidebar. The "Prev/Next" text
+   or symbols are handled by CSS classes in _static/custom.css
+#}
+
+{% block prev_next %}
+  {%- if prev %}
+     <a class='left-prev' href="{{ prev.link|e }}" title="{{ _('previous chapter')}}">{{ prev.title }}</a>
+  {%- endif %}
+  {%- if next %}
+     <a class='right-next' href="{{ next.link|e }}" title="{{ _('next chapter')}}">{{ next.title }}</a>
+  {%- endif %}
+{% endblock %}
+
+
+{% block body %}
+  {{super()}}
+  {{ self.prev_next() }}
+{% endblock %}


### PR DESCRIPTION
This is in addition to the content in the sidebar in order to be more
discoverable by users.

I'm also personally a fan of having it on top of each page as well; but
I don't think it fits well with _this_ theme, And the link in the
sidebar are sufficient.

--- 

Here is what it looks like:

---

<img width="683" alt="screen shot 2017-11-08 at 13 16 37" src="https://user-images.githubusercontent.com/335567/32574829-225e0586-c487-11e7-8764-57ca95aa320d.png">
---
If a title is too long it get elided:

--- 

<img width="689" alt="screen shot 2017-11-08 at 13 16 45" src="https://user-images.githubusercontent.com/335567/32574858-3332db8e-c487-11e7-9df0-3835025d080c.png">

---

This is not included, but we could also add link at the top of the page

<img width="695" alt="screen shot 2017-11-08 at 13 15 50" src="https://user-images.githubusercontent.com/335567/32574914-5e5d88d6-c487-11e7-893d-52038fe3e818.png">

---

cc @willingc 

