### PR TITLE
Remove dependencies in Sphinx RTD Theme and work around conda bug.

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,8 +6,8 @@ dependencies:
 - traitlets>=4.1
 - tornado>=4.1
 - sphinx>=1.4, !=1.5.4
-- sphinx_rtd_theme
 - graphviz
+- pip
 - pip:
   - recommonmark==0.4.0
   - pygraphviz==1.4rc1


### PR DESCRIPTION
The Sphinx RTD theme is AFAICT not useful.

Conda has a bug (https://github.com/conda/conda/issues/5680), with a
proposed fix (https://github.com/conda/conda/pull/6275). Waiting for it
we should should list pip as a conda dependency when using the `pip:`
section, as a temporary workaround.