### PR TITLE
Add top Previous/Next on each page.

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -26,3 +26,10 @@ img.logo {
     content: '« ';
 }
 
+.prev-next-bottom {
+  margin-top: 3em;
+}
+
+.prev-next-top {
+  margin-bottom: 1em;
+}

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -7,17 +7,24 @@
    or symbols are handled by CSS classes in _static/custom.css
 #}
 
-{% block prev_next %}
+{% macro prev_next(prev, next, prev_title='', next_title='') %}
   {%- if prev %}
-     <a class='left-prev' href="{{ prev.link|e }}" title="{{ _('previous chapter')}}">{{ prev.title }}</a>
+     <a class='left-prev' href="{{ prev.link|e }}" title="{{ _('previous chapter')}}">{{ prev_title or prev.title }}</a>
   {%- endif %}
   {%- if next %}
-     <a class='right-next' href="{{ next.link|e }}" title="{{ _('next chapter')}}">{{ next.title }}</a>
+     <a class='right-next' href="{{ next.link|e }}" title="{{ _('next chapter')}}">{{ next_title or next.title }}</a>
   {%- endif %}
-{% endblock %}
+  <div style='clear:both;'></div>
+{% endmacro %}
 
 
 {% block body %}
+  <div class='prev-next-top'>
+    {{ prev_next(prev, next, 'Previous', 'Next') }}
+  </div>
+
   {{super()}}
-  {{ self.prev_next() }}
+  <div class='prev-next-bottom'>
+    {{ prev_next(prev, next) }}
+  </div>
 {% endblock %}


### PR DESCRIPTION
As requested by willinc, to see what it looks like (and if we like it).
Text is literally `Previous` and `Next` not to visually change between
page and stay discreet.

I think it is useful, (I like that), but I tink it is only minimally
useful so would be ok if it's not merged.

<img width="921" alt="screen shot 2017-11-08 at 18 14 14" src="https://user-images.githubusercontent.com/335567/32585119-b61f01b6-c4b0-11e7-9800-449104ccfd3b.png">
