### PR TITLE
Avoid spurious newlines in binderhub secret

### DIFF
--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -5,8 +5,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.registry.enabled -}}
-  config.json: |
-    {{ b64enc (printf "{\"auths\": { \"https://%s\": { \"email\": \"not@val.id\", \"auth\": \"%s\" } } }" .Values.registry.host (b64enc (printf "%s:%s" .Values.registry.username .Values.registry.password) ) ) }}
+  config.json: {{ b64enc (printf "{\"auths\": { \"https://%s\": { \"email\": \"not@val.id\", \"auth\": \"%s\" } } }" .Values.registry.host (b64enc (printf "%s:%s" .Values.registry.username .Values.registry.password) ) ) | quote }}
   {{- end }}
   binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
   {{ if .Values.github.clientId -}}


### PR DESCRIPTION
I have absolutely no idea why this was perfectly fine until
today and suddenly decided to start giving me hell. helm
fails completely because there is a newline at the end of the
secret value, rejected by kubernetes.

I hate text templating to produce objects.