### PR TITLE
Enable Branch Names to contain slashes (Fix #263)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ install:
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 - chmod +x bin/helm
 - helm init --client-only
-- python setup.py install
-- python setup.py test
+- pip install .
 script:
 - |
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
@@ -22,6 +21,8 @@ script:
     cd - 
   fi
 - "./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
+- pip install pytest
+- pytest -v tests/
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   fi
 - "./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
 - pip install pytest
-- pytest -v tests/
+- pytest -v
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 - chmod +x bin/helm
 - helm init --client-only
+- python setup.py install
+- python setup.py test
 script:
 - |
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,12 @@ and run binderhub on the host system.
 
 All features should work, including building and launching.
 
+9. Running unit tests
+
+  ```bash
+  python setup.py test
+  ```
+
 ## Pure HTML / CSS / JS development
 
 If you do not want to set up minikube but just want to hack on the html / css / js,

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -21,6 +21,25 @@ from traitlets.config import LoggingConfigurable
 
 GITHUB_RATE_LIMIT = Gauge('binderhub_github_rate_limit_remaining', 'GitHub rate limit remaining')
 
+
+def tokenize_spec(spec):
+    """Tokenize a Git Spec into parts, error if spec invalid."""
+
+    spec_parts = spec.split('/', 2)  # allow ref to contain "/"
+    if len(spec_parts) != 3:
+        msg = 'Spec is not of the form "user/repo/ref", provided: "{spec}".'.format(spec=spec)
+        if len(spec_parts) == 2 and spec_parts[-1] != 'master':
+            msg += ' Did you mean "{spec}/master"?'.format(spec=spec)
+        raise ValueError(msg)
+
+    return spec_parts
+
+def strip_suffix(text, suffix):
+    if text.endswith(suffix):
+        text = text[:-(len(suffix))]
+    return text
+
+
 class RepoProvider(LoggingConfigurable):
     """Base class for a repo provider"""
     name = Unicode(
@@ -119,25 +138,6 @@ class GitHubRepoProvider(RepoProvider):
         super().__init__(*args, **kwargs)
         self.user, self.repo, self.unresolved_ref = self.process_spec(self.spec)
         self.repo = strip_suffix(self.repo, ".git")
-
-    @staticmethod
-    def process_spec(spec):
-        """Tokenizes a Github Spec into parts, error if spec invalid."""
-
-        spec_parts = spec.split('/', 2)  # allow ref to contain "/"
-        if len(spec_parts) != 3:
-            msg = 'Spec is not of the form "user/repo/ref", provided: "{spec}".'.format(spec=spec)
-            if len(spec_parts) == 2 and spec_parts[-1] != 'master':
-                msg += ' Did you mean "{spec}/master"?'.format(spec=spec)
-            raise ValueError(msg)
-
-        return spec_parts
-
-    @staticmethod
-    def strip_suffix(text, suffix):
-        if text.endswith(suffix):
-            text = text[:-(len(suffix))]
-        return text
 
     def get_repo_url(self):
         return "https://github.com/{user}/{repo}".format(user=self.user, repo=self.repo)

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -117,7 +117,7 @@ class GitHubRepoProvider(RepoProvider):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        spec_parts = self.spec.split('/')
+        spec_parts = self.spec.split('/', 2)  # allow ref to contain "/"
         if len(spec_parts) != 3:
             msg = 'Spec is not of the form "user/repo/ref", provided: "{spec}".'.format(spec=self.spec)
             if len(spec_parts) == 2 and spec_parts[-1] != 'master':
@@ -126,7 +126,7 @@ class GitHubRepoProvider(RepoProvider):
 
         self.user, self.repo, self.unresolved_ref = spec_parts
         if self.repo.endswith('.git'):
-            self.repo = self.repo[:len(self.repo) - 4]
+            self.repo = self.repo[:-4]  # Strip .git suffix
 
     def get_repo_url(self):
         return "https://github.com/{user}/{repo}".format(user=self.user, repo=self.repo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+kubernetes==3.*
+tornado
+traitlets
+docker
+jinja2
+prometheus_client

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,33 @@
 from setuptools import setup, find_packages
 
+install_requirements = [
+    'kubernetes==3.*',
+    'tornado',
+    'traitlets',
+    'docker',
+    'jinja2',
+    'prometheus_client'
+]
+
+setup_requirements = [
+    'pytest-runner'
+]
+
+test_requirements = [
+    'pytest'
+]
+
 setup(
     name='binderhub',
-    version='0.1',
-    install_requires=[
-        'kubernetes==3.*',
-        'tornado',
-        'traitlets',
-        'docker',
-        'jinja2',
-        'prometheus_client'
-    ],
+    version='0.1.1',
+    install_requires=install_requirements,
     python_requires='>=3.5',
     author='Project Jupyter Contributors',
     author_email='jupyter@googlegroups.com',
     license='BSD',
     packages=find_packages(),
     include_package_data=True,
+    setup_requires=setup_requirements,
+    test_suite='tests',
+    tests_require=test_requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 from setuptools import setup, find_packages
-
-install_requirements = [
-    'kubernetes==3.*',
-    'tornado',
-    'traitlets',
-    'docker',
-    'jinja2',
-    'prometheus_client'
-]
+from pip.req import parse_requirements
+import uuid
 
 setup_requirements = [
     'pytest-runner'
@@ -16,6 +9,9 @@ setup_requirements = [
 test_requirements = [
     'pytest'
 ]
+
+install_requirements = [str(ir.req) for ir in parse_requirements(
+                        "requirements.txt", session=uuid.uuid1())]
 
 setup(
     name='binderhub',

--- a/tests/repoproviders_test.py
+++ b/tests/repoproviders_test.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+import pytest
+
+from binderhub.repoproviders import GitHubRepoProvider
+
+
+# General string processing
+@pytest.mark.parametrize(
+    'raw_text, suffix, clean_text', [
+        ("foo.git", ".git", "foo"),
+        ("foo.bar", ".git", "foo.bar"),
+        ("foo.bar", ".bar", "foo")
+    ]
+)
+def test_string_strip(raw_text, suffix, clean_text):
+    assert GitHubRepoProvider.strip_suffix(raw_text, suffix) == clean_text
+
+
+# user/repo/reference
+@pytest.mark.parametrize(
+    'spec, raw_user, raw_repo, raw_ref', [
+        ("user/repo/master", "user", "repo", "master"),
+        ("user/repo/hotfix/squash-bug", "user", "repo", "hotfix/squash-bug"),
+        ("user/repo/feature/save_world", "user", "repo", "feature/save_world")
+    ]
+)
+def test_spec_processing(spec, raw_user, raw_repo, raw_ref):
+    user, repo, unresolved_ref = GitHubRepoProvider.process_spec(spec)
+    assert raw_user == user
+    assert raw_repo == repo
+    assert raw_ref == unresolved_ref
+
+
+class TestSpecErrorHandling(TestCase):
+
+    def test_too_short_spec(self):
+        spec = "nothing_to_split"
+        with self.assertRaisesRegexp(ValueError, "Spec is not of the form"):
+            user, repo, unresolved_ref = GitHubRepoProvider.process_spec(spec)
+
+    def test_long_spec(self):
+        # No specification is too long, extra slashes go to the "ref" property
+        spec = "a/long/specification/with/many/slashes/to/split/on"
+        spec_parts = GitHubRepoProvider.process_spec(spec)
+        assert len(spec_parts) == 3
+
+    def test_spec_with_no_suggestion(self):
+        spec = "short/master"
+        error = "^((?!Did you mean).)*$".format(spec)  # negative match
+        with self.assertRaisesRegexp(ValueError, error):
+            user, repo, unresolved_ref = GitHubRepoProvider.process_spec(spec)
+
+    def test_spec_with_suggestion(self):
+        spec = "short/suggestion"
+        error = "Did you mean \"{}/master\"?".format(spec)
+        with self.assertRaisesRegexp(ValueError, error):
+            user, repo, unresolved_ref = GitHubRepoProvider.process_spec(spec)


### PR DESCRIPTION
# Background

- When people follow the common `git-flow` [naming convention](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow), their branches will contain a `/` character. 
- In the present version of binderhub, such branches will not work (this should Fix #263)
- We'd like to be able to support building off of branches named with any naming convention, otherwise people will always have to build off of `develop` or `master`. 

# Changelog

- Adjust the `split` function so that binderhub supports branches named with `git-flow` conventions
- Minor change to a line that strips `.git` off the repo name with a more succinct + performant line.

# Notes

- I tried to test this locally by following directions in `CONTRIBUTING.md`, however I'm presently unable to get any repos to work. I think this may be related to #262 .