### PR TITLE
Use recommended template for creating docker config

### DIFF
--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -14,3 +14,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.registry.host (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
+{{- end }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.registry.enabled -}}
-  config.json: {{ b64enc (printf "{\"auths\": { \"https://%s\": { \"email\": \"not@val.id\", \"auth\": \"%s\" } } }" .Values.registry.host (b64enc (printf "%s:%s" .Values.registry.username .Values.registry.password) ) ) | quote }}
+  config.json: {{ template "imagePullSecret" . }}
   {{- end }}
   binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
   {{ if .Values.github.clientId -}}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -5,7 +5,7 @@ metadata:
 type: Opaque
 data:
   {{ if .Values.registry.enabled -}}
-  config.json: {{ template "imagePullSecret" . }}
+  config.json: {{ template "imagePullSecret" . | quote }}
   {{- end }}
   binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
   {{ if .Values.github.clientId -}}


### PR DESCRIPTION
This updates how the `config.json` in `secret.yaml` gets created to match `helms` "tips and tricks" example found [here](https://github.com/kubernetes/helm/blob/master/docs/charts_tips_and_tricks.md#creating-image-pull-secrets).

This may be related to #262 and the recent changes to the `secrets.yaml`. I have yet to test this, but posting it for @hydrosquall and others who may be running into the same issue.