### PR TITLE
[MRG] Update CSS rules to match H4 logo-subtext

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -180,6 +180,6 @@ div.front {
     font-size: .9em;
 }
 
-h3.logo-subtext {
+h4.logo-subtext {
   margin-top: -60px;
 }


### PR DESCRIPTION
This is a followup to #226. Without this PR things look like:

<img width="526" alt="screen shot 2017-11-12 at 17 59 43" src="https://user-images.githubusercontent.com/1448859/32701302-5c9d4348-c7d3-11e7-8d54-2bd72ad57e9e.png">

and after this PR:

<img width="427" alt="screen shot 2017-11-12 at 18 00 00" src="https://user-images.githubusercontent.com/1448859/32701303-62cf7b1e-c7d3-11e7-99d8-962fc100c6a7.png">
