### PR TITLE
Adjust order in which we mention how to specify dependencies

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -131,7 +131,7 @@
         <span class="point point-red">2</span>
       </div>
       <div class="col-md-7 front">
-        <span class="front-em">We build a Docker image of your repository</span><br />Does your repository depend on files being loaded for your live notebooks? We will search in your repository's root for a dependency such as a Dockerfile or requirements.txt. The first dependency file found will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
+        <span class="front-em">We build a Docker image of your repository</span><br />Does your repository depend on files being loaded for your live notebooks? We will search in your repository's root for a dependency such as a requirements.txt, environment.yml or Dockerfile. The first dependency file found will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
       </div>
     </div>
 


### PR DESCRIPTION
People might think Dockerfile is preferred because it is listed first
when the opposite is true.