### PR TITLE
add missing https in auth helper

### DIFF
--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -16,5 +16,5 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "imagePullSecret" }}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.registry.host (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
+{{- printf "{\"auths\": {\"https://%s\": {\"auth\": \"%s\"}}}" .Values.registry.host (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
 {{- end }}


### PR DESCRIPTION
typo introduced in #265 had registry as 'gcr.io' instead of 'https://gcr.io'

registry.host is just the hostname, not the full registry URL