### PR TITLE
run minikube on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,15 @@ script:
 - helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 - helm dependency update helm-chart/binderhub
 - |
+  export IP=$(ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')"
+  echo -e "hub:\n  url: http://$IP:30949" > helm-chart/travis-binder.yaml"
+- |
   helm install \
     --name binder-test \
     --namespace binder-test \
     helm-chart/binderhub \
-    -f helm-chart/minikube-binder.yaml
+    -f helm-chart/minikube-binder.yaml \
+    -f helm-chart/travis-binder.yaml
 
 # wait for helm deploy to come up
 - |
@@ -77,20 +81,18 @@ script:
     kubectl get pod --namespace binder-test
     sleep 1
   done
-
-# wait for servers to come up
 - |
-  until curl http://$(minikube ip):30948 > /dev/null; do
+  until curl http://$IP:30948 > /dev/null; do
     sleep 1
   done
 - |
-  until curl http://$(minikube ip):30949 > /dev/null; do
+  until curl http://$IP:30949 > /dev/null; do
     sleep 1
   done
 
 # run a few tests again, this time against the helm-installed binder
 - |
-  BINDER_TEST_URL=http://$(minikube ip):30948 \
+  BINDER_TEST_URL=http://$IP:30948 \
   BINDER_TEST_HUB_NAMESPACE=binder-test \
   BINDER_TEST_BUILD_NAMESPACE=binder-test \
   pytest -vsx -m remote

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ install:
   chmod +x bin/git-crypt
 - pip install . -r dev-requirements.txt
 script:
-- set -e
 # build helm chart
 - ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,41 @@ python:
 - 3.6
 services:
 - docker
+sudo: required
+
 install:
 - mkdir -p bin
 - export PATH=$PWD/bin:$PATH
-- curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz
+# install kubectl, minikube
+# based on https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
+- |
+  curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
+  chmod +x kubectl
+  mv kubectl bin/
+- |
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+  chmod +x minikube
+  mv minikube bin/
+- sudo minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
+- minikube update-context
+- |
+  JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+  until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+    echo "waiting for kubernetes"
+    sleep 1
+  done
+# install helm
+- >
+  curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 - chmod +x bin/helm
-- helm init --client-only
+- helm init
+- |
+  until [[ $(kubectl get pod --namespace kube-system | grep tiller | awk '{print $3}') == "Running" ]]; do
+    echo "waiting for tiller"
+    sleep 1
+  done
+  helm version
 # Install git-crypt
 - |
   curl -L https://github.com/minrk/git-crypt-bin/releases/download/0.5.0/git-crypt > bin/git-crypt
@@ -17,15 +45,16 @@ install:
   chmod +x bin/git-crypt
 - pip install . -r dev-requirements.txt
 script:
+- ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
+- helm install --name binder helm-chart
 - pytest -v --cov binderhub
+after_success:
+- codecov
 - |
   if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
-    export PUSH="--push"
+    ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE} --push
   fi
-- "./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
-after_success:
-  - codecov
 branches:
   only:
   - master
@@ -37,5 +66,7 @@ before_install:
   fi
 env:
   global:
+  - KUBE_VERSION=1.8.0
+  - CHANGE_MINIKUBE_NONE_USER=true
   - secure: BuO4oUz5YZvWhH919Tk8h3McM60NybLImIwB+0C4cmcDC/Z4uS1Jh8R8UbD3vIkJyjPgd+WuoaYGzzgJfCiS5i5TZZfi5yI0URu67fc044vaS7zSegZWsuN40mP4QNYTb+VdYniav8pqqyPyUpKNbOQ+/YJ+BWrC/ncqSL+P+UR6PE9T3TQ4XDuB45z0B2hhfDWBMpP6KtGae7YOWstIPi8ufiS76jjRzE4ziLqsOSwJRGhRbjJXqdcZeH2d54jUJSzCEGMSo5lxrFL27YOJ6Vuzr0V208AiQe60CyxtAzyiamVoE9U8pYOnv9KRDMeROSdz2HJkGetedNgCHpf0mNUWLZzQ6udzXtKeG2pxKeLDYKSm8Y3GGGa87nWRaWS1dYwCTHLe1r6Jwt6QwuBqqIa0oOMujStTEgbUOLLw5e80kSWqTxb52XnDi5SgOMGNzcylAYJLHFCL5U9ShAyZWGRAy0p7tFycXy44/k7RiqXr6Xur7NuB9bzXkmsDa7qS1t2DXoUA8FlpxfvqaSqVuFSrN16JHQeBOZGEYondQ2NPvi2vNT68Us4saWUxBf8oxF5pctbJYDDOxWpYFq/pza2+Elset9dv5KjCb61qtotLpo4PER4zgvde5/5HRa1CAOJlVfZB1Au3+b1NoVWNnPcwlb2UGut1+bcaDWyPf20=
   - secure: uqQrm6T6oGloQIHs1tLtQm3iIZFUtv1lNgtT+oCfYw3MC1CJ5AkKRaClAcVlFVOoCAE1GeCbnkob0i+LkwE+FQ1uw0fH9QyGx0PiEBrT3ilOXtkHvLXzcB/8PqPnIRR+vQnqigX2wsfiy0po99gBeaKiQjfybZ8UVp03M7+peQ4Y/Dxoj0G0nYZPsCo4F5plfdalJQX+ZVi1QlkglTotVxvb8QjrxXUrJ3OgXyVgW5fmkrRY6rWlb7RkSPlxmOhOZ7KM0BghMvox2VAD2jTatW/IEjqqaek8VqyKe1Dhw8wRUwQIwAH0VV1tUslHGcPcpbosGTPsfH7pTSUIa6ZRWd2dymMCpp7NwmFPm38QOZS/psiYNFPM6FvQnyqmtiUiU9MfcwMNJxiAUyTSslficd1Lt/aTTgBJQnK9Zd+/J6uuSc1aMGSgVNaM6eXxyNITXqz067zn8apCJm6UUEVM5FFs5SdfNXycJeV7qBwT8oe2+lvC4YzB2bHVGlnynK4IBPZsSFiBxPTBhcHVZp2FIMoC7cm/2dKW0gKPMho2Glhb7Zxn0mFej7XrT+IllD4yCjYSuSG2hpNMgE0+pc/89F2eLtey+oRAH0p4+K8DXsVCHsb7rSq+i7WDtFhFR0DBRWPG8B//CyLSbr4UoKumShbXYCI1dpSYzATmVyphQc8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 - chmod +x bin/helm
 - helm init
 - |
-  until [[ $(kubectl get pod --namespace kube-system | grep tiller | awk '{print $3}') == "Running" ]]; do
+  until helm version; do
     echo "waiting for tiller"
     sleep 1
   done

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,16 @@ script:
     sleep 1
   done
 
+# wait for servers to come up
+- |
+  until curl http://$(minikube ip):30948 > /dev/null; do
+    sleep 1
+  done
+- |
+  until curl http://$(minikube ip):30949 > /dev/null; do
+    sleep 1
+  done
+
 # run a few tests again, this time against the helm-installed binder
 - |
   BINDER_TEST_URL=http://$(minikube ip):30948 \

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,7 @@ script:
 # run a few tests again, this time against the helm-installed binder
 - |
   BINDER_TEST_URL=http://$IP:30948 \
-  BINDER_TEST_HUB_NAMESPACE=binder-test \
-  BINDER_TEST_BUILD_NAMESPACE=binder-test \
+  BINDER_TEST_NAMESPACE=binder-test \
   pytest -vsx -m remote
 - helm delete --purge binder-test
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,13 +58,24 @@ script:
 # smoke test helm install
 - helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 - helm dependency update helm-chart/binderhub
-- helm install --name binder-test helm-chart/binderhub -f helm-chart/minikube-binder.yaml
-# TODO: verify that helm deploy worked
-- helm delete --purge binder-test
+- |
+  helm install \
+    --name binder-test \
+    --namespace binder-test \
+    helm-chart/binderhub \
+    -f helm-chart/minikube-binder.yaml
 
 # install jupyterhub for local binderhub testing
 - ./testing/minikube/install-hub
 - pytest -vsx --cov binderhub
+
+# run a few tests again, this time against the helm-installed binder
+- |
+  BINDER_TEST_URL=http://127.0.0.1:30948 \
+  BINDER_TEST_HUB_NAMESPACE=binder-test \
+  BINDER_TEST_BUILD_NAMESPACE=binder-test \
+  pytest -vsx -m remote
+- helm delete --purge binder-test
 after_success:
 - codecov
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,10 @@ script:
 - helm dependency update helm-chart/binderhub
 - helm install --name binder-test helm-chart/binderhub -f helm-chart/minikube-binder.yaml
 # TODO: verify that helm deploy worked
-# TODO: wait for jupyterhub
 - helm delete --purge binder-test
+
+# install jupyterhub for local binderhub testing
+- ./testing/minikube/install-hub
 - pytest -v --cov binderhub
 after_success:
 - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   done
 # install helm
 - >
-  curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz
+  curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 - chmod +x bin/helm
 - helm init

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,12 @@ script:
   BINDER_TEST_BUILD_NAMESPACE=binder-test \
   pytest -vsx -m remote
 - helm delete --purge binder-test
+after_failure:
+- |
+  for pod in $(kubectl get pod --namespace=binder-test | awk '{print $1}'); do
+    echo $pod
+    kubectl logs --namespace=binder-test $pod
+  done
 after_success:
 - codecov
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
   chmod +x minikube
   mv minikube bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
+- sudo $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
 - minikube update-context
 - |
   JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   chmod +x kubectl
   mv kubectl bin/
 - |
-  curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
   chmod +x minikube
   mv minikube bin/
 - sudo $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
@@ -78,6 +78,7 @@ before_install:
   fi
 env:
   global:
+  - MINIKUBE_VERSION=0.23.0
   - KUBE_VERSION=1.8.0
   - CHANGE_MINIKUBE_NONE_USER=true
   - secure: BuO4oUz5YZvWhH919Tk8h3McM60NybLImIwB+0C4cmcDC/Z4uS1Jh8R8UbD3vIkJyjPgd+WuoaYGzzgJfCiS5i5TZZfi5yI0URu67fc044vaS7zSegZWsuN40mP4QNYTb+VdYniav8pqqyPyUpKNbOQ+/YJ+BWrC/ncqSL+P+UR6PE9T3TQ4XDuB45z0B2hhfDWBMpP6KtGae7YOWstIPi8ufiS76jjRzE4ziLqsOSwJRGhRbjJXqdcZeH2d54jUJSzCEGMSo5lxrFL27YOJ6Vuzr0V208AiQe60CyxtAzyiamVoE9U8pYOnv9KRDMeROSdz2HJkGetedNgCHpf0mNUWLZzQ6udzXtKeG2pxKeLDYKSm8Y3GGGa87nWRaWS1dYwCTHLe1r6Jwt6QwuBqqIa0oOMujStTEgbUOLLw5e80kSWqTxb52XnDi5SgOMGNzcylAYJLHFCL5U9ShAyZWGRAy0p7tFycXy44/k7RiqXr6Xur7NuB9bzXkmsDa7qS1t2DXoUA8FlpxfvqaSqVuFSrN16JHQeBOZGEYondQ2NPvi2vNT68Us4saWUxBf8oxF5pctbJYDDOxWpYFq/pza2+Elset9dv5KjCb61qtotLpo4PER4zgvde5/5HRa1CAOJlVfZB1Au3+b1NoVWNnPcwlb2UGut1+bcaDWyPf20=

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,9 +71,17 @@ script:
     helm-chart/binderhub \
     -f helm-chart/minikube-binder.yaml
 
+# wait for helm deploy to come up
+- |
+  JSONPATH='{range .items[*]}{@.status.phase};{end}'
+  until kubectl get pod --namespace binder-test -o jsonpath="$JSONPATH" | grep -q -i "^\(running;\)\+$"; do
+    kubectl get pod --namespace binder-test
+    sleep 1
+  done
+
 # run a few tests again, this time against the helm-installed binder
 - |
-  BINDER_TEST_URL=http://127.0.0.1:30948 \
+  BINDER_TEST_URL=http://$(minikube ip):30948 \
   BINDER_TEST_HUB_NAMESPACE=binder-test \
   BINDER_TEST_BUILD_NAMESPACE=binder-test \
   pytest -vsx -m remote

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,12 @@ install:
 - pip install . -r dev-requirements.txt
 script:
 - ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
-- helm install --name binder helm-chart
+
+# smoke test helm install
+- helm install --name binder-test helm-chart/binderhub -f helm-chart/minikube-binder.yaml
+# TODO: verify that helm deploy worked
+- helm del --purge binder-test
+# TODO: wait for jupyterhub
 - pytest -v --cov binderhub
 after_success:
 - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,12 @@ script:
 - set -e
 # build helm chart
 - ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
+
+# install jupyterhub for local binderhub testing
+- ./testing/minikube/install-hub
+- pytest -vsx --cov binderhub
+- helm delete --purge binder-test-hub
+
 # smoke test helm install
 - helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 - helm dependency update helm-chart/binderhub
@@ -64,10 +70,6 @@ script:
     --namespace binder-test \
     helm-chart/binderhub \
     -f helm-chart/minikube-binder.yaml
-
-# install jupyterhub for local binderhub testing
-- ./testing/minikube/install-hub
-- pytest -vsx --cov binderhub
 
 # run a few tests again, this time against the helm-installed binder
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,103 +4,28 @@ python:
 services:
 - docker
 sudo: required
+branches:
+  only:
+  - master
 
+before_install:
+- |
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TEST" == "helm" ]]; then
+    openssl aes-256-cbc -K $encrypted_d8355cc3d845_key -iv $encrypted_d8355cc3d845_iv -in travis.enc -out travis -d
+    chmod 0400 travis
+  fi
 install:
 - mkdir -p bin
 - export PATH=$PWD/bin:$PATH
-# install nsenter (needed by kube on trusty)
-- |
-  curl -L https://github.com/minrk/git-crypt-bin/releases/download/trusty/nsenter > nsenter
-  echo "5652bda3fbea6078896705130286b491b6b1885d7b13bda1dfc9bdfb08b49a2e  nsenter" | shasum -a 256 -c -
-  chmod +x nsenter
-  sudo mv nsenter /usr/local/bin/
-
-# install kubectl, minikube
-# based on https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
-- |
-  curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
-  chmod +x kubectl
-  mv kubectl bin/
-- |
-  curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
-  chmod +x minikube
-  mv minikube bin/
-- sudo $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
-- minikube update-context
-- |
-  JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
-  until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
-    echo "waiting for kubernetes"
-    sleep 1
-  done
-# install helm
-- >
-  curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
-  | tar -xz -C bin --strip-components 1 linux-amd64/helm
-- chmod +x bin/helm
-- helm init
-- |
-  until helm version; do
-    echo "waiting for tiller"
-    sleep 1
-  done
-  helm version
-# Install git-crypt
-- |
-  curl -L https://github.com/minrk/git-crypt-bin/releases/download/0.5.0/git-crypt > bin/git-crypt
-  echo "46c288cc849c23a28239de3386c6050e5c7d7acd50b1d0248d86e6efff09c61b  git-crypt" | shasum -a 256 -c -
-  chmod +x bin/git-crypt
+- ./ci/install.sh
 - pip install . -r dev-requirements.txt
 script:
-# build helm chart
-- ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
-
-# install jupyterhub for local binderhub testing
-- ./testing/minikube/install-hub
-- pytest -vsx --cov binderhub
-- helm delete --purge binder-test-hub
-
-# smoke test helm install
-- helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
-- helm dependency update helm-chart/binderhub
-- |
-  export IP=$(ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')"
-  echo -e "hub:\n  url: http://$IP:30949" > helm-chart/travis-binder.yaml"
-- |
-  helm install \
-    --name binder-test \
-    --namespace binder-test \
-    helm-chart/binderhub \
-    -f helm-chart/minikube-binder.yaml \
-    -f helm-chart/travis-binder.yaml
-
-# wait for helm deploy to come up
-- |
-  JSONPATH='{range .items[*]}{@.status.phase};{end}'
-  until kubectl get pod --namespace binder-test -o jsonpath="$JSONPATH" | grep -q -i "^\(running;\)\+$"; do
-    kubectl get pod --namespace binder-test
-    sleep 1
-  done
-- |
-  until curl http://$IP:30948 > /dev/null; do
-    sleep 1
-  done
-- |
-  until curl http://$IP:30949 > /dev/null; do
-    sleep 1
-  done
-
-# run a few tests again, this time against the helm-installed binder
-- |
-  BINDER_TEST_URL=http://$IP:30948 \
-  BINDER_TEST_NAMESPACE=binder-test \
-  pytest -vsx -m remote
-- helm delete --purge binder-test
+- export BINDER_TEST_NAMESPACE=binder-test-$TEST
+- ./ci/test-$TEST
 after_failure:
-- |
-  for pod in $(kubectl get pod --namespace=binder-test | awk '{print $1}'); do
+- for pod in $(kubectl get pod --namespace=$BINDER_TEST_NAMESPACE | awk '{print $1}'); do
     echo $pod
-    kubectl logs --namespace=binder-test $pod
+    kubectl logs --namespace=$BINDER_TEST_NAMESPACE $pod
   done
 after_success:
 - codecov
@@ -109,16 +34,11 @@ after_success:
     docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
     ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE} --push
   fi
-branches:
-  only:
-  - master
-before_install:
-- |
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    openssl aes-256-cbc -K $encrypted_d8355cc3d845_key -iv $encrypted_d8355cc3d845_iv -in travis.enc -out travis -d
-    chmod 0400 travis
-  fi
+
 env:
+  matrix:
+  - TEST=main
+  - TEST=helm
   global:
   - MINIKUBE_VERSION=0.23.0
   - KUBE_VERSION=1.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,12 @@ script:
 # build helm chart
 - ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
 # smoke test helm install
+- helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
+- helm dependency update helm-chart/binderhub
 - helm install --name binder-test helm-chart/binderhub -f helm-chart/minikube-binder.yaml
 # TODO: verify that helm deploy worked
-- helm del --purge binder-test
 # TODO: wait for jupyterhub
+- helm delete --purge binder-test
 - pytest -v --cov binderhub
 after_success:
 - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
 
 # install jupyterhub for local binderhub testing
 - ./testing/minikube/install-hub
-- pytest -v --cov binderhub
+- pytest -vsx --cov binderhub
 after_success:
 - codecov
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,9 @@ install:
   chmod +x bin/git-crypt
 - pip install . -r dev-requirements.txt
 script:
+- set -e
+# build helm chart
 - ./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
-
 # smoke test helm install
 - helm install --name binder-test helm-chart/binderhub -f helm-chart/minikube-binder.yaml
 # TODO: verify that helm deploy worked

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ sudo: required
 install:
 - mkdir -p bin
 - export PATH=$PWD/bin:$PATH
+# install nsenter (needed by kube on trusty)
+- |
+  curl -L https://github.com/minrk/git-crypt-bin/releases/download/trusty/nsenter > nsenter
+  echo "5652bda3fbea6078896705130286b491b6b1885d7b13bda1dfc9bdfb08b49a2e  nsenter" | shasum -a 256 -c -
+  chmod +x nsenter
+  sudo mv nsenter /usr/local/bin/
+
 # install kubectl, minikube
 # based on https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
 - |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,10 +35,7 @@ and run binderhub on the host system.
 
 5. Install JupyterHub in minikube with helm
 
-        helm install jupyterhub/jupyterhub --version=v0.5.x-2140cd6 \
-            --name=binder \
-            --namespace=binder \
-            -f testing/minikube/jupyterhub-helm-config.yaml
+        ./testing/minikube/install-hub
 
 6. Install binderhub and its development requirements:
 
@@ -79,7 +76,7 @@ there is a simpler method!
    python3 -m binderhub -f testing/localonly/binderhub_config.py
    ```
 
-3. You can now access it locally at https://localhost:8585
+3. You can now access it locally at http://localhost:8585
 
 Note that building and launching will not work, but the
 `testing/localonly/binderhub_config.py` setup a fake building process which

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -41,6 +41,7 @@ class Build:
         self.image_name = image_name
         self.push_secret = push_secret
         self.builder_image = builder_image
+        self.main_loop = IOLoop.current()
 
     def get_cmd(self):
         """Get the cmd to run to build the image"""
@@ -63,7 +64,7 @@ class Build:
 
     def progress(self, kind, obj):
         """Put the current action item into the queue for execution."""
-        IOLoop.instance().add_callback(self.q.put, {'kind': kind, 'payload': obj})
+        self.main_loop.add_callback(self.q.put, {'kind': kind, 'payload': obj})
 
     def submit(self):
         """Submit a image spec to openshift's s2i and wait for completion """

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -86,7 +86,10 @@ class Build:
         self.pod = client.V1Pod(
             metadata=client.V1ObjectMeta(
                 name=self.name,
-                labels={"name": self.name}
+                labels={
+                    "name": self.name,
+                    "component": "binderhub-build",
+                },
             ),
             spec=client.V1PodSpec(
                 containers=[

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -127,6 +127,9 @@ class Build:
                     self.cleanup()
                 elif self.pod.status.phase == 'Failed':
                     self.cleanup()
+        except Exception as e:
+            app_log.exception("Error in watch stream")
+            raise
         finally:
             w.stop()
 

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -83,6 +83,24 @@ def app(request, io_loop, _binderhub_config):
     """
     if REMOTE_BINDER:
         app = RemoteBinderHub()
+        # wait for the remote binder to be up
+        remaining = 30
+        deadline = time.monotonic() + remaining
+        success = False
+        last_error = None
+        while remaining:
+            try:
+                requests.get(BINDER_URL, timeout=remaining)
+            except Exception as e:
+                print(f"Waiting for binder: {e}")
+                last_error = e
+                time.sleep(1)
+                remaining = deadline - time.monotonic()
+            else:
+                success = True
+                break
+        if not success:
+            raise last_error
         app.url = BINDER_URL
         return app
 

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -15,6 +15,7 @@ minikube_testing_config = os.path.join(root, 'testing', 'minikube', 'binderhub_c
 
 @pytest.fixture(scope='session')
 def _binderhub_config():
+    """separate from app fixture to load config and check for hub only once"""
     cfg = PyFileConfigLoader(minikube_testing_config).load_config()
     cfg.BinderHub.build_namespace = 'binder-test'
     try:
@@ -25,7 +26,7 @@ def _binderhub_config():
     try:
         urlopen(cfg.BinderHub.hub_url, timeout=5).close()
     except Exception as e:
-        print(f"Hub not available at {cfg.BinderHub.hub_url}: {e}")
+        print(f"JupyterHub not available at {cfg.BinderHub.hub_url}: {e}")
         cfg.BinderHub.hub_url = ''
     return cfg
 

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -1,9 +1,14 @@
 """pytest fixtures for binderhub"""
-import os
-from urllib.request import urlopen
 
+from binascii import b2a_hex
+import os
+import time
+from unittest import mock
+
+import kubernetes.client
 import kubernetes.config
 import pytest
+import requests
 from traitlets.config.loader import PyFileConfigLoader
 
 from ..app import BinderHub
@@ -13,21 +18,33 @@ here = os.path.abspath(os.path.dirname(__file__))
 root = os.path.join(here, os.pardir, os.pardir)
 minikube_testing_config = os.path.join(root, 'testing', 'minikube', 'binderhub_config.py')
 
+BUILD_NAMESPACE = 'binder-test'
+HUB_NAMESPACE = 'binder-test-hub'
+KUBERNETES_AVAILABLE = False
+
+
 @pytest.fixture(scope='session')
 def _binderhub_config():
     """separate from app fixture to load config and check for hub only once"""
     cfg = PyFileConfigLoader(minikube_testing_config).load_config()
-    cfg.BinderHub.build_namespace = 'binder-test'
+    cfg.BinderHub.build_namespace = BUILD_NAMESPACE
+    global KUBERNETES_AVAILABLE
     try:
         kubernetes.config.load_kube_config()
     except Exception:
         cfg.BinderHub.builder_required = False
+        KUBERNETES_AVAILABLE = False
+    else:
+        KUBERNETES_AVAILABLE = True
+
     # check if Hub is running and ready
     try:
-        urlopen(cfg.BinderHub.hub_url, timeout=5).close()
+        requests.get(cfg.BinderHub.hub_url, timeout=5, allow_redirects=False)
     except Exception as e:
         print(f"JupyterHub not available at {cfg.BinderHub.hub_url}: {e}")
         cfg.BinderHub.hub_url = ''
+    else:
+        print(f"JupyterHub available at {cfg.BinderHub.hub_url}")
     return cfg
 
 
@@ -57,15 +74,113 @@ def app(request, io_loop, _binderhub_config):
     return bhub
 
 
+@pytest.fixture(scope='session')
+def cleanup_binder_pods(request):
+    """Cleanup running binders.
+
+    Fires at beginning and end of session
+    """
+    if not KUBERNETES_AVAILABLE:
+        # kubernetes not available, nothing to do
+        return
+    kube = kubernetes.client.CoreV1Api()
+    def cleanup():
+        pods = kube.list_namespaced_pod(HUB_NAMESPACE).items
+        pods = [
+            pod for pod in pods
+            if pod.metadata.labels.get('component') == 'singleuser-server'
+        ]
+        for pod in pods:
+            print('deleting', pod.metadata.name, pod.metadata.labels)
+            try:
+                kube.delete_namespaced_pod(
+                    pod.metadata.name,
+                    HUB_NAMESPACE,
+                    kubernetes.client.V1DeleteOptions(grace_period_seconds=0),
+                )
+            except kubernetes.client.rest.ApiException as e:
+                # ignore 404, 409: already gone
+                if e.status not in (404, 409):
+                    raise
+        while pods:
+            print(f"Waiting for {len(pods)} binder pods to exit")
+            time.sleep(1)
+
+            pods = kube.list_namespaced_pod(HUB_NAMESPACE).items
+            pods = [
+                pod for pod in pods
+                if pod.metadata.labels.get('component') == 'singleuser-server'
+            ]
+    cleanup()
+    request.addfinalizer(cleanup)
+
+
 @pytest.fixture
-def launch(app):
+def needs_launch(app, cleanup_binder_pods):
     """Fixture to skip tests if launch is unavailable"""
     if not app.hub_url:
         raise pytest.skip("test requires launcher (jupyterhub)")
 
 
+@pytest.fixture(scope='session')
+def cleanup_build_pods(request):
+    if not KUBERNETES_AVAILABLE:
+        # kubernetes not available, nothing to do
+        return
+    kube = kubernetes.client.CoreV1Api()
+    try:
+        kube.create_namespace(
+            kubernetes.client.V1Namespace(metadata={'name': BUILD_NAMESPACE})
+        )
+    except kubernetes.client.rest.ApiException as e:
+        # ignore 409: already exists
+        if e.status != 409:
+            raise
+
+    def cleanup():
+        pods = kube.list_namespaced_pod(BUILD_NAMESPACE).items
+        for pod in pods:
+            print('deleting', pod.metadata.name, pod.metadata.labels)
+            try:
+                kube.delete_namespaced_pod(
+                    pod.metadata.name,
+                    BUILD_NAMESPACE,
+                    kubernetes.client.V1DeleteOptions(grace_period_seconds=0),
+                )
+            except kubernetes.client.rest.ApiException as e:
+                # ignore 404, 409: already gone
+                if e.status not in (404, 409):
+                    raise
+        while pods:
+            print(f"Waiting for {len(pods)} build pods to exit")
+            time.sleep(1)
+            pods = kube.list_namespaced_pod(BUILD_NAMESPACE).items
+    cleanup()
+    request.addfinalizer(cleanup)
+
+
 @pytest.fixture
-def build(app):
+def needs_build(app, cleanup_build_pods):
     """Fixture to skip tests if build is unavailable"""
     if not app.builder_required:
         raise pytest.skip("test requires builder (kubernetes)")
+
+
+@pytest.fixture
+def always_build(app, request):
+    """Fixture to ensure checks for cached build return False
+
+    by giving the build slug a random prefix
+    """
+    session_id = b2a_hex(os.urandom(5)).decode('ascii')
+    def patch_provider(Provider):
+        original_slug = Provider.get_build_slug
+        def patched_slug(self):
+            slug = original_slug(self)
+            return f"test-{session_id}-{slug}"
+        return mock.patch.object(Provider, 'get_build_slug', patched_slug)
+
+    for Provider in app.repo_providers.values():
+        patch = patch_provider(Provider)
+        patch.start()
+        request.addfinalizer(patch.stop)

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -12,6 +12,7 @@ from .utils import async_requests
 @pytest.mark.parametrize("slug", [
     "gh/binder-examples/requirements/0ffdc6b47d6fa1942de01565319bddf95330d652",
 ])
+@pytest.mark.remote
 def test_build(app, needs_build, needs_launch, always_build, slug):
     build_url = f"{app.url}/build/{slug}"
     r = yield async_requests.get(build_url, stream=True)

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -8,7 +8,7 @@ from tornado.httputil import url_concat
 
 from .utils import async_requests
 
-@pytest.mark.gen_test(timeout=300)
+@pytest.mark.gen_test(timeout=900)
 @pytest.mark.parametrize("slug", [
     "gh/binder-examples/requirements/0ffdc6b47d6fa1942de01565319bddf95330d652",
 ])

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -1,0 +1,44 @@
+"""Test building repos"""
+
+import json
+import sys
+
+import pytest
+from tornado.httputil import url_concat
+
+from .utils import async_requests
+
+@pytest.mark.gen_test(timeout=300)
+@pytest.mark.parametrize("slug", [
+    "gh/binder-examples/requirements/0ffdc6b47d6fa1942de01565319bddf95330d652",
+])
+def test_build(app, needs_build, needs_launch, always_build, slug):
+    build_url = f"{app.url}/build/{slug}"
+    r = yield async_requests.get(build_url, stream=True)
+    r.raise_for_status()
+    events = []
+    for f in async_requests.iter_lines(r):
+        # await line Future
+        try:
+            line = yield f
+        except StopIteration:
+            break
+        line = line.decode('utf8', 'replace')
+        if line.startswith('data:'):
+            event = json.loads(line.split(':', 1)[1])
+            events.append(event)
+            assert 'message' in event
+            sys.stdout.write(event['message'])
+
+    final = events[-1]
+    assert 'phase' in final
+    assert final['phase'] == 'ready'
+    assert 'url' in final
+    assert 'token' in final
+    print(final['url'])
+    r = yield async_requests.get(url_concat(final['url'], {'token': final['token']}))
+    r.raise_for_status()
+    assert r.url.startswith(final['url'])
+
+
+

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -50,6 +50,7 @@ def _resolve_url(page_url, url):
 
 
 @pytest.mark.gen_test
+@pytest.mark.remote
 def test_main_page(app):
     """Check the main page and any links on it"""
     r = yield async_requests.get(app.url)

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -1,7 +1,9 @@
 """Test main handlers"""
 
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
 import pytest
-from tornado.httputil import url_concat
 
 from .utils import async_requests
 
@@ -20,3 +22,62 @@ def test_legacy_redirect(app, old_url, new_url):
     r = yield async_requests.get(app.url + old_url, allow_redirects=False)
     assert r.status_code == 302
     assert r.headers['location'] == new_url
+
+
+def _resolve_url(page_url, url):
+    """Resolve a URL relative to a page"""
+
+    # full URL, nothing to resolve
+    if '://' in url:
+        return url
+
+    parsed = urlparse(page_url)
+
+    if url.startswith('/'):
+        # absolute path
+        return f"{parsed.scheme}://{parsed.netloc}{url}"
+
+    # relative path URL
+
+    if page_url.endswith('/'):
+        # URL is a directory, resolve relative to dir
+        path = parsed.path
+    else:
+        # URL is not a directory, resolve relative to parent
+        path = parsed.path.rsplit('/', 1)[0] + '/'
+
+    return f"{parsed.scheme}://{parsed.netloc}{path}{url}"
+
+
+@pytest.mark.gen_test
+def test_main_page(app):
+    """Check the main page and any links on it"""
+    r = yield async_requests.get(app.url)
+    assert r.status_code == 200
+    soup = BeautifulSoup(r.text, 'html5lib')
+
+    # check src links (style, images)
+    for el in soup.find_all(src=True):
+        url = _resolve_url(app.url, el['src'])
+        r = yield async_requests.get(url)
+        assert r.status_code == 200, f"{r.status_code} {url}"
+
+    # check hrefs
+    for el in soup.find_all(href=True):
+        href = el['href']
+        if href.startswith('#'):
+            continue
+        url = _resolve_url(app.url, href)
+        r = yield async_requests.get(url)
+        assert r.status_code == 200, f"{r.status_code} {url}"
+
+
+@pytest.mark.gen_test
+def test_parametrized_page(app):
+    sha = 'b8259dac9eb4aa5f2d65d8881f2da94a4952a195'
+    r = yield async_requests.get(app.url + f'/v2/gh/minrk/ligo-binder/{sha}?filepath=index.ipynb')
+    assert r.status_code == 200
+    soup = BeautifulSoup(r.text, 'html5lib')
+    assert soup.find(id='repository')['value'] == 'https://github.com/minrk/ligo-binder'
+    assert soup.find(id='ref')['value'] == sha
+    assert soup.find(id='filepath')['value'] == 'index.ipynb'

--- a/binderhub/tests/utils.py
+++ b/binderhub/tests/utils.py
@@ -17,5 +17,13 @@ class _AsyncRequests:
         requests_method = getattr(requests, name)
         return lambda *args, **kwargs: self.executor.submit(requests_method, *args, **kwargs)
 
+    def iter_lines(self, response):
+        """Asynchronously iterate through the lines of a response"""
+        it = response.iter_lines()
+        while True:
+            yield self.executor.submit(lambda : next(it))
+
+
+
 # async_requests.get = requests.get returning a Future, etc.
 async_requests = _AsyncRequests()

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -ex
+# install nsenter if missing (needed by kube on trusty)
+if ! which nsenter; then
+  curl -L https://github.com/minrk/git-crypt-bin/releases/download/trusty/nsenter > nsenter
+  echo "5652bda3fbea6078896705130286b491b6b1885d7b13bda1dfc9bdfb08b49a2e  nsenter" | shasum -a 256 -c -
+  chmod +x nsenter
+  sudo mv nsenter /usr/local/bin/
+fi
+
+# install kubectl, minikube
+# based on https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
+echo "installing kubectl"
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
+chmod +x kubectl
+mv kubectl bin/
+
+echo "installing minikube"
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
+chmod +x minikube
+mv minikube bin/
+
+echo "starting minikube"
+sudo $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
+minikube update-context
+
+echo "waiting for kubernetes"
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+  sleep 1
+done
+
+echo "installing helm"
+curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz \
+  | tar -xz -C bin --strip-components 1 linux-amd64/helm
+chmod +x bin/helm
+helm init
+
+echo "waiting for tiller"
+until helm version; do
+    sleep 1
+  done
+helm version
+
+echo "installing git-crypt"
+curl -L https://github.com/minrk/git-crypt-bin/releases/download/0.5.0/git-crypt > bin/git-crypt
+echo "46c288cc849c23a28239de3386c6050e5c7d7acd50b1d0248d86e6efff09c61b  bin/git-crypt" | shasum -a 256 -c -
+chmod +x bin/git-crypt

--- a/ci/test-helm
+++ b/ci/test-helm
@@ -1,0 +1,49 @@
+#!/bin/bash
+# test helm deployment
+# - build and install helm chart
+# - run tests marked with 'remote'
+
+set -ex
+
+export IP=$(ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
+export BINDER_TEST_URL=http://$IP:30901
+export HUB_URL=http://$IP:30902
+echo -e "hub:\n  url: $HUB_URL" > helm-chart/travis-binder.yaml
+
+
+echo "building helm chart"
+./helm-chart/build.py build --commit-range ${TRAVIS_COMMIT_RANGE}
+
+# smoke test helm install
+echo "installing binderhub helm chart"
+
+helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
+helm dependency update helm-chart/binderhub
+cat helm-chart/travis-binder.yaml
+
+helm install \
+  --name binder-test \
+  --namespace binder-test-helm \
+  helm-chart/binderhub \
+  -f helm-chart/minikube-binder.yaml \
+  -f helm-chart/travis-binder.yaml
+
+# wait for helm deploy to come up
+echo "waiting for pods to become ready"
+JSONPATH='{range .items[*]}{@.status.phase};{end}'
+until kubectl get pod --namespace $BINDER_TEST_NAMESPACE -o jsonpath="$JSONPATH" | grep -q -i "^\(running;\)\+$"; do
+  kubectl get pod --namespace $BINDER_TEST_NAMESPACE
+  sleep 1
+done
+echo "waiting for servers to become responsive"
+until curl $BINDER_TEST_URL > /dev/null; do
+  sleep 1
+done
+until curl $HUB_URL> /dev/null; do
+  sleep 1
+done
+
+echo "running tests against $BINDER_TEST_URL"
+# run a few tests again, this time against the helm-installed binder
+pytest -vsx -m remote
+helm delete --purge binder-test

--- a/ci/test-main
+++ b/ci/test-main
@@ -1,0 +1,8 @@
+#!/bin/bash
+# main test script: runs the basic Python tests,
+# with JupyterHub launched via helm
+
+set -ex
+./testing/minikube/install-hub
+pytest -vsx --cov binderhub
+helm delete --purge binder-test-hub

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 bs4
 codecov
+html5lib
 pytest
 pytest-cov
 pytest-tornado

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-bs4
+beautifulsoup4
 codecov
 html5lib
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,4 @@ pytest
 pytest-cov
 pytest-tornado
 requests
-ruamel.yaml
+ruamel.yaml>=0.15

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
+bs4
+codecov
 pytest
 pytest-cov
 pytest-tornado
-codecov
-ruamel.yaml
 requests
+ruamel.yaml

--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -10,11 +10,11 @@ cors: &cors
   allowOrigin: '*'
 
 hub:
-  url: http://192.168.99.100:30949
+  url: http://192.168.99.100:30902
 
 service:
   type: NodePort
-  nodePort: 30948
+  nodePort: 30901
 
 jupyterhub:
   hub:
@@ -37,7 +37,7 @@ jupyterhub:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255
     service:
       type: NodePort
-      nodePort: 30949
+      nodePort: 30902
 
   singleuser:
     storage:

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -16,7 +16,7 @@ import time
 from kubernetes import client, config
 from ruamel import yaml
 
-namespace = 'binder-test-hub'
+namespace = 'binder-test'
 name = 'binder-test-hub'
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -16,7 +16,7 @@ import time
 from kubernetes import client, config
 from ruamel import yaml
 
-namespace = 'binder-test'
+namespace = os.environ.get('BINDER_TEST_NAMESPACE') or 'binder-test'
 name = 'binder-test-hub'
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Script to install jupyterhub helm chart with minikube
+
+for testing binderhub
+
+Gets the jupyterhub chart version from the binderhub helm chart
+to ensure we are testing against a reasonable version.
+"""
+
+import os
+import pipes
+from subprocess import check_call, check_output
+import time
+
+from kubernetes import client, config
+from ruamel import yaml
+
+namespace = 'binder-test-hub'
+name = 'binder-test-hub'
+
+here = os.path.abspath(os.path.dirname(__file__))
+helm_chart = os.path.join(here, os.pardir, os.pardir, 'helm-chart')
+requirements_yaml = os.path.join(helm_chart, 'binderhub', 'requirements.yaml')
+
+def get_hub_chart_dependency():
+    """Get the JupyterHub chart info from the binderhub chart requirements.yaml"""
+    with open(requirements_yaml) as f:
+        requirements = yaml.safe_load(f)
+    for dep in requirements['dependencies']:
+        if dep['name'] == 'jupyterhub':
+            return dep
+    else:
+        raise ValueError("Couldn't find JupyterHub in %s:\n%s" %
+            (requirements_yaml, requirements)
+        )
+
+jupyterhub = get_hub_chart_dependency()
+
+# update the helm repo
+check_call(['helm', 'repo', 'add', 'jupyterhub', jupyterhub['repository']])
+check_call(['helm', 'repo', 'update', 'jupyterhub'])
+
+# launch with helm install (or upgrade, if already installed)
+args = [
+    'jupyterhub/jupyterhub',
+    f'--version={jupyterhub["version"]}',
+    f'--namespace={namespace}',
+    '-f', os.path.join(here, 'jupyterhub-helm-config.yaml'),
+]
+is_running = name in check_output(['helm', 'list', '-q']).decode('utf8', 'replace').split()
+if is_running:
+    cmd = ['helm', 'upgrade', name]
+else:
+    cmd = ['helm', 'install', f'--name={name}']
+
+cmd.extend(args)
+print("\n    %s\n" % ' '.join(map(pipes.quote, cmd)))
+
+check_call(cmd)
+
+
+# wait for deployment to be running via kube API
+
+config.load_kube_config()
+kube = client.CoreV1Api()
+
+def wait_for(f, msg, timeout=300):
+    """Wait for f() to return True"""
+    print(f"Waiting until {msg}")
+    for i in range(int(timeout)):
+        if f():
+            break
+        time.sleep(1)
+    else:
+        raise TimeoutError(f"{msg} did not occur in {timeout} seconds")
+    print(msg)
+
+def hub_running():
+    """Return whether all pods in our test namespace are ready"""
+    pods = kube.list_namespaced_pod(namespace).items
+    # debug:
+    for pod in pods:
+        print(f"{pod.status.phase}\t{pod.metadata.name}")
+    return all(pod.status.phase == 'Running' for pod in pods)
+
+# wait until all of our pods are running
+try:
+    wait_for(hub_running, "Hub is up")
+except TimeoutError:
+    # show pods on timeout, in case there's a hint about what's wrong
+    check_call(['kubectl', 'get', 'pod', '--all-namespaces'])
+    raise


### PR DESCRIPTION
The goal of this PR is to have two things:

1. tests that verify that `helm install` works with the helm chart
2. a running binderhub as part of the Python test suite, so we can run proper tests


- [x] install minikube, helm
- [x] smoke-test `helm install binderhub`
- [x] verify that `helm install binderhub` produces a running binderhub
- [x] launch jupyterhub via helm
- [x] launch binderhub for tests, hooked up to jupyterhub

Something I don't plan to do, but might be nice in terms of integration coverage:

-  Run tests against binderhub launched via the helm chart,
   rather than hub via helm with local binder.
   The reason being error reporting and coverage reporting,
   which are greatly improved when the server is running in-process
   with the tests.