### PR TITLE
finish scrubbing illustrator from svg

### DIFF
--- a/binderhub/static/logo.svg
+++ b/binderhub/static/logo.svg
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+<svg version="1.1" id="Layer_1"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="212.118px"
 	 height="65.883px" viewBox="0 0 212.118 65.883" enable-background="new 0 0 212.118 65.883" xml:space="preserve">
 <switch>
-	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
-	</foreignObject>
-	<g i:extraneous="self">
+	<g>
 		<g>
 			<path fill="#545454" d="M50.751,48.727V12.472h7.251v17.547c1.885-2.32,4.544-3.094,7.299-3.094
 				c6.042,0,10.586,5.269,10.586,11.167S71.344,49.21,65.302,49.21c-2.755,0-5.849-0.87-7.299-3.046v2.562H50.751z M63.078,43.409


### PR DESCRIPTION
Previous #288 scrubbed illustrator content but not references to it, resulting in an invalid svg.

This should display the logo in browsers now.