### PR TITLE
Escape characters in build slugs properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'kubernetes==3.*',
+        'escapism',
         'tornado',
         'traitlets',
         'docker',


### PR DESCRIPTION
We need to be DNS safe for use in kubernetes object names.

fixes #240