### PR TITLE
ensure build name is lowercase

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -119,7 +119,7 @@ class BuildHandler(BaseHandler):
             name=build_slug[:limit - hash_length - ref_length - len(prefix) - 2],
             hash=build_slug_hash[:hash_length],
             ref=ref[:ref_length]
-        ), safe=safe_chars, escape_char='-')
+        ), safe=safe_chars, escape_char='-').lower()
 
     async def fail(self, message):
         await self.emit({

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -218,7 +218,9 @@ class BuildHandler(BaseHandler):
         with BUILDS_INPROGRESS.track_inprogress():
             build_starttime = time.perf_counter()
             pool = self.settings['build_pool']
-            pool.submit(build.submit)
+            submit_future = pool.submit(build.submit)
+            # TODO: hook up actual error handling when this fails
+            IOLoop.current().add_callback(lambda : submit_future)
 
             log_future = None
 


### PR DESCRIPTION
follow-up to #298

escapism can itself create uppercase escapes, so cast with `lower()` after escaping.

and ensure that errors in submit are at least logged

TODO: (for another PR because right now, this is blocking any builds from working at all)

- make sure the build fails if submit fails (it does not right now)