### PR TITLE
[MRG] truncate build slug after escaping

### DIFF
--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -221,7 +221,8 @@ def always_build(app, request):
     """
     if REMOTE_BINDER:
         return
-    session_id = b2a_hex(os.urandom(5)).decode('ascii')
+    # make it long to ensure we run into max build slug length
+    session_id = b2a_hex(os.urandom(16)).decode('ascii')
 
     def patch_provider(Provider):
         original_slug = Provider.get_build_slug

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -38,8 +38,6 @@ def _binderhub_config():
     """
     cfg = PyFileConfigLoader(minikube_testing_config).load_config()
     cfg.BinderHub.build_namespace = TEST_NAMESPACE
-    if ON_TRAVIS:
-        cfg.BinderHub.hub_url = cfg.BinderHub.hub_url.replace('192.168.99.100', '127.0.0.1')
     global KUBERNETES_AVAILABLE
     try:
         kubernetes.config.load_kube_config()

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -10,7 +10,7 @@ from .utils import async_requests
 
 @pytest.mark.gen_test(timeout=900)
 @pytest.mark.parametrize("slug", [
-    "gh/binder-examples/requirements/0ffdc6b47d6fa1942de01565319bddf95330d652",
+    "gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd",
 ])
 @pytest.mark.remote
 def test_build(app, needs_build, needs_launch, always_build, slug):


### PR DESCRIPTION
long build names were getting too long because truncation happened before escaping, and the escapes increased the length of the string beyond the limit

- slugs are case-insensitive (uppercase are safe, cast to lowercase)
- only strings that come from providers are escaped (build_slug, ref)
- prefix, hash are assumed safe because they are internal

This should wait until #282 is merged so that builds can be tested.
I'll rebase with an update to the tests to ensure the build slug is long.