### PR TITLE
update jupyterhub chart with ingress changes

### DIFF
--- a/ci/test-main
+++ b/ci/test-main
@@ -4,5 +4,7 @@
 
 set -ex
 ./testing/minikube/install-hub
+# DEBUG: give the hub a chance to wake up
+sleep 5
 pytest -vsx --cov binderhub
 helm delete --purge binder-test-hub

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.5.0-d1edb2e"
+  version: "0.5.0-7e9089b"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -14,17 +14,21 @@ metadata:
   {{- end }}
 spec:
   rules:
-    - http:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
         paths:
           - path: /
             backend:
               serviceName: binder
               servicePort: 8585
-      host: {{ .Values.ingress.host }}
+    {{- end }}
 {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
   tls:
     - secretName: kubelego-tls-binder-{{ .Release.Name }}
       hosts:
-        - {{ .Values.ingress.host }}
+        {{- range $host := .Values.ingress.hosts }}
+        - {{ $host }}
+        {{- end }}
 {{- end }}
 {{- end -}}

--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -17,9 +17,9 @@ service:
   nodePort: 30901
 
 jupyterhub:
+  rbac:
+    enabled: false
   hub:
-    rbac:
-      enabled: false
     resources:
       requests:
         cpu: 0.2
@@ -37,7 +37,8 @@ jupyterhub:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255
     service:
       type: NodePort
-      nodePort: 30902
+      nodePorts:
+        http: 30902
 
   singleuser:
     storage:

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -3,9 +3,9 @@
 
 # the binder apiToken bit requires jupyterhub helm-chart v0.5.x
 
+rbac:
+  enabled: false
 hub:
-  rbac:
-    enabled: false
   cookieSecret: "36091e950f98f033aeae2520e2fe4c8599bc391598f910e510ad670765fbc1ff"
   db:
     type: "sqlite-memory"
@@ -60,4 +60,5 @@ proxy:
   secretToken: "443fa28905c209eaf5803f911de7748f443c78062767d9d28d514dc4fbefd843"
   service:
     type: NodePort
-    nodePort: 30123
+    nodePorts:
+      http: 30123


### PR DESCRIPTION
gets latest fixes, including init-container support and kubespawner fix that should cleanup pods after failed launch

There doesn't appear to be anything ingress-related to do here, but there will be on mybinder.org-deploy when we get there. <del>It proved cleaner to consolidate ingress at the binder chart level than at the deployment level.</del>

- [x] The nodePort config is going to need https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/296 for the helm tests to pass, I think.