### PR TITLE
Add link to "preparing your repo" section of the documentation

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -131,7 +131,7 @@
         <span class="point point-red">2</span>
       </div>
       <div class="col-md-7 front">
-        <span class="front-em">We build a Docker image of your repository</span><br />Does your repository depend on files being loaded for your live notebooks? We will search in your repository's root for a dependency such as a requirements.txt, environment.yml or Dockerfile. The first dependency file found will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
+        <span class="front-em">We build a Docker image of your repository</span><br />Does your repository depend on files being loaded for your live notebooks? We will search in your repository's root for a dependency such as a requirements.txt or environment.yml (<a href="#">more details</a>). The first dependency file found will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
       </div>
     </div>
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -131,7 +131,7 @@
         <span class="point point-red">2</span>
       </div>
       <div class="col-md-7 front">
-        <span class="front-em">We build a Docker image of your repository</span><br />Does your repository depend on files being loaded for your live notebooks? We will search in your repository's root for a dependency such as a requirements.txt or environment.yml (<a href="#">more details</a>). The first dependency file found will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
+        <span class="front-em">We build a Docker image of your repository</span><br />Binder will search for a dependency file, such as requirements.txt or environment.yml, in the repository's root directory (<a href="#">more details on more complex dependencies in documentation</a>). The dependency files will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
       </div>
     </div>
 


### PR DESCRIPTION
Having a link directly to the instructions on how to prep your repo will hopefully lead more people towards using "not a Dockerfile".

Update the link and merge after jupyterhub/binder#36