### PR TITLE
Streamline css.

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -19,11 +19,6 @@
     display: none;
 }
 
-#basic-url-snippet, #markdown-badge-snippet, #rst-badge-snippet, {
-  max-width: 200px;
-  font-size: 75%;
-}
-
 body {
     padding-top: 32px;
     font-family: "ClearSans-Thin", sans-serif;
@@ -32,17 +27,6 @@ body {
 form {
     font-family: "ClearSans-Light", sans-serif;
 }
-
-hr {
-    border: 0;
-    clear:both;
-    display:block;
-    width: 100%;
-    padding:0;
-    margin: 5px 0 5px 0;
-    border-top: 1px solid #cecece;
-
-  }
 
 p > a {
     cursor: pointer;
@@ -88,10 +72,10 @@ p > a:hover {
 .btn-submit{
     background-color:rgb(243, 162, 83);
     box-shadow: 1px 1px rgba(0,0,0,.075);
-    width:220%;
     color:white;
     border:none;
     height:35px;
+    width: 100%;
     border-radius: 4px;
 }
 
@@ -140,6 +124,7 @@ h4 {
 
 #launch-buttons {
     margin-top: 24px;
+    width: 100%;
 }
 
 #log {
@@ -166,18 +151,8 @@ h4 {
     margin-bottom:20px;
 }
 
-.url li {
-    list-style-type: none;
-    padding: 0 12px 0 12px;
-    height:30px;
-}
-
 .badges{
     margin-bottom:40px;
-}
-
-.badges li{
-    list-style-type: none;
 }
 
 .bluedropdown{
@@ -195,40 +170,33 @@ h4 {
 }
 
 
-.badge-snippet-row{
+.badge-snippet-row {
     width: 100%;
+    display: flex;
+    flex-direction: reverse;
+    border-bottom: 1px #ccc solid;
+    padding: 10px;
 }
 
-#basic-url-snippet, #markdown-badge-snippet, #rst-badge-snippet{
-    width:90%;
-    float:left;
-    margin: 12px 0 12px 12px;
-    padding: 7px;
-}
-
-
-.icon{
+.badge-snippet-row .icon{
+    order: 0;
     max-width: 30px;
+    max-height: 40px;
     padding:3px;
-    margin-top: 13px;
-    margin-left: 4px;
+    /* margin-top: 13px; */
+    /*margin-left: 4px; */
 }
 
-#caret{
-    width:20px;
-    background-color: none;
+.input-group-btn .btn {
+    border: solid #ccc 1px;
+} 
+
+.badge-snippet-row pre{
+    order: 1;
+    margin: 0;
+    flex-grow: 1;
 }
 
-#copyicon{
-    width:20px;
-}
-
-#greyline{
-    Stroke: Solid;
-    Align: Center;
-    Width: 1px;
-    color: #CECECE
-}
 
 #how-it-works {
     line-height: 1.5;
@@ -285,28 +253,25 @@ h4.logo-subtext {
   margin-top: -60px;
 }
 
-#badge-url {
-  display: table-cell;
-  vertical-align: middle;
-  text-align: center;
-}
-
 .url-row {
   height: 100%;
-  width: 100%;
+  width:  100%;
   display: table;
+  padding: 10px;
+}
+
+.url-row pre {
+  margin-bottom: 0;
+}
+
+.form-row .form-group:first-child{
+  padding-left: 0;
+}
+
+.form-row .form-group:last-child{
+  padding-right: 0;
 }
 
 #badge-snippets {
   width: 100%;
-}
-
-#basic-url-snippet {
-  width: 95%;
-}
-
-.badge-snippet-row pre {
-  float: right !important;
-  margin-right: 20px !important;
-  margin-left: 8px !important;
 }

--- a/binderhub/static/index.js
+++ b/binderhub/static/index.js
@@ -140,8 +140,7 @@ function updateUrl() {
 
 function updateUrlDiv() {
   var url = updateUrl()
-  $('#badge-url').text(url);
-  $('#badge-url').attr('href', url)
+  $('#basic-url-snippet').text(url);
   $('#markdown-badge-snippet').text(markdownBadge(url));
   $('#rst-badge-snippet').text(rstBadge(url));
 }

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -29,7 +29,7 @@
           <label for="repository">GitHub repo or URL</label>
           <input class="form-control" type="text" id="repository" placeholder="GitHub repository name or link" value="{{ url or '' }}"/>
         </div>
-        <div class="row">
+        <div class="form-row">
           <div class="form-group col-md-4">
             <label for="ref">Git branch, tag, or commit</label>
             <input class="form-control" type="text" id="ref" placeholder="master" value="{{ ref or '' }}"/>
@@ -104,7 +104,7 @@
               <label>Copy and share this URL:</label>
             </div>
             <div class="url-row">
-              <pre id="basic-url-snippet"><a href="#" id="badge-url" title="show url snippet">Begin typing to see your URL!</a></pre>
+              <pre id="basic-url-snippet">Begin typing to see your URL!</pre>
             </div>
         </div>
 
@@ -122,7 +122,6 @@
                  <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet</pre>
                  <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
               </div>
-              <hr>
               <!--RST section-->
               <div  class="badge-snippet-row">
                 <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet</pre>


### PR DESCRIPTION
A lot of what was done with css was ad-hoc values and tweaking.
This cleanup the css/html layout to use  more common an robust technique
and decrease the special casing of some elements and uniforming style.

It also remove a number of rules that are not used. 

-- 

A couple of changed style on the main page:

Forms alligned on the left.

<img width="40" alt="screen shot 2017-12-08 at 16 02 27" src="https://user-images.githubusercontent.com/335567/33779544-b3a9bd54-dc4d-11e7-85f1-fd232c296865.png">

White space on the right of icons independant of screen width (using flexbox)
<img width="104" alt="screen shot 2017-12-08 at 16 02 21" src="https://user-images.githubusercontent.com/335567/33779545-b3f50f48-dc4d-11e7-97b6-548d6191c3e2.png">

File selector style match input style with border.
<img width="210" alt="screen shot 2017-12-08 at 16 02 17" src="https://user-images.githubusercontent.com/335567/33779546-b43dc346-dc4d-11e7-8419-7abb91d8c889.png">

Buttons are aligned on the right.

<img width="102" alt="screen shot 2017-12-08 at 16 02 11" src="https://user-images.githubusercontent.com/335567/33779547-b4620cce-dc4d-11e7-941b-c48d600b7161.png">

The link to copy/past is also not an `<a>` tag anymore so easier to copy and past...