### PR TITLE
Minimal CSS fixes.

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -20,7 +20,6 @@
 }
 
 body {
-    padding-top: 32px;
     font-family: "ClearSans-Thin", sans-serif;
 }
 
@@ -157,7 +156,7 @@ h4 {
 
 .bluedropdown{
     background-color:#579ACA;
-    border-radius: 4px 4px 0px 0px;
+    border-radius: 3px 3px 0px 0px;
     height:35px;
     width: 100%;
 }
@@ -275,3 +274,17 @@ h4.logo-subtext {
 #badge-snippets {
   width: 100%;
 }
+
+/**/
+
+@media (max-width: 991px){
+    .form-row .form-group {
+        padding: 0;
+    }
+
+    #launch-buttons {
+        margin-top: inherit;
+    }
+
+}
+


### PR DESCRIPTION
Border radius of nested elements should differ by one pixel otherwise a
gap appear.

Align forms on narrow screen (less than 991 pixel). Bootstrap have a
longstaning bug that the narrow to wide transtition for some rules are
991, and otherrules 992px.

I also move the all page 32 pixel up because not everyone has lots of screen real estate. 

-- 

Edit, the 3px radius avoid this:

<img width="114" alt="screen shot 2017-12-09 at 12 30 38" src="https://user-images.githubusercontent.com/335567/33795322-ae131858-dcdf-11e7-970d-3b96633ae2be.png">

the media query give this on narrow screen:

<img width="795" alt="screen shot 2017-12-09 at 12 45 55" src="https://user-images.githubusercontent.com/335567/33795326-bc24c234-dcdf-11e7-914b-3e44a97b7838.png">
