### PR TITLE
[WIP] require docker registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ on GitHub if you don't have a token.
    ```bash
    helm init
    ```
+
 4. Add the JupyterHub helm charts repo:
 
    ```bash
@@ -42,15 +43,21 @@ on GitHub if you don't have a token.
 
         python3 -m pip install -e . -r dev-requirements.txt
 
-7. Before starting the local dev/test deployment run:
+7. Before starting the local dev/test deployment run,
+   start a local docker registry (in minikube):
 
         eval $(minikube docker-env)
+        # spawn registry in minikube docker
+        docker run -d -p 5000:5000 --restart=always --name registry registry:2
+        # forward localhost:5000 to minikube:5000 so both binderhub
+        # and kubernetes see the same registry at 127.0.0.1:5000
+        ssh -i $(minikube ssh-key) docker@$(minikube ip) -L5000:127.0.0.1:5000 -f -N
 
-7. Start binderhub with the testing config file:
+8. Start binderhub with the testing config file:
 
         python3 -m binderhub -f testing/minikube/binderhub_config.py
 
-8. Visit [http://localhost:8585](http://localhost:8585)
+9. Visit [http://localhost:8585](http://localhost:8585)
 
 All features should work, including building and launching.
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -53,10 +53,8 @@ class Build:
             '--ref', self.ref,
             '--image', self.image_name,
             '--no-clean', '--no-run', '--json-logs',
+            '--push',
         ]
-
-        if self.push_secret:
-            cmd.append('--push')
 
         if self.memory_limit:
             cmd.append('--build-memory-limit')

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -11,36 +11,47 @@ from tornado.httputil import url_concat
 
 class DockerRegistry:
     def __init__(self, registry):
-        if not registry.startswith('https://'):
+        if '://' not in registry:
             registry = 'https://' + registry
-        with open(os.path.expanduser('~/.docker/config.json')) as f:
-            raw_auths = json.load(f)['auths']
-
-        self.username, self.password = base64.b64decode(
-            raw_auths[registry]['auth'].encode('utf-8')
-        ).decode('utf-8').split(':', 1)
 
         self.registry = registry
+        self.username = None
+        self.password = None
+
+        try:
+            with open(os.path.expanduser('~/.docker/config.json')) as f:
+                raw_auths = json.load(f).get('auths', {})
+        except FileNotFoundError:
+            raw_auths = {}
+
+        if registry in raw_auths:
+            self.username, self.password = base64.b64decode(
+                raw_auths[registry]['auth'].encode('utf-8')
+            ).decode('utf-8').split(':', 1)
+
 
     @gen.coroutine
     def get_image_manifest(self, image, tag):
         client = httpclient.AsyncHTTPClient()
         # first, get a token to perform the manifest request
-        auth_req = httpclient.HTTPRequest(
-            url_concat('{}/v2/token'.format(self.registry), {
-                # HACK: This won't work for all registries!
-                'service': self.registry.split('://', 1)[-1],
-                'scope': 'repository:{}:pull'.format(image),
-            }),
-            auth_username=self.username,
-            auth_password=self.password,
-        )
-        auth_resp = yield client.fetch(auth_req)
-        token = json.loads(auth_resp.body.decode('utf-8', 'replace'))['token']
+        headers = {}
+        if self.username:
+            auth_req = httpclient.HTTPRequest(
+                url_concat('{}/v2/token'.format(self.registry), {
+                    # HACK: This won't work for all registries!
+                    'service': self.registry.split('://', 1)[-1],
+                    'scope': 'repository:{}:pull'.format(image),
+                }),
+                auth_username=self.username,
+                auth_password=self.password,
+            )
+            auth_resp = yield client.fetch(auth_req)
+            token = json.loads(auth_resp.body.decode('utf-8', 'replace'))['token']
+            headers['Authorization'] = {'Bearer {}'.format(token)}
 
         req = httpclient.HTTPRequest(
             '{}/v2/{}/manifests/{}'.format(self.registry, image, tag),
-            headers={'Authorization': 'Bearer {}'.format(token)},
+            headers=headers,
         )
         try:
             resp = yield client.fetch(req)

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -38,11 +38,17 @@ helm init
 
 echo "waiting for tiller"
 until helm version; do
-    sleep 1
-  done
+  sleep 1
+done
 helm version
 
 echo "installing git-crypt"
 curl -L https://github.com/minrk/git-crypt-bin/releases/download/0.5.0/git-crypt > bin/git-crypt
 echo "46c288cc849c23a28239de3386c6050e5c7d7acd50b1d0248d86e6efff09c61b  bin/git-crypt" | shasum -a 256 -c -
 chmod +x bin/git-crypt
+
+echo "installing local docker registry"
+docker run -d -p 5000:5000 --restart=always --name registry registry:2
+until curl -s http://127.0.0.1:5000; do
+  sleep 1
+done

--- a/testing/minikube/binderhub_config.py
+++ b/testing/minikube/binderhub_config.py
@@ -3,8 +3,10 @@ import subprocess
 try:
     minikube_ip = subprocess.check_output(['minikube', 'ip']).decode('utf-8').strip()
 except (subprocess.SubprocessError, FileNotFoundError):
-    minikube_ip = '192.168.1.100'
+    minikube_ip = '192.168.99.100'
 
 c.BinderHub.hub_url = 'http://{}:30123'.format(minikube_ip)
 c.BinderHub.hub_api_token = 'aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4'
-c.BinderHub.use_registry = False
+c.BinderHub.docker_image_prefix = '127.0.0.1:5000/'
+c.BinderHub.docker_registry_url = 'http://127.0.0.1:5000'
+c.BinderHub.docker_push_secret = None


### PR DESCRIPTION
Follow-up to #319

This reduces the number of moving parts at runtime for docker-in-docker by requiring a docker registry to always be used. Instead of running without a registry, a local registry should be run when a public registry is not desired.

TODO:

- [x] remove use_registry flag
- [x] support insecure local registries (http, no auth)
- [x] run registry on travis
- [ ] add registry to helm chart so deploying with local registry is one-click
- [ ] test with d-in-d on travis now that we have a registry