### PR TITLE
dind: conditional daemonset, support initContainers

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.dind.enabled -}}
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -34,3 +35,4 @@ spec:
       - name: rundind
         hostPath:
           path: {{ .Values.dind.hostSocketDir }}
+{{- end }}

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -14,9 +14,13 @@ spec:
       labels:
         name: {{ .Release.Name }}-dind
     spec:
+      {{ if .Values.dind.initContainers -}}
+      initContainers:
+{{ toYaml .Values.dind.initContainers | indent 10 }}
+      {{- end }}
       containers:
       - name: dind
-        image: {{ .Values.dind.daemonset.image.name}}:{{ .Values.dind.daemonset.image.tag }}
+        image: {{ .Values.dind.daemonset.image.name }}:{{ .Values.dind.daemonset.image.tag }}
         args:
           - dockerd
           - --storage-driver={{ .Values.dind.storageDriver }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -133,6 +133,7 @@ deployment:
 
 dind:
   enabled: false
+  initContainers:
   daemonset:
     image:
       name: docker

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -133,7 +133,7 @@ deployment:
 
 dind:
   enabled: false
-  initContainers:
+  initContainers: []
   daemonset:
     image:
       name: docker


### PR DESCRIPTION
Minor updates while deploying docker-in-docker:

- only run the daemonset when dind.enabled is True
- allow initContainers for dind itself, which should allow us to firewall builds like we do for runs