### PR TITLE
go back to publishing the chart in after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
 services:
 - docker
 sudo: required
+branches:
+  only:
+  - master
 
 install:
 - mkdir -p bin
@@ -18,17 +21,18 @@ after_failure:
     echo $pod
     kubectl logs --namespace=$BINDER_TEST_NAMESPACE $pod
   done
-
 after_success:
 - codecov
-
-jobs:
-  include:
-  - stage: deploy
-    if: type = push AND branch = master
-    # set env to avoid deploy matrix
-    env: TEST=helm
-    script: ./ci/deploy.sh
+- |
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TEST" == "helm" ]]; then
+    openssl aes-256-cbc -K $encrypted_d8355cc3d845_key -iv $encrypted_d8355cc3d845_iv -in travis.enc -out travis -d
+    chmod 0400 travis
+    export GIT_SSH_COMMAND="ssh -i ${PWD}/travis"
+    docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
+    cd helm-chart
+    ./build.py --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
+    cd ..
+  fi
 
 env:
   matrix:

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -eu
-docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
-openssl aes-256-cbc -K $encrypted_d8355cc3d845_key -iv $encrypted_d8355cc3d845_iv -in travis.enc -out travis -d
-set -x
-chmod 0400 travis
-export GIT_SSH_COMMAND="ssh -i ${PWD}/travis"
-cd helm-chart
-./build.py --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart


### PR DESCRIPTION
fixes for new build.py:

- define GIT_SSH_COMMAND
- add --publish-chart arg

quicker than running deploy as its own job because it doesn't require running install and build over again.

Since this revers the last few PRs, a clearer diff is [this one](https://github.com/jupyterhub/binderhub/compare/513ba4e627b5b8d3d8933aab45b9839a4c97893c...minrk:back-to-one).