### PR TITLE
remove -deployment from binder pod name

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.5.0-66934b6"
+  version: "0.5.0-f963312"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: binderhub-deployment
+  name: binder
 spec:
   replicas: 1
   strategy:
@@ -14,7 +14,11 @@ spec:
   template:
     metadata:
       labels:
-        name: binder-pod
+        app: binder
+        name: binder
+        component: binder
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
         {{ if .Values.deployment.labels -}}
         # Because toYaml + indent is super flaky
         {{ range $key, $value := .Values.deployment.labels -}}

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         name: {{ .Release.Name }}-dind
+        app: binder
+        component: dind
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
     spec:
       {{ if .Values.dind.initContainers -}}
       initContainers:

--- a/helm-chart/binderhub/templates/service.yaml
+++ b/helm-chart/binderhub/templates/service.yaml
@@ -10,7 +10,11 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}
   {{- end }}
   selector:
-    name: binder-pod
+    app: binder
+    name: binder
+    component: binder
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
   ports:
     - protocol: TCP
       port: 80


### PR DESCRIPTION
and apply common labels

matching upstream changes in jupyterhub chart, which is pulled in here as well