### PR TITLE
implement per_repo_quota

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -108,6 +108,18 @@ class BinderHub(Application):
         config=True
     )
 
+    per_repo_quota = Integer(
+        0,
+        help="""
+        Maximum number of concurrent users running from a given repo.
+
+        Limits the amount of Binder that can be consumed by a single repo.
+
+        0 (default) means no quotas.
+        """,
+        config=True,
+    )
+
     docker_push_secret = Unicode(
         'docker-push-secret',
         allow_none=True,
@@ -315,6 +327,7 @@ class BinderHub(Application):
             "build_namespace": self.build_namespace,
             "builder_image_spec": self.builder_image_spec,
             'build_pool': self.build_pool,
+            'per_repo_quota': self.per_repo_quota,
             'repo_providers': self.repo_providers,
             'use_registry': self.use_registry,
             'registry': registry,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -5,19 +5,19 @@ Handlers for working with version control services (i.e. GitHub) for builds.
 import hashlib
 from http.client import responses
 import json
-import threading
 import string
 import time
 import escapism
 
 import docker
 from kubernetes import client
+from tornado.concurrent import chain_future, Future
 from tornado import gen, web
 from tornado.queues import Queue
 from tornado.iostream import StreamClosedError
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
-from prometheus_client import Histogram, Gauge, Counter
+from prometheus_client import Histogram, Gauge
 
 from .base import BaseHandler
 from .build import Build, FakeBuild
@@ -217,19 +217,19 @@ class BuildHandler(BaseHandler):
             else:
                 image_found = True
 
-        """----- Launch a notebook server if the image already is built -----"""
+        # Launch a notebook server if the image already is built
+        kube = client.CoreV1Api()
+
         if image_found:
             await self.emit({
                 'phase': 'built',
                 'imageName': image_name,
                 'message': 'Found built image, launching...\n'
             })
-            await self.launch()
+            await self.launch(kube)
             return
 
-        """----- Prepare to build -----"""
-        api = client.CoreV1Api()
-
+        # Prepare to build
         q = Queue()
 
         if self.settings['use_registry']:
@@ -241,7 +241,7 @@ class BuildHandler(BaseHandler):
 
         build = BuildClass(
             q=q,
-            api=api,
+            api=kube,
             name=build_name,
             namespace=self.settings["build_namespace"],
             git_url=repo,
@@ -312,7 +312,7 @@ class BuildHandler(BaseHandler):
         if not failed:
             BUILD_TIME.labels(status='success').observe(time.perf_counter() - build_starttime)
             with LAUNCHES_INPROGRESS.track_inprogress():
-                await self.launch()
+                await self.launch(kube)
 
         # Don't close the eventstream immediately.
         # (javascript) eventstream clients reconnect automatically on dropped connections,
@@ -324,8 +324,47 @@ class BuildHandler(BaseHandler):
         # well-behaved clients will close connections after they receive the launch event.
         await gen.sleep(60)
 
-    async def launch(self):
+    async def launch(self, kube):
         """Ask JupyterHub to launch the image."""
+        # check quota first
+        quota = self.settings.get('per_repo_quota')
+
+        image_no_tag = self.image_name.rsplit(':', 1)[0]
+        matching_pods = 0
+        total_pods = 0
+        pool = self.settings['build_pool']
+        f = pool.submit(kube.list_namespaced_pod,
+            self.settings["build_namespace"],
+            label_selector='app=jupyterhub,component=singleuser-server',
+        )
+        # concurrent.futures.Future isn't awaitable
+        # wrap in tornado Future
+        # tornado 5 will have `.run_in_executor`
+        tf = Future()
+        chain_future(f, tf)
+        pods = await tf
+        for pod in pods.items:
+            total_pods += 1
+            for container in pod.spec.containers:
+                image = container.image.rsplit(':', 1)[0]
+                if image == image_no_tag:
+                    matching_pods += 1
+                    break
+
+        # TODO: allow whitelist of repos to exceed quota
+        if quota and matching_pods >= quota:
+            app_log.error("%s has exceeded quota: %s/%s (%s total)",
+                self.repo, matching_pods, quota, total_pods)
+            await self.fail("Too many users running %s! Try again soon." % self.repo)
+            return
+
+        if quota and matching_pods >= 0.5 * quota:
+            log = app_log.warning
+        else:
+            log = app_log.info
+        log("Launching pod for %s: %s other pods running this repo (%s total)",
+            self.repo, matching_pods, total_pods)
+
         await self.emit({
             'phase': 'launching',
             'message': 'Launching server...\n',

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
   binder.google-analytics-domain: {{ .Values.googleAnalyticsDomain | quote }}
   {{- end }}
   binder.cors: {{ toJson .Values.cors | quote }}
+  binder.per-repo-quota: {{ .Values.perRepoQuota | quote }}
   binder.registry.prefix: {{ .Values.registry.prefix | quote }}
   binder.repo2docker-image: {{ .Values.repo2dockerImage | quote }}
   binder.hub-url: {{ .Values.hub.url | quote }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -15,6 +15,8 @@ image:
 
 repo2dockerImage: jupyter/repo2docker:6e9088d
 
+perRepoQuota: 100
+
 googleAnalyticsCode:
 googleAnalyticsDomain:
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -25,6 +25,7 @@ c.BinderHub.docker_push_secret = get_config('binder.push-secret')
 c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
 c.BinderHub.use_registry = get_config('binder.use-registry', True)
+c.BinderHub.per_repo_quota = get_config('binder.per-repo-quota', 0)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
 c.BinderHub.hub_url = get_config('binder.hub-url')

--- a/testing/minikube/binderhub_config.py
+++ b/testing/minikube/binderhub_config.py
@@ -8,3 +8,4 @@ except (subprocess.SubprocessError, FileNotFoundError):
 c.BinderHub.hub_url = 'http://{}:30123'.format(minikube_ip)
 c.BinderHub.hub_api_token = 'aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4'
 c.BinderHub.use_registry = False
+c.BinderHub.build_namespace = 'binder-test'


### PR DESCRIPTION
sets the maximum number of pods that can be running from a given repo

default in the helm chart is 100, default for the app is 0 (no limit)

Currently, this fails the launch with an error that too many people are using the repo. Alternately, we could hold the launch in a queue and wait until the quota is no longer met.

closes #331