### PR TITLE
Add user-name and user-id arguments to build command

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -203,7 +203,7 @@ class BinderHub(Application):
     )
 
     builder_image_spec = Unicode(
-        'jupyter/repo2docker:235f0ad',
+        'jupyter/repo2docker:v0.4.1',
         help="""
         The builder image to be used for doing builds
         """,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -203,7 +203,7 @@ class BinderHub(Application):
     )
 
     builder_image_spec = Unicode(
-        'jupyter/repo2docker:v0.4.1',
+        'jupyter/repo2docker:235f0ad',
         help="""
         The builder image to be used for doing builds
         """,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -53,6 +53,8 @@ class Build:
             '--ref', self.ref,
             '--image', self.image_name,
             '--no-clean', '--no-run', '--json-logs',
+            '--user-name', 'jovyan',
+            '--user-id', '1000'
         ]
 
         if self.push_secret:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -12,7 +12,7 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: local
 
-repo2dockerImage: jupyter/repo2docker:v0.4.1
+repo2dockerImage: jupyter/repo2docker:235f0ad
 
 googleAnalyticsCode:
 


### PR DESCRIPTION
Follows up jupyter/repo2docker#172

We need to explicitly set the username and userid to use inside the
container now. This adds the corresponding commandline arguments to
the repo2docker call.