### PR TITLE
Revert "Add user-name and user-id arguments to build command"

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -203,7 +203,7 @@ class BinderHub(Application):
     )
 
     builder_image_spec = Unicode(
-        'jupyter/repo2docker:235f0ad',
+        'jupyter/repo2docker:v0.4.1',
         help="""
         The builder image to be used for doing builds
         """,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -53,8 +53,6 @@ class Build:
             '--ref', self.ref,
             '--image', self.image_name,
             '--no-clean', '--no-run', '--json-logs',
-            '--user-name', 'jovyan',
-            '--user-id', '1000'
         ]
 
         if self.push_secret:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -12,7 +12,7 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: local
 
-repo2dockerImage: jupyter/repo2docker:235f0ad
+repo2dockerImage: jupyter/repo2docker:v0.4.1
 
 googleAnalyticsCode:
 


### PR DESCRIPTION
Reverts jupyterhub/binderhub#378

This needs a slightly careful mybinder.org deploy, since I think we need to co-ordinate 
a repo2docker bump too at the same time. If we aren't going to deploy this right away
 can we revert this and leave it open until we can?