### PR TITLE
Bump jupyterhub chart version

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.5.0"
+  version: "0.6.0-9701a90"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/367
which might help with the flaky tests.