### PR TITLE
Allow setting Google Analytics domain explicitly

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -64,6 +64,17 @@ class BinderHub(Application):
         config=True
     )
 
+    google_analytics_domain = Unicode(
+        'auto',
+        help="""
+        The Google Analytics domain to use on the main page.
+
+        By default this is set to 'auto', which sets it up for current domain and all
+        subdomains. This can be set to a more restrictive domain here for better privacy
+        """,
+        config=True
+    )
+
     base_url = Unicode(
         '/',
         help="The base URL of the entire application",
@@ -306,6 +317,7 @@ class BinderHub(Application):
             'registry': registry,
             'traitlets_config': self.config,
             'google_analytics_code': self.google_analytics_code,
+            'google_analytics_domain': self.google_analytics_domain,
             'jinja2_env': jinja_env,
             'build_memory_limit': self.build_memory_limit,
             'build_docker_host': self.build_docker_host,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -19,7 +19,8 @@ class MainHandler(BaseHandler):
             ref='',
             filepath=None,
             submit=False,
-            google_analytics_code=self.settings['google_analytics_code']
+            google_analytics_code=self.settings['google_analytics_code'],
+            google_analytics_domain=self.settings['google_analytics_domain'],
         )
 
 
@@ -46,6 +47,7 @@ class ParameterizedMainHandler(BaseHandler):
             urlpath=self.get_argument('urlpath', None),
             submit=True,
             google_analytics_code=self.settings['google_analytics_code'],
+            google_analytics_domain=self.settings['google_analytics_domain'],
         )
 
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -44,7 +44,7 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '{{ google_analytics_code }}', 'auto');
+    ga('create', '{{ google_analytics_code }}', '{{ google_analytics_domain }}');
     ga('send', 'pageview');
   }
   </script>


### PR DESCRIPTION
By default cookie is set for all subdomains too, which is bad
privacy.