### PR TITLE
consolidate tips/notes

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -72,12 +72,9 @@ Create a file called ``secret.yaml`` and enter the following::
 
 .. tip::
 
-   The content you put just after ``password: |`` must all line up at the same
-   tab level.
-
-.. tip::
-
-   Don't forget the ``|`` after the ``password:`` label.
+   * The content you put just after ``password: |`` must all line up at the same
+     tab level.
+   * Don't forget the ``|`` after the ``password:`` label.
 
 Create ``config.yaml``
 ----------------------
@@ -98,14 +95,11 @@ Create a file called ``config.yaml`` and enter the following::
 
 .. note::
 
-   **``<google-project-id>``** can be found in the JSON file that you
-   pasted above. It is the text that is in the ``project_id`` field. This is
-   the project *ID*, which may be different from the project *name*.
-
-.. note::
-
-   **``<prefix>``** can be any string, and will be prepended to image names. We
-   recommend something descriptive such as ``dev`` or ``prod``.
+   * **``<google-project-id>``** can be found in the JSON file that you
+     pasted above. It is the text that is in the ``project_id`` field. This is
+     the project *ID*, which may be different from the project *name*.
+   * **``<prefix>``** can be any string, and will be prepended to image names. We
+     recommend something descriptive such as ``dev`` or ``prod``.
 
 Install BinderHub
 -----------------
@@ -122,13 +116,10 @@ that you've just created. Do this by running the following command::
 
 .. note::
 
-   ``--version`` refers to the version of the BinderHub **Helm Chart**.
-
-.. note::
-
-   ``name`` and ``namespace`` may be different, but we recommend using
-   the same ``name`` and ``namespace`` to avoid confusion. We recommend
-   something descriptive and short.
+   * ``--version`` refers to the version of the BinderHub **Helm Chart**.
+   * ``name`` and ``namespace`` may be different, but we recommend using
+     the same ``name`` and ``namespace`` to avoid confusion. We recommend
+     something descriptive and short.
 
 This installation step will deploy both a BinderHub and a JupyterHub, but
 they are not yet set up to communicate with each other. We'll fix this in


### PR DESCRIPTION
I've found that over time as the install instructions have gotten more complex, some pages have a feeling of being cluttered because of the several boxes, indentation levels, etc. This is a quick PR to see if we could consolidate some of the tip/notes boxes in order to simplify the look. My hope is that this will make the text easier to follow.

Basically, any time that we have two tips/notes right after each other, this consolidates them into one box with a bulleted list. So

![image](https://user-images.githubusercontent.com/1839645/34622176-f3f5f9f4-f200-11e7-9c2f-7dd14905fd20.png)

becomes

![image](https://user-images.githubusercontent.com/1839645/34622154-dae9b9f0-f200-11e7-90bb-de215a0f8c36.png)

What do folks think about this? If people like it, I can make a similar PR to z2jh