### PR TITLE
adding clipboard clicking

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -276,3 +276,21 @@ h4.logo-subtext {
     }
 
 }
+
+/*Clipboard styling*/
+
+img.icon.clipboard{
+    order: 1;
+    border: thin solid silver;
+    border-radius: 5px;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    border-left: none;
+}
+img.icon.clipboard:hover {
+    background: #f5f5f5;
+}
+
+img.icon.clipboard:active {
+    background: #ddd;
+}

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -169,7 +169,7 @@ h4 {
 }
 
 
-.badge-snippet-row {
+.badge-snippet-row, .url-row {
     width: 100%;
     display: flex;
     flex-direction: reverse;
@@ -177,7 +177,7 @@ h4 {
     padding: 10px;
 }
 
-.badge-snippet-row .icon{
+.badge-snippet-row .icon, .url-row .icon {
     order: 0;
     max-width: 30px;
     max-height: 40px;
@@ -188,9 +188,9 @@ h4 {
 
 .input-group-btn .btn {
     border: solid #ccc 1px;
-} 
+}
 
-.badge-snippet-row pre{
+.badge-snippet-row pre, .url-row pre {
     order: 1;
     margin: 0;
     flex-grow: 1;
@@ -252,17 +252,6 @@ h4.logo-subtext {
   margin-top: -60px;
 }
 
-.url-row {
-  height: 100%;
-  width:  100%;
-  display: table;
-  padding: 10px;
-}
-
-.url-row pre {
-  margin-bottom: 0;
-}
-
 .form-row .form-group:first-child{
   padding-left: 0;
 }
@@ -287,4 +276,3 @@ h4.logo-subtext {
     }
 
 }
-

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -194,6 +194,8 @@ h4 {
     order: 1;
     margin: 0;
     flex-grow: 1;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 }
 
 

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -229,8 +229,12 @@ $(function(){
         var badgeSnippets = $('#badge-snippets');
         if (badgeSnippets.hasClass('hidden')) {
             badgeSnippets.removeClass('hidden');
+            $("#badge-snippet-caret").removeClass("glyphicon-triangle-right")
+            $("#badge-snippet-caret").addClass("glyphicon-triangle-bottom")
         } else {
             badgeSnippets.addClass('hidden');
+            $("#badge-snippet-caret").removeClass("glyphicon-triangle-bottom")
+            $("#badge-snippet-caret").addClass("glyphicon-triangle-right")
         }
 
         return false;

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -11,13 +11,13 @@
   pushing -> failed
 */
 import * as Terminal from 'xterm';
+import Clipboard from 'clipboard';
 import 'xterm/lib/xterm.css';
 import 'bootstrap';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';
 import '../index.css';
-
 
 // FIXME: Can not seem to import this addon from npm
 // See https://github.com/xtermjs/xterm.js/issues/1018 for more details
@@ -197,11 +197,11 @@ $(function(){
     });
     updatePathText();
 
-    $('#repository').on('keyup paste', updateUrlDiv);
+    $('#repository').on('keyup paste change', updateUrlDiv);
 
-    $('#ref').on('keyup paste', updateUrlDiv);
+    $('#ref').on('keyup paste change', updateUrlDiv);
 
-    $('#filepath').on('keyup paste', updateUrlDiv);
+    $('#filepath').on('keyup paste change', updateUrlDiv);
 
     log.open(document.getElementById('log'), false);
     log.fit();
@@ -312,3 +312,8 @@ $(function(){
         $('#build-form').submit();
     }
 });
+
+// Load the clipboard after the page loads so it can find the buttons it needs
+window.onload = function() {
+  new Clipboard('.clipboard');
+}

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -91,13 +91,18 @@
               <div  class="badge-snippet-row">
                  <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet.</pre>
                  <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
-                 <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
+                 <img class="icon clipboard"
+                    src="{{static_url("images/copy-icon-black.svg")}}"
+                    data-clipboard-target="#markdown-badge-snippet"
+                    alt="Copy markdown link to clipboard">
               </div>
               <!--RST section-->
               <div  class="badge-snippet-row">
-                <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet.</pre>
-                <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
-                <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
+                  <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet.</pre>
+                  <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
+                  <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}"
+                    data-clipboard-target="#rst-badge-snippet"
+                    alt="Copy rst link to clipboard">
               </div>
             </div>
         </div>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -8,6 +8,7 @@
 <script>
  {% if submit %} window.submitBuild = true; {% endif %}
 </script>
+
 {% endblock head %}
 
 {% block main %}
@@ -69,16 +70,17 @@
         <!--url section-->
         <div class="url row">
             <div class="bluedropdown">
-              <label>Copy and share this URL:</label>
+              <label>Click the icon below to copy and share this URL:</label>
             </div>
             <div class="url-row">
-              <pre id="basic-url-snippet">After filling in the form, a generated URL for sharing your Binder will be displayed here.</pre>
+              <pre id="basic-url-snippet">Fill in the fields to see a URL for sharing your Binder.</pre>
+              <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
             </div>
         </div>
 
         <div class="badges row">
             <div class="bluedropdown" id="toggle-badge-snippet">
-              <label>Click, then paste into your README to get badge: <img id="badge" src="{{static_url("images/badge.svg")}}"></label>
+              <label>Click an icon below, then paste into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge.svg")}}"></label>
               <a id="badge-link"></a>
               <a href="#" title="show badge snippets"><span class="caret"></span></a>
 
@@ -87,17 +89,17 @@
             <div id="badge-snippets" class="hidden">
               <!--Markdown section-->
               <div  class="badge-snippet-row">
-                 <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet</pre>
-                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
+                 <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet.</pre>
+                 <img class="icon clipboard" src="{{static_url("images/markdown-icon.svg")}}" data-clipboard-target="#markdown-badge-snippet">
               </div>
               <!--RST section-->
               <div  class="badge-snippet-row">
-                <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet</pre>
-                <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
+                <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet.</pre>
+                <img class="icon clipboard" src="{{static_url("images/rst-icon.svg")}}" data-clipboard-target="#rst-badge-snippet">
               </div>
             </div>
         </div>
-        
+
         <div id="build-progress" class="progress on-build hidden row">
           <div id="phase-failed" class="progress-bar progress-bar-danger progress-bar-striped hidden" style="width: 100%">
             Failed

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -70,7 +70,7 @@
         <!--url section-->
         <div class="url row">
             <div class="bluedropdown">
-              <label>Click the icon below to copy and share this URL:</label>
+              <label>Copy the URL below and share your Binder with others:</label>
             </div>
             <div class="url-row">
               <pre id="basic-url-snippet">Fill in the fields to see a URL for sharing your Binder.</pre>
@@ -80,9 +80,9 @@
 
         <div class="badges row">
             <div class="bluedropdown" id="toggle-badge-snippet">
-              <label>Click an icon below, then paste into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge.svg")}}"></label>
+              <label>Copy the text below, then paste into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge.svg")}}"></label>
               <a id="badge-link"></a>
-              <a href="#" title="show badge snippets"><span class="caret"></span></a>
+              <a href="#" title="show badge snippets"><span id="badge-snippet-caret" class="glyphicon glyphicon-triangle-right"></span></a>
 
               </button>
             </div>
@@ -90,12 +90,14 @@
               <!--Markdown section-->
               <div  class="badge-snippet-row">
                  <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet.</pre>
-                 <img class="icon clipboard" src="{{static_url("images/markdown-icon.svg")}}" data-clipboard-target="#markdown-badge-snippet">
+                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
+                 <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
               </div>
               <!--RST section-->
               <div  class="badge-snippet-row">
                 <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet.</pre>
-                <img class="icon clipboard" src="{{static_url("images/rst-icon.svg")}}" data-clipboard-target="#rst-badge-snippet">
+                <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
+                <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
               </div>
             </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "`BinderHub`",
   "devDependencies": {
     "bootstrap": "^3.3.7",
+    "clipboard": "^1.7.1",
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.6",


### PR DESCRIPTION
Now that we're using npm, this uses a little npm package that lets you auto-copy to the clipboard. It does a couple of things:

1. Makes all the icons next to the text fields clickable, which copies the text to the clipboard
2. Updates the prompts on the build page to reflect this
3. Adds a clipboard badge to the main URL text box (and also fixes a bug where the box would run off of the screen if it was too narrow)
4. Mostly fixes the bug that @ryanlovett mentioned in #388 