### PR TITLE
Include CSS on all pages.

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -3,7 +3,6 @@
 {% block head %}
 <meta id="base-url" data-url="{{base_url}}">
 <script src="{{static_url("dist/bundle.js")}}"></script>
-<link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>
 {{ super() }}
 <script>
  {% if submit %} window.submitBuild = true; {% endif %}

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -4,6 +4,7 @@
   <title>{% block title %}Binder (beta){% endblock %}</title>
   {% block head %}
   <link id="favicon" rel="shortcut icon" type="image/png" href="{{static_url("favicon.ico")}}" />
+  <link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>
 
   {% endblock head %}
 </head>


### PR DESCRIPTION
Fixes the fact that error pages right now have no styles...

...  because right now it look like

<img width="671" alt="screen shot 2018-01-07 at 18 40 34" src="https://user-images.githubusercontent.com/335567/34652128-608a283a-f3da-11e7-99fe-656999fbb28f.png">
