### PR TITLE
add event source dependency

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -14,6 +14,7 @@ import * as Terminal from 'xterm';
 import Clipboard from 'clipboard';
 import 'xterm/lib/xterm.css';
 import 'bootstrap';
+import 'event-source-polyfill';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bootstrap": "^3.3.7",
     "clipboard": "^1.7.1",
     "css-loader": "^0.28.7",
+    "event-source-polyfill": "^0.0.12",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.6",
     "jquery": "^3.2.1",


### PR DESCRIPTION
This adds the npm package `event-source-polyfill` which makes it possible for Binder events to work on the MS Edge browser.