### PR TITLE
Pass GitHub credentials to repo2docker for cloning

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -95,7 +95,7 @@ class Build:
             ))
 
         env = []
-        if provider.git_credential:
+        if self.git_credential:
             env.append(client.V1EnvVar(name='GIT_CREDENTIAL_ENV', value=provider.git_credential))
 
         self.pod = client.V1Pod(

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -250,7 +250,8 @@ class BuildHandler(BaseHandler):
             push_secret=push_secret,
             builder_image=self.settings['builder_image_spec'],
             memory_limit=self.settings['build_memory_limit'],
-            docker_host=self.settings['build_docker_host']
+            docker_host=self.settings['build_docker_host'],
+            git_credential=provider.git_credentials
         )
 
         with BUILDS_INPROGRESS.track_inprogress():

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -69,6 +69,12 @@ class RepoProvider(LoggingConfigurable):
 
     unresolved_ref = Unicode()
 
+    git_credentials = Unicode(
+        "",
+        help="""
+        Credentials (if any) to pass to git when cloning.
+        """,
+    )
 
     def is_banned(self):
         """
@@ -290,6 +296,13 @@ class GitHubRepoProvider(RepoProvider):
             if value:
                 auth[key] = value
         return auth
+
+    @default('git_credentials')
+    def _default_git_credentials(self):
+        if self.access_token:
+            # Based on https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth
+            return 'username={}\npassword=x-oauth-basic'
+        return ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -301,7 +301,7 @@ class GitHubRepoProvider(RepoProvider):
     def _default_git_credentials(self):
         if self.access_token:
             # Based on https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth
-            return 'username={}\npassword=x-oauth-basic'
+            return 'username={token}\npassword=x-oauth-basic'.format(token=self.access_token)
         return ""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This helps GitHub identify how many clones we are doing,
and also allows users to build off private repos on their own
installations.

Fixes #237 