### PR TITLE
add async test timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 - pip install . -r dev-requirements.txt
 script:
 - export BINDER_TEST_NAMESPACE=binder-test-$TEST
+- export ASYNC_TEST_TIMEOUT=15
 - ./ci/test-$TEST
 after_failure:
 - for pod in $(kubectl get pod --namespace=$BINDER_TEST_NAMESPACE | awk '{print $1}'); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
 - pip install . -r dev-requirements.txt
 script:
 - export BINDER_TEST_NAMESPACE=binder-test-$TEST
-- export ASYNC_TEST_TIMEOUT=15
 - ./ci/test-$TEST
 after_failure:
 - for pod in $(kubectl get pod --namespace=$BINDER_TEST_NAMESPACE | awk '{print $1}'); do

--- a/ci/test-helm
+++ b/ci/test-helm
@@ -49,5 +49,6 @@ done
 
 echo "running tests against $BINDER_TEST_URL"
 # run a few tests again, this time against the helm-installed binder
+export ASYNC_TEST_TIMEOUT=15
 pytest -vsx -m remote
 helm delete --purge binder-test

--- a/ci/test-helm
+++ b/ci/test-helm
@@ -49,6 +49,7 @@ done
 
 echo "running tests against $BINDER_TEST_URL"
 # run a few tests again, this time against the helm-installed binder
+sleep 10
 export ASYNC_TEST_TIMEOUT=15
 pytest -vsx -m remote
 helm delete --purge binder-test

--- a/ci/test-main
+++ b/ci/test-main
@@ -5,7 +5,7 @@
 set -ex
 ./testing/minikube/install-hub
 # DEBUG: give the hub a chance to wake up
-sleep 5
+sleep 10
 export ASYNC_TEST_TIMEOUT=15
 pytest -vsx --cov binderhub
 helm delete --purge binder-test-hub

--- a/ci/test-main
+++ b/ci/test-main
@@ -6,5 +6,6 @@ set -ex
 ./testing/minikube/install-hub
 # DEBUG: give the hub a chance to wake up
 sleep 5
+export ASYNC_TEST_TIMEOUT=15
 pytest -vsx --cov binderhub
 helm delete --purge binder-test-hub


### PR DESCRIPTION
Addresses #410 

- Increase ASYNC_TEST_TIMEOUT from default to 15 which is what we have been using for Tornado on JupyterHub tests
- Increase sleep to 10s