### PR TITLE
Attempt to fix flaky CI

### DIFF
--- a/ci/test-helm
+++ b/ci/test-helm
@@ -37,10 +37,10 @@ echo "waiting for pods to become ready"
 kubectl --namespace=$BINDER_TEST_NAMESPACE get deployment -o name | xargs -L1 kubectl --namespace=$BINDER_TEST_NAMESPACE rollout status --watch
 
 echo "waiting for servers to become responsive"
-until curl $BINDER_TEST_URL > /dev/null; do
+until curl --fail $BINDER_TEST_URL > /dev/null; do
   sleep 1
 done
-until curl $HUB_URL> /dev/null; do
+until curl --fail $HUB_URL> /dev/null; do
   sleep 1
 done
 

--- a/ci/test-helm
+++ b/ci/test-helm
@@ -34,11 +34,8 @@ helm install \
 
 # wait for helm deploy to come up
 echo "waiting for pods to become ready"
-JSONPATH='{range .items[*]}{@.status.phase};{end}'
-until kubectl get pod --namespace $BINDER_TEST_NAMESPACE -o jsonpath="$JSONPATH" | grep -q -i "^\(running;\)\+$"; do
-  kubectl get pod --namespace $BINDER_TEST_NAMESPACE
-  sleep 1
-done
+kubectl --namespace=$BINDER_TEST_NAMESPACE get deployment -o name | xargs -L1 kubectl --namespace=$BINDER_TEST_NAMESPACE rollout status --watch
+
 echo "waiting for servers to become responsive"
 until curl $BINDER_TEST_URL > /dev/null; do
   sleep 1


### PR DESCRIPTION
- Use `kubectl rollout` to wait for deployments to finish rolling out
- Wait until we get a successful response from our endpoints before starting test,
  rather than until we get *any* response

Should fix #410 