### PR TITLE
Using z2jh cloud instructions for k8s and helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,11 @@ _build/
 
 # Node stuff
 node_modules/
+package-lock.json
 
 # Built files
 binderhub/static/dist
+
+# Instructions we download
+k8s.txt
+helm.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@
 #
 import os
 import sys
+import requests
 curdir = os.path.dirname(__file__)
 sys.path.append(os.path.abspath(os.path.join(curdir, 'script')))
 
@@ -188,3 +189,22 @@ texinfo_documents = [
      author, 'BinderHub', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+# -- Custom scripts -------------------------------------------
+
+# Grab the latest version of the k8s and helm install instructions.
+k8s_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/create-k8s-cluster.rst"
+helm_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/setup-helm.rst"
+
+resp = requests.get(k8s_instructions)
+with open('./k8s.txt', 'w') as ff:
+    ff.write(resp.text)
+
+resp = requests.get(helm_instructions)
+with open('./helm.txt', 'w') as ff:
+    # Bump section headers
+    lines = resp.text.split('\n')
+    for ii, ln in enumerate(lines):
+        if ln.startswith('---'):
+            lines[ii] = ln.replace('-', '~')
+    ff.write('\n'.join(lines))

--- a/doc/create-cloud-resources.rst
+++ b/doc/create-cloud-resources.rst
@@ -23,80 +23,16 @@ Setting up Kubernetes on `Google Cloud <https://cloud.google.com/>`_
    If you would like to help with adding instructions for other cloud
    providers, `please contact us <https://github.com/jupyterhub/binderhub/issues>`_!
 
-`Google Container Engine <https://cloud.google.com/container-engine/>`_
-(confusingly abbreviated to GKE) is the simplest and most common way of setting
-up a Kubernetes Cluster. You may be able to receive `free credits
-<https://cloud.google.com/free/>`_ for trying it out. You will need to
-connect your credit card or other payment method to your google cloud account.
+.. include:: k8s.txt
+   :start-after: Setting up Kubernetes on `Google Cloud <https://cloud.google.com/>`_
+   :end-before: .. _microsoft-azure:
 
-1. Go to `https://console.cloud.google.com <https://console.cloud.google.com>`_ and log in.
+Install Helm
+------------
 
-2. Enable the `Container Engine API <https://console.cloud.google.com/apis/api/container.googleapis.com/overview>`_.
-
-3. Use **Google Cloud Shell** (`Google documentation <https://cloud.google.com/shell/docs/starting-cloud-shell>`_)
-   which will give you access to the ``gcloud`` command-line tool.
-
-   .. note::
-
-      Alternatively, advanced users may wish to install the ``gcloud`` command-line
-      tool in the `Google Cloud SDK <https://cloud.google.com/sdk/gcloud/>`_.
-      These tools send commands to Google Cloud and lets you do things like
-      create and delete clusters.
-
-4. Install ``kubectl``, which is a tool for controlling kubernetes. From
-   Google Cloud shell (or a terminal for advanced users who have installed
-   ``gcloud`` using the SDK), enter:
-
-     .. code-block:: bash
-
-        gcloud components install kubectl
-
-5. Create a Kubernetes cluster on Google Cloud, by typing in the following
-   command:
-
-   .. code-block:: bash
-
-      gcloud container clusters create <YOUR_CLUSTER> \
-          --num-nodes=3 \
-          --machine-type=n1-standard-2 \
-          --zone=us-central1-b
-
-   where:
-
-   * ``--num-nodes`` specifies how many computers to spin up. The higher the
-     number, the greater the cost.
-   * ``--machine-type`` specifies the amount of CPU and RAM in each node. There
-     is a `variety of types <https://cloud.google.com/compute/docs/machine-types>`_
-     to choose from. Picking something appropriate here will have a large effect
-     on how much you pay - smaller machines restrict the max amount of RAM each
-     user can have access to but allow more fine-grained scaling, reducing cost.
-     The default (`n1-standard-2`) has 2CPUs and 7.5G of RAM each, and might not
-     be a good fit for all use cases!
-   * ``--zone`` specifies which data center to use. Pick something that is not
-     too far away from your users. You can find a list of them `here <https://cloud.google.com/compute/docs/regions-zones/regions-zones#available>`_.
-
-6. To test if your cluster is initialized, run:
-
-   .. code-block:: bash
-
-      kubectl get node
-
-   The response should list three running nodes.
-
-Next we'll install a few tools that are required for BinderHub to run properly.
-
-Installing Helm
----------------
-
-Next, we'll install **Helm**. This allows us to control our Kubernetes cluster
-with a configuration file (called a Helm Chart). By using a **Helm Chart**, we
-can set up the cluster deployment to have the resources necessary for
-running BinderHub.
-
-Run the following commands to download and install helm::
-
-   curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-   helm init
+.. include:: helm.txt
+   :start-after: ===============
+   :end-before: Next Step
 
 .. _setup-registry:
 

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -4,3 +4,8 @@ pygraphviz==1.4rc1
 sphinx>=1.4, !=1.5.4
 traitlets>=4.1
 recommonmark
+prometheus_client
+docker
+kubernetes
+escapism
+requests

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -112,14 +112,17 @@ First, get the latest helm chart for BinderHub.::
 Next, **install the Helm Chart** using the configuration files
 that you've just created. Do this by running the following command::
 
-    helm install jupyterhub/binderhub --version=v0.1.0-397eb59 --name=binder --namespace=binder -f secret.yaml -f config.yaml
+    helm install jupyterhub/binderhub --version=v0.1.0-fbd816c --name=<choose-name> --namespace=<choose-namespace> -f secret.yaml -f config.yaml
 
 .. note::
 
    * ``--version`` refers to the version of the BinderHub **Helm Chart**.
    * ``name`` and ``namespace`` may be different, but we recommend using
      the same ``name`` and ``namespace`` to avoid confusion. We recommend
-     something descriptive and short.
+     something descriptive and short, such as ``binder``.
+   * If you run ``kubectl get pod --namespace=<namespace-from-above>`` you may
+     notice the binder pod in ``CrashLoopBackoff``. This is expected, and will
+     be resolved in the next section.
 
 This installation step will deploy both a BinderHub and a JupyterHub, but
 they are not yet set up to communicate with each other. We'll fix this in
@@ -132,7 +135,7 @@ Connect BinderHub and JupyterHub
 In the google console, run the following command to print the IP address
 of the JupyterHub we just deployed.::
 
-  kubectl --namespace=binder get svc proxy-public
+  kubectl --namespace=<namespace-from-above> get svc proxy-public
 
 Copy the IP address under ``EXTERNAL-IP``. This is the IP of your
 JupyterHub. Now, add the following lines to ``config.yaml`` file::
@@ -142,7 +145,7 @@ JupyterHub. Now, add the following lines to ``config.yaml`` file::
 
 Next, upgrade the helm chart to deploy this change::
 
-  helm upgrade binder jupyterhub/binderhub --version=v0.1.0-397eb59 -f secret.yaml -f config.yaml
+  helm upgrade <namespace-from-above> jupyterhub/binderhub --version=v0.1.0-fbd816c -f secret.yaml -f config.yaml
 
 Try out your BinderHub Deployment
 ---------------------------------
@@ -153,7 +156,7 @@ BinderHub deployment.
 First, find the IP address of the BinderHub deployment by running the following
 command::
 
-  kubectl --namespace=binder get svc binder
+  kubectl --namespace=<namespace-from-above> get svc binder
 
 Note the IP address in ``EXTERNAL-IP``. This is your BinderHub IP address.
 Type this IP address in your browser and a BinderHub should be waiting there


### PR DESCRIPTION
In #402 we realized that a lot of the k8s and helm instructions had become out of date. This PR adds a nifty rST feature to include parts of another text file. It grabs relevant parts of the latest version of the z2jh install instructions and injects them into our install instructions here (we should pin it to `v0.6-doc` when that is released). That way these docs will not get out-of-sync with z2jh like they are now.

I can confirm that following these docs resulted in a functioning BinderHub!

Here's an example of the docs:

http://predictablynoisy.com/binderhub/create-cloud-resources.html

Closes #402 