### PR TITLE
Update the version of the repo2docker image

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -215,7 +215,7 @@ class BinderHub(Application):
     )
 
     builder_image_spec = Unicode(
-        'jupyter/repo2docker:235f0ad',
+        'jupyter/repo2docker:6e9088d',
         help="""
         The builder image to be used for doing builds
         """,

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -12,7 +12,7 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: local
 
-repo2dockerImage: jupyter/repo2docker:235f0ad
+repo2dockerImage: jupyter/repo2docker:6e9088d
 
 googleAnalyticsCode:
 googleAnalyticsDomain:


### PR DESCRIPTION
I think the failures of travis (like [this](https://github.com/jupyterhub/binderhub/pull/418)) at the moment is because binderhub is not yet using the [new version of repo2docker](https://github.com/jupyter/repo2docker/pull/197).