### PR TITLE
Bump JupyterHub chart version

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.6.0-2c53640"
+  version: "0.6.0-dcb92ba"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
Comes with https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/461
which is a performance fix