### PR TITLE
add nodeSelector configuration for binder pod

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         checksum/config-map: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      nodeSelector: {{ toJson .Values.nodeSelector }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: binderhub
       {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -7,6 +7,7 @@ rbac:
   enabled: true
 
 baseUrl: /
+nodeSelector: {}
 
 image:
   name: jupyterhub/k8s-binderhub


### PR DESCRIPTION
Hi, currently I don't see a way to assign the binder pod to a specific node via helm config file. So this change makes it possible to set `nodeSelector` in helm configuration.