### PR TITLE
Better links on empty input.

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -161,9 +161,16 @@ function updateUrl() {
 
 function updateUrlDiv() {
   var url = updateUrl()
-  $('#basic-url-snippet').text(url);
-  $('#markdown-badge-snippet').text(markdownBadge(url));
-  $('#rst-badge-snippet').text(rstBadge(url));
+  if ((url||'').trim().length > 0){
+    $('#basic-url-snippet').text(url);
+    $('#markdown-badge-snippet').text(markdownBadge(url));
+    $('#rst-badge-snippet').text(rstBadge(url));
+  } else {
+    ['#basic-url-snippet', '#markdown-badge-snippet', '#rst-badge-snippet' ].map(function(item, ind){
+      var el = $(item)
+      el.text(el.attr('data-default'));
+    })
+  }
 }
 
 
@@ -189,8 +196,8 @@ $(function(){
         disableStdin: true
     });
 
-    // setup badge dropdown
-    updateUrl();
+    // setup badge dropdown and default values.
+    updateUrlDiv();
 
     $("#url-or-file-btn").find("a").click(function (evt) {
       $("#url-or-file-selected").text($(this).text());

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -72,7 +72,7 @@
               <label>Copy the URL below and share your Binder with others:</label>
             </div>
             <div class="url-row">
-              <pre id="basic-url-snippet">Fill in the fields to see a URL for sharing your Binder.</pre>
+              <pre id="basic-url-snippet" data-default="Fill in the fields to see a URL for sharing your Binder."></pre>
               <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#basic-url-snippet" alt="Copy to clipboard">
             </div>
         </div>
@@ -88,7 +88,7 @@
             <div id="badge-snippets" class="hidden">
               <!--Markdown section-->
               <div  class="badge-snippet-row">
-                 <pre id="markdown-badge-snippet">Fill in the fields to see the markdown badge snippet.</pre>
+                 <pre id="markdown-badge-snippet" data-default="Fill in the fields to see the markdown badge snippet."></pre>
                  <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
                  <img class="icon clipboard"
                     src="{{static_url("images/copy-icon-black.svg")}}"
@@ -97,7 +97,7 @@
               </div>
               <!--RST section-->
               <div  class="badge-snippet-row">
-                  <pre id="rst-badge-snippet">Fill in the fields to see the rST badge snippet.</pre>
+                  <pre id="rst-badge-snippet" data-default="Fill in the fields to see the rST badge snippet."></pre>
                   <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
                   <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}"
                     data-clipboard-target="#rst-badge-snippet"


### PR DESCRIPTION
If the repo links is emptied by the user, the various badges/links are
in inconsistent state.

Add logic to revert to original message "Fill in the fields to see a URL
for sharing your Binder." and similar.