### PR TITLE
Make the timeout at which 'too long' message appears

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -265,7 +265,7 @@ $(function(){
                 $('#loader').addClass("paused");
                 $('div#loader-text p').html("Repository " + repo + " is taking a long time to load!<br />See the logs for details.")
                 $('#loader').hover(function() {$('#loader').removeClass("paused")}, function() {$('#loader').addClass("paused")});
-            }, 30000)
+            }, 120000)
         }
 
         $('#build-progress .progress-bar').addClass('hidden');


### PR DESCRIPTION
Current timeout of 30s is too short, since a lot of repositories
definitely take longer than that

Ref #433 