### PR TITLE
Ignore case when checking for banned repositories

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -75,7 +75,9 @@ class RepoProvider(LoggingConfigurable):
         Return true if the given spec has been banned
         """
         for banned in self.banned_specs:
-            if re.match(banned, self.spec):
+            # Ignore case, because most git providers do not
+            # count DS-100/textbook as different from ds-100/textbook
+            if re.match(banned, self.spec, re.IGNORECASE):
                 return True
         return False
 


### PR DESCRIPTION
I think the problem with the ds-100/textbook repo was that it was *actually* DS-100/textbook, and since we are doing a case-sensitive regex match it didn't match! This means the banning works fine when you copy paste the repo into mybinder.org, but does not when hit with the API! This fixes it :)