### PR TITLE
add nodeSelector configuration for build pod

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -234,6 +234,15 @@ class BinderHub(Application):
         config=True
     )
 
+    build_node_selector = Dict(
+        default_value=None,
+        allow_none=True,
+        config=True,
+        help="""
+        Select the node where build pod runs on.
+        """
+    )
+
     repo_providers = Dict(
         {
             'gh': GitHubRepoProvider,
@@ -326,6 +335,7 @@ class BinderHub(Application):
             'launcher': self.launcher,
             "build_namespace": self.build_namespace,
             "builder_image_spec": self.builder_image_spec,
+            'build_node_selector': self.build_node_selector,
             'build_pool': self.build_pool,
             'per_repo_quota': self.per_repo_quota,
             'repo_providers': self.repo_providers,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -235,8 +235,7 @@ class BinderHub(Application):
     )
 
     build_node_selector = Dict(
-        default_value=None,
-        allow_none=True,
+        {},
         config=True,
         help="""
         Select the node where build pod runs on.

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -32,7 +32,7 @@ class Build:
 
     """
     def __init__(self, q, api, name, namespace, git_url, ref, builder_image,
-                 image_name, push_secret, memory_limit, docker_host):
+                 image_name, push_secret, memory_limit, docker_host, node_selector):
         self.q = q
         self.api = api
         self.git_url = git_url
@@ -45,6 +45,7 @@ class Build:
         self.main_loop = IOLoop.current()
         self.memory_limit = memory_limit
         self.docker_host = docker_host
+        self.node_selector = node_selector
 
     def get_cmd(self):
         """Get the cmd to run to build the image"""
@@ -115,6 +116,7 @@ class Build:
                         )
                     )
                 ],
+                node_selector=self.node_selector,
                 volumes=volumes,
                 restart_policy="Never"
             )

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -207,7 +207,7 @@ class BuildHandler(BaseHandler):
             image_found = bool(image_manifest)
         else:
             # Check if the image exists locally!
-            # Assume we're running in single-node mode!
+            # Assume we're running in single-node mode or all binder pods are assigned to the same node!
             docker_client = docker.from_env(version='auto')
             try:
                 docker_client.images.get(image_name)
@@ -250,7 +250,8 @@ class BuildHandler(BaseHandler):
             push_secret=push_secret,
             builder_image=self.settings['builder_image_spec'],
             memory_limit=self.settings['build_memory_limit'],
-            docker_host=self.settings['build_docker_host']
+            docker_host=self.settings['build_docker_host'],
+            node_selector=self.settings['build_node_selector']
         )
 
         with BUILDS_INPROGRESS.track_inprogress():

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
   binder.per-repo-quota: {{ .Values.perRepoQuota | quote }}
   binder.registry.prefix: {{ .Values.registry.prefix | quote }}
   binder.repo2docker-image: {{ .Values.repo2dockerImage | quote }}
+  {{ if .Values.buildNodeSelector -}}
+  binder.build-node-selector: {{ toJson .Values.buildNodeSelector | quote }}
+  {{- end }}
   binder.hub-url: {{ .Values.hub.url | quote }}
   binder.base_url: {{ .Values.baseUrl | quote }}
 

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -14,6 +14,7 @@ image:
   tag: local
 
 repo2dockerImage: jupyter/repo2docker:687788f
+buildNodeSelector: {}
 
 perRepoQuota: 100
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -28,6 +28,7 @@ c.BinderHub.use_registry = get_config('binder.use-registry', True)
 c.BinderHub.per_repo_quota = get_config('binder.per-repo-quota', 0)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
+c.BinderHub.build_node_selector = get_config('binder.build-node-selector', None)
 c.BinderHub.hub_url = get_config('binder.hub-url')
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -28,7 +28,7 @@ c.BinderHub.use_registry = get_config('binder.use-registry', True)
 c.BinderHub.per_repo_quota = get_config('binder.per-repo-quota', 0)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
-c.BinderHub.build_node_selector = get_config('binder.build-node-selector', None)
+c.BinderHub.build_node_selector = get_config('binder.build-node-selector', {})
 c.BinderHub.hub_url = get_config('binder.hub-url')
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 


### PR DESCRIPTION
Hi, with this change it is possible to assign build pods to a specific node by setting `buildNodeSelector`. The reason of the change is same as https://github.com/jupyterhub/binderhub/pull/436. If `buildNodeSelector` is not specified in config.yaml, it will behave as before.

With this change it is also possible to run binderhub in multi-node mode without using a container registry by assigning all binderhub pods to the same node.