### PR TITLE
use a semaphore to limit concurrent requests to the Hub API

### DIFF
--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -10,10 +10,11 @@ from urllib.parse import urlparse
 import uuid
 
 from tornado.log import app_log
+from tornado.locks import Semaphore
 from tornado import web, gen
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
 from traitlets.config import LoggingConfigurable
-from traitlets import Unicode
+from traitlets import Any, Integer, Unicode, default
 
 # pattern for checking if it's an ssh repo and not a URL
 # used only after verifying that `://` is not present
@@ -30,13 +31,28 @@ class Launcher(LoggingConfigurable):
 
     hub_api_token = Unicode(help="The API token for the Hub")
     hub_url = Unicode(help="The URL of the Hub")
+    concurrency = Integer(20,
+        help="""The maximum number of concurrently outstanding requests to the Hub
+
+        too many concurrently outstanding requests may result in TimeoutErrors
+
+        uses a semaphore to limit the number of requests
+        """,
+        config=True,
+    )
+
+    semaphore = Any()
+    @default('semaphore')
+    def _semaphore_default(self):
+        return Semaphore(self.concurrency)
 
     async def api_request(self, url, *args, **kwargs):
         """Make an API request to JupyterHub"""
         headers = kwargs.setdefault('headers', {})
         headers.update({'Authorization': 'token %s' % self.hub_api_token})
         req = HTTPRequest(self.hub_url + 'hub/api/' + url, *args, **kwargs)
-        resp = await AsyncHTTPClient().fetch(req)
+        async with self.semaphore:
+            resp = await AsyncHTTPClient().fetch(req)
         # TODO: handle errors
         return resp
 
@@ -47,7 +63,6 @@ class Launcher(LoggingConfigurable):
         from https://github.com/minrk/binder-example.git
         """
         # start with url path
-        print
         if '://' not in repo and _ssh_repo_pat.match(repo):
             # ssh url
             path = repo.split(':', 1)[1]

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -31,7 +31,7 @@ class Launcher(LoggingConfigurable):
 
     hub_api_token = Unicode(help="The API token for the Hub")
     hub_url = Unicode(help="The URL of the Hub")
-    concurrency = Integer(20,
+    concurrency = Integer(10,
         help="""The maximum number of concurrently outstanding requests to the Hub
 
         too many concurrently outstanding requests may result in TimeoutErrors

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -29,6 +29,7 @@ data:
   binder.appendix: {{ .Values.build.appendix | quote }}
   {{- end }}
   binder.hub-url: {{ .Values.hub.url | quote }}
+  binder.hub-api-concurrency: {{ .Values.hub.concurrency | quote }}
   binder.base_url: {{ .Values.baseUrl | quote }}
 
   {{ if .Values.github.hostname -}}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -70,6 +70,7 @@ cors: &cors
 
 hub:
   url:
+  concurrency: 10
 
 jupyterhub:
   cull:

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -42,6 +42,8 @@ if os.path.exists('/etc/binderhub/config/binder.appendix'):
 c.BinderHub.hub_url = get_config('binder.hub-url')
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 
+c.Launcher.concurrency = get_config('binder.hub-api-concurrency')
+
 c.BinderHub.google_analytics_code = get_config('binder.google-analytics-code', None)
 google_analytics_domain = get_config('binder.google-analytics-domain', None)
 if google_analytics_domain:


### PR DESCRIPTION
Too many concurrent AsyncHTTPClient requests can result in TimeoutErrors

limit enforced with a Semaphore on Launcher

switching to pycurl may have alleviated this, but let's double-up the protection.

use `c.Launcher.concurrency` config to change the limit. Default is 10.

TODO:

- [x] expose limit config via helm chart