### PR TITLE
define OPTIONS handler everywhere

### DIFF
--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -55,6 +55,9 @@ class BaseHandler(web.RequestHandler):
             message=message,
         )
 
+    def options(self, *args, **kwargs):
+        pass
+
 
 class Custom404(BaseHandler):
     """Raise a 404 error, rendering the error.html template"""


### PR DESCRIPTION
browsers may sniff OPTIONS as part of preflight of AJAX requests

This is happening now because API requests from jupyterlab to defunct servers are being redirected to the main binder page instead of jupyterhub.

An options handler doesn't need to do anything other than set headers.