### PR TITLE
Switch JupyterHub chart version to 0.6

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.6.0-dcb92ba"
+  version: "0.6.0"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
The version we are using suffered from a severe performance
bug, causing very high CPU usage!

See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/461
and https://github.com/jupyterhub/kubespawner/pull/125