### PR TITLE
Update JupyterHub helm chart version

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.6.0"
+  version: "v0.7.0-2cdcb44"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
The new version of the chart brings in a new culler that is better at
handling users that are slow to stop. See
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/531