### PR TITLE
[MRG] Expose resource requests and limits for DIND container

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -25,6 +25,8 @@ spec:
       containers:
       - name: dind
         image: {{ .Values.dind.daemonset.image.name }}:{{ .Values.dind.daemonset.image.tag }}
+        resources:
+{{ toYaml .Values.dind.resources | indent 10}}
         args:
           - dockerd
           - --storage-driver={{ .Values.dind.storageDriver }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -159,6 +159,7 @@ dind:
       tag: 17.11.0-ce-dind
   storageDriver: overlay2
   hostSocketDir: /var/run/dind
+  resources: {}
 
 imageCleaner:
   image:


### PR DESCRIPTION
This exposes the resource limit and requests for the Docker in Docker
container in the helm chart.

Don't deploy this to mybinder.org without first discussing what sensible default for these limits and requests should be. Then adjusting/reviewing jupyterhub/mybinder.org-deploy#491 and then merging and deploying this.