### PR TITLE
put binder-specific hub.extraConfig under a key

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -68,55 +68,56 @@ jupyterhub:
   hub:
     rbac:
       enabled: true
-    extraConfig: |
-      import os
-      import sys
-      import yaml
-      def get_config_map(key, default=None):
-          """
-          Find a configmap item of a given name & return it
+    extraConfig:
+      binder: |
+        import os
+        import sys
+        import yaml
+        def get_config_map(key, default=None):
+            """
+            Find a configmap item of a given name & return it
 
-          Parses everything as YAML, so lists and dicts are available too
-          """
-          path = os.path.join('/etc/jupyterhub/config', key)
-          try:
-              with open(path) as f:
-                  return yaml.safe_load(f)
-          except FileNotFoundError:
-              return default
+            Parses everything as YAML, so lists and dicts are available too
+            """
+            path = os.path.join('/etc/jupyterhub/config', key)
+            try:
+                with open(path) as f:
+                    return yaml.safe_load(f)
+            except FileNotFoundError:
+                return default
 
-      # get cors config from config-map
-      cors = get_config_map('custom.cors', {})
+        # get cors config from config-map
+        cors = get_config_map('custom.cors', {})
 
-      # disable login (users created exclusively via API)
-      c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
+        # disable login (users created exclusively via API)
+        c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
 
-      # image & token are set via spawn options
-      from kubespawner import KubeSpawner
+        # image & token are set via spawn options
+        from kubespawner import KubeSpawner
 
-      class BinderSpawner(KubeSpawner):
-        def get_args(self):
-            args = [
-                '--ip=0.0.0.0',
-                '--port=%i' % self.port,
-                '--NotebookApp.base_url=%s' % self.server.base_url,
-                '--NotebookApp.token=%s' % self.user_options['token'],
-            ]
-            allow_origin = cors.get('allowOrigin')
-            if allow_origin:
-                args.append('--NotebookApp.allow_origin=' + allow_origin)
-            return args + self.args
+        class BinderSpawner(KubeSpawner):
+          def get_args(self):
+              args = [
+                  '--ip=0.0.0.0',
+                  '--port=%i' % self.port,
+                  '--NotebookApp.base_url=%s' % self.server.base_url,
+                  '--NotebookApp.token=%s' % self.user_options['token'],
+              ]
+              allow_origin = cors.get('allowOrigin')
+              if allow_origin:
+                  args.append('--NotebookApp.allow_origin=' + allow_origin)
+              return args + self.args
 
-        def start(self):
-            if 'token' not in self.user_options:
-              raise web.HTTPError(400, "token required")
-            if 'image' not in self.user_options:
-              raise web.HTTPError(400, "image required")
+          def start(self):
+              if 'token' not in self.user_options:
+                raise web.HTTPError(400, "token required")
+              if 'image' not in self.user_options:
+                raise web.HTTPError(400, "image required")
 
-            self.singleuser_image_spec = self.user_options['image']
-            return super().start()
+              self.singleuser_image_spec = self.user_options['image']
+              return super().start()
 
-      c.JupyterHub.spawner_class = BinderSpawner
+        c.JupyterHub.spawner_class = BinderSpawner
 
     extraConfigMap:
       cors: *cors

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -13,37 +13,38 @@ hub:
     binder:
       admin: true
       apiToken: "aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4"
-  extraConfig: |
-    # disable login (users created exclusively via API)
-    c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
+  extraConfig:
+    binder: |
+      # disable login (users created exclusively via API)
+      c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
 
-    # image & token are set via spawn options
-    from kubespawner import KubeSpawner
+      # image & token are set via spawn options
+      from kubespawner import KubeSpawner
 
-    class BinderSpawner(KubeSpawner):
-      def get_args(self):
-          return [
-              '--ip=0.0.0.0',
-              '--port=%i' % self.port,
-              '--NotebookApp.base_url=%s' % self.server.base_url,
-              '--NotebookApp.token=%s' % self.user_options['token'],
-              '--NotebookApp.allow_origin=*',
-          ] + self.args
+      class BinderSpawner(KubeSpawner):
+        def get_args(self):
+            return [
+                '--ip=0.0.0.0',
+                '--port=%i' % self.port,
+                '--NotebookApp.base_url=%s' % self.server.base_url,
+                '--NotebookApp.token=%s' % self.user_options['token'],
+                '--NotebookApp.allow_origin=*',
+            ] + self.args
 
-      def start(self):
-          if 'token' not in self.user_options:
-            raise web.HTTPError(400, "token required")
-          if 'image' not in self.user_options:
-            raise web.HTTPError(400, "image required")
+        def start(self):
+            if 'token' not in self.user_options:
+              raise web.HTTPError(400, "token required")
+            if 'image' not in self.user_options:
+              raise web.HTTPError(400, "image required")
 
-          self.singleuser_image_spec = self.user_options['image']
-          return super().start()
+            self.singleuser_image_spec = self.user_options['image']
+            return super().start()
 
-    # launch jupyter notebook instead of jupyterhub-singleuser
-    c.JupyterHub.spawner_class = BinderSpawner
+      # launch jupyter notebook instead of jupyterhub-singleuser
+      c.JupyterHub.spawner_class = BinderSpawner
 
-    # debug!
-    c.JupyterHub.log_level = 10
+      # debug!
+      c.JupyterHub.log_level = 10
 
 singleuser:
   cmd: jupyter-notebook


### PR DESCRIPTION
this should have no effect here, only when a downstream deployment (e.g. mybinder.org-deploy) wants to add some config they should be able to with:

```yaml
hub:
  extraConfig:
    myConfig: |
      c.JupyterHub.log_level = 10
```

which will *add* to the hub's config, rather than replacing what's here, which is the current behavior.