### PR TITLE
support handcrafted links to non-github binders

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -41,6 +41,7 @@ class ParameterizedMainHandler(BaseHandler):
         self.render_template(
             "loading.html",
             base_url=self.settings['base_url'],
+            provider_prefix=provider_prefix,
             url=provider.get_repo_url(),
             ref=provider.unresolved_ref,
             filepath=self.get_argument('filepath', None),

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -135,6 +135,7 @@ class GitRepoProvider(RepoProvider):
             raise ValueError("`resolved_ref` must be specified as a query parameter for the basic git provider")
         self.sha1_validate(resolved_ref)
         self.resolved_ref = resolved_ref
+        self.unresolved_ref = resolved_ref
 
     @gen.coroutine
     def get_resolved_ref(self):

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -114,13 +114,13 @@ Image.prototype.launch = function(url, token, filepath, pathType) {
     window.location.href = url;
 };
 
-function v2url(repository, ref, path, pathType) {
-  // return a v2 url from a repository, ref, and (file|url)path
+function v2url(provider_prefix, repository, ref, path, pathType) {
+  // return a v2 url from a provider_prefix, repository, ref, and (file|url)path
   if (repository.length === 0) {
     // no repo, no url
     return null;
   }
-  var url = window.location.origin + BASE_URL + 'v2/gh/' + repository + '/' + ref;
+  var url = window.location.origin + BASE_URL + 'v2/' + provider_prefix + '/' + repository + '/' + ref;
   if (path && path.length > 0) {
     url = url + '?' + pathType + 'path=' + encodeURIComponent(path);
   }
@@ -147,13 +147,19 @@ function updatePathText() {
 
 function updateUrl() {
   // update URLs and links (badges, etc.)
+  var provider_prefix = $('#provider_prefix').val().trim();
   var repo = $('#repository').val().trim();
   repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
   // trim trailing or leading '/' on repo
   repo = repo.replace(/(^\/)|(\/?$)/g, '');
+  // git providers encode the URL of the git repository as the repo
+  // argument.
+  if (repo.includes("://")) {
+    repo = encodeURIComponent(repo);
+  }
   var ref = $('#ref').val().trim() || 'master';
   var filepath = $('#filepath').val().trim();
-  var url = v2url(repo, ref, filepath, getPathType());
+  var url = v2url(provider_prefix, repo, ref, filepath, getPathType());
   // update URL references
   $("#badge-link").attr('href', url);
   return url;
@@ -252,10 +258,16 @@ $(function(){
     $('#build-form').submit(function() {
         var repo = $('#repository').val().trim();
         var ref =  $('#ref').val().trim() || 'master';
+        var provider_prefix =  $('#provider_prefix').val().trim();
         repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
         // trim trailing or leading '/' on repo
         repo = repo.replace(/(^\/)|(\/?$)/g, '');
-        var image = new Image('gh', repo + '/' + ref);
+        // git providers encode the URL of the git repository as the
+        // repo argument.
+        if (repo.includes("://")) {
+          repo = encodeURIComponent(repo);
+        }
+        var image = new Image(provider_prefix, repo + '/' + ref);
 
         var url = updateUrl();
         // add fixed build URL to window history so that reload with refill the form

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -24,6 +24,7 @@
 
       <form id="build-form" class="form jumbotron">
         <h4 id="form-header" class='row'>Build and launch a repository</h4>
+        <input type="hidden" id="provider_prefix" value="gh"/>
         <div class="form-group row">
           <label for="repository">GitHub repo or URL</label>
           <input class="form-control" type="text" id="repository" placeholder="GitHub repository name or link" value="{{ url or '' }}"/>

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -30,6 +30,7 @@
 <!-- Keep the build form so that the JS works the same as index, but hide it -->
 <form id="build-form" class="form jumbotron hidden">
   <h4 id="form-header" class='row'>Build and launch a repository</h4>
+  <input type="hidden" id="provider_prefix" value="{{ provider_prefix or 'gh' }}"/>
   <div class="form-group row">
     <label for="repository">GitHub repo or URL</label>
     <input class="form-control" type="text" id="repository" placeholder="GitHub repository name or link" value="{{ url or '' }}"/>


### PR DESCRIPTION
Here is my attempt to fix #475.

The `index.html` form still support only GitHub repositories, but I believe we should now be able to handcraft links to binders with the gitlab or git providers, as I was trying to do.

I guess that someone else can later upgrade the form to support other git providers by making it possible to change the `provider_prefix` input.

Now, I've only tested this by following the [pure HTML/CSS/JS dev settup](https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md#pure-html--css--js-development) and adding and completing the `repo_providers` in `testing/localonly/binderhub_config.py`.  Then I tried the link given in #475 and made sure it would remain unchanged by the javascript code.  After that the loading fails with `Internal Server Error`, which I guess is expected.  (Setting up the full testing environment seems way too complicated for some evening hack.)