### PR TITLE
helm chart: load appendix as regular file

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -16,7 +16,7 @@ image:
 build:
   repo2dockerImage: jupyter/repo2docker:687788f
   nodeSelector: {}
-  appendix: null
+  appendix:
 
 perRepoQuota: 100
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -29,7 +29,10 @@ c.BinderHub.per_repo_quota = get_config('binder.per-repo-quota', 0)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
 c.BinderHub.build_node_selector = get_config('binder.build-node-selector', {})
-c.BinderHub.appendix = get_config('binder.appendix', '')
+
+if os.path.exists('/etc/binderhub/config/binder.appendix'):
+    with open('/etc/binderhub/config/binder.appendix') as f:
+        c.BinderHub.appendix = f.read()
 
 c.BinderHub.hub_url = get_config('binder.hub-url')
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']


### PR DESCRIPTION
rather than trying to parse as yaml, which eliminates newlines

This is needed to use the appendix in the helm chart (https://github.com/jupyterhub/mybinder.org-deploy/pull/502)