### PR TITLE
bump jupyterhub in helm chart

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-655cc71"
+  version: "v0.7.0-63bfc9b"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
gets kubespawner updates needed for self-culling pods