### PR TITLE
update registry, so that docker hub registry works

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -13,7 +13,7 @@ import tornado.ioloop
 import tornado.options
 import tornado.log
 import tornado.web
-from traitlets import Unicode, Integer, Bool, Dict, observe, validate, TraitError
+from traitlets import Unicode, Integer, Bool, Dict, observe, validate, TraitError, default
 from traitlets.config import Application
 
 from .base import Custom404
@@ -159,6 +159,33 @@ class BinderHub(Application):
         Set according to whatever registry you are pushing to.
 
         Defaults to "", which is probably not what you want :)
+        """,
+        config=True
+    )
+
+    docker_registry_host = Unicode(
+        "",
+        help="""
+        Docker registry host.
+        """,
+        config=True
+    )
+
+    docker_auth_host = Unicode(
+        help="""
+        Docker authentication host.
+        """,
+        config=True
+    )
+
+    @default('docker_auth_host')
+    def _docker_auth_host_default(self):
+        return self.docker_registry_host
+
+    docker_token_url = Unicode(
+        "",
+        help="""
+        Url to request docker registry authentication token.
         """,
         config=True
     )
@@ -340,7 +367,9 @@ class BinderHub(Application):
         jinja_options = dict(autoescape=True, )
         jinja_env = Environment(loader=FileSystemLoader(TEMPLATE_PATH), **jinja_options)
         if self.use_registry and self.builder_required:
-            registry = DockerRegistry(self.docker_image_prefix.split('/', 1)[0])
+            registry = DockerRegistry(self.docker_auth_host,
+                                      self.docker_token_url,
+                                      self.docker_registry_host)
         else:
             registry = None
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -226,7 +226,7 @@ class BuildHandler(BaseHandler):
         ).replace('_', '-').lower()
 
         if self.settings['use_registry']:
-            image_manifest = await self.registry.get_image_manifest(*image_name.split('/', 1)[1].split(':', 1))
+            image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
             image_found = bool(image_manifest)
         else:
             # Check if the image exists locally!

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -10,28 +10,24 @@ from tornado.httputil import url_concat
 
 
 class DockerRegistry:
-    def __init__(self, registry):
-        if not registry.startswith('https://'):
-            registry = 'https://' + registry
+    def __init__(self, auth_host, auth_token_url, registry_host):
         with open(os.path.expanduser('~/.docker/config.json')) as f:
             raw_auths = json.load(f)['auths']
 
         self.username, self.password = base64.b64decode(
-            raw_auths[registry]['auth'].encode('utf-8')
+            raw_auths[auth_host]['auth'].encode('utf-8')
         ).decode('utf-8').split(':', 1)
 
-        self.registry = registry
+        self.auth_token_url = auth_token_url
+        self.registry_host = registry_host
 
     @gen.coroutine
     def get_image_manifest(self, image, tag):
         client = httpclient.AsyncHTTPClient()
         # first, get a token to perform the manifest request
         auth_req = httpclient.HTTPRequest(
-            url_concat('{}/v2/token'.format(self.registry), {
-                # HACK: This won't work for all registries!
-                'service': self.registry.split('://', 1)[-1],
-                'scope': 'repository:{}:pull'.format(image),
-            }),
+            url_concat(self.auth_token_url,
+                       {'scope': 'repository:{}:pull'.format(image)}),
             auth_username=self.username,
             auth_password=self.password,
         )
@@ -39,7 +35,7 @@ class DockerRegistry:
         token = json.loads(auth_resp.body.decode('utf-8', 'replace'))['token']
 
         req = httpclient.HTTPRequest(
-            '{}/v2/{}/manifests/{}'.format(self.registry, image, tag),
+            '{}/v2/{}/manifests/{}'.format(self.registry_host, image, tag),
             headers={'Authorization': 'Bearer {}'.format(token)},
         )
         try:

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -16,5 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "imagePullSecret" }}
-{{- printf "{\"auths\": {\"https://%s\": {\"auth\": \"%s\"}}}" .Values.registry.host (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
+{{- $authHost := default .Values.registry.host .Values.registry.authHost -}}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $authHost (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
 {{- end }}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -7,6 +7,10 @@ data:
   {{ if .Values.registry.enabled -}}
   binder.push-secret: binder-secret
   binder.registry.host: {{ .Values.registry.host | quote }}
+  {{ if .Values.registry.authHost -}}
+  binder.registry.auth-host: {{ .Values.registry.authHost | quote }}
+  {{- end }}
+  binder.registry.auth-token-url: {{ .Values.registry.authTokenUrl | quote }}
   {{ end -}}
   {{ if .Values.googleAnalyticsCode -}}
   binder.google-analytics-code: {{ .Values.googleAnalyticsCode | quote }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -26,7 +26,9 @@ googleAnalyticsDomain:
 registry:
   enabled: false
   prefix: binderhub-local/
-  host: gcr.io
+  host: https://gcr.io
+  authHost:
+  authTokenUrl: https://gcr.io/v2/token?service=gcr.io
   username: _json_key
   password:
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -20,6 +20,11 @@ def get_config(key, default=None):
 c.BinderHub.debug = True
 
 c.BinderHub.docker_image_prefix = get_config('binder.registry.prefix')
+if get_config('binder.use-registry'):
+    c.BinderHub.docker_registry_host = get_config('binder.registry.host')
+    if get_config('binder.registry.auth-host'):
+        c.BinderHub.docker_auth_host = get_config('binder.registry.auth-host')
+    c.BinderHub.docker_token_url = get_config('binder.registry.auth-token-url')
 
 c.BinderHub.docker_push_secret = get_config('binder.push-secret')
 c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']


### PR DESCRIPTION
Hi,

Firstly I am not sure if this is a good implementation but I saw https://github.com/jupyterhub/binderhub/issues/486 and wanted share how we managed to use docker hub public registry. gcr should still work without changing any configuration.

Configuration to use docker hub registry:

- `secret.yaml`:
```
registry:
  username: <docker_hub_username>
  password: <docker_hub_password>
```
- `config.yaml`:
```
registry:
  enabled: true
  prefix: <user/organization_name>/<image_prefix>
  authHost: index.docker.io/v1
  authTokenUrl: https://auth.docker.io/token?service=registry.docker.io&scope=repository:{image}:pull
  imageManifestUrl: https://registry.hub.docker.com/v2/{image}/manifests/{tag}
```