### PR TITLE
Fix launching fav icons when base_url is used

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -263,7 +263,7 @@ $(function(){
           window.history.pushState({}, '', url);
         }
         updateUrlDiv(url);
-        update_favicon("/favicon_building.ico");
+        update_favicon(BASE_URL + "favicon_building.ico");
 
         // Update the text of the loading page if it exists
         if ($('div#loader-text').length > 0) {
@@ -304,7 +304,7 @@ $(function(){
 
             $("#loader").addClass("paused");
             $('div#loader-text p').html("Repository " + repo + " has failed to load!<br />See the logs for details.")
-            update_favicon("/favicon_fail.ico");
+            update_favicon(BASE_URL + "favicon_fail.ico");
             // If we fail for any reason, we will show logs!
             if (!logsVisible) {
                 $('#toggle-logs').click();
@@ -324,7 +324,7 @@ $(function(){
                 $('#phase-launching').removeClass('hidden');
             }
             $('#phase-launching').removeClass('hidden');
-            update_favicon("/favicon_success.ico");
+            update_favicon(BASE_URL + "favicon_success.ico");
         });
 
         image.onStateChange('ready', function(oldState, newState, data) {

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -61,7 +61,6 @@
           <div class="form-group col-md-2">
             <div class="btn-group" id="launch-buttons">
               <button id="submit" class="btn-submit" type="submit">launch</button>
-            </button>
             </div>
           </div>
         </div>
@@ -82,8 +81,6 @@
               <label>Copy the text below, then paste into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge.svg")}}"></label>
               <a id="badge-link"></a>
               <a href="#" title="show badge snippets"><span id="badge-snippet-caret" class="glyphicon glyphicon-triangle-right"></span></a>
-
-              </button>
             </div>
             <div id="badge-snippets" class="hidden">
               <!--Markdown section-->
@@ -136,8 +133,6 @@
             <div id="log"></div>
           </div>
         </div>
-
-
       </form>
     </div>
   </div>

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -8,7 +8,7 @@
 </script>
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>
-<link rel="stylesheet" href="{{static_url("loading.css")}}"
+<link rel="stylesheet" href="{{static_url("loading.css")}}">
 {% endblock head %}
 
 {% block main %}
@@ -63,7 +63,8 @@
         </div>
       </div>
     </div>
-  </form>
+  </div>
+</form>
 {% endblock main %}
 
 {% block footer %}


### PR DESCRIPTION
Hi, 

Currently fav icons (building, fail and succes) during launching don't work, if `base_url` is specified.

And there were some minor problems (redundant or missing closing tags) with html templates.

