### PR TITLE
disable git shallow-clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ helm-chart/binderhub/charts
 # Instructions we download
 k8s.txt
 helm.txt
+travis
+helm-chart/travis-binder.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,16 @@ script:
 - export BINDER_TEST_NAMESPACE=binder-test-$TEST
 - ./ci/test-$TEST
 after_failure:
-- for pod in $(kubectl get pod --namespace=$BINDER_TEST_NAMESPACE | awk '{print $1}'); do
+- |
+  # get pod logs
+  for pod in $(kubectl get pod --namespace=$BINDER_TEST_NAMESPACE | awk '{print $1}'); do
     echo $pod
     kubectl logs --namespace=$BINDER_TEST_NAMESPACE $pod
   done
 after_success:
 - codecov
 - |
+  # publish helm chart
   if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TEST" == "helm" ]]; then
     openssl aes-256-cbc -K $encrypted_d8355cc3d845_key -iv $encrypted_d8355cc3d845_iv -in travis.enc -out travis -d
     chmod 0400 travis
@@ -35,6 +38,7 @@ after_success:
     docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
     cd helm-chart
     chartpress --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
+    git diff
     cd ..
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - 3.6
+git:
+  depth: false
 services:
 - docker
 sudo: required

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,4 @@ pytest-cov
 pytest-tornado
 requests
 ruamel.yaml>=0.15
-https://github.com/jupyterhub/chartpress/archive/master.tar.gz
+https://github.com/jupyterhub/chartpress/archive/271c75e.tar.gz


### PR DESCRIPTION
Same as https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/621

shallow-clone can result in incorrect image tagging if image directories go without updates for a bit.

Additionally:

- show `git diff` after chartpress for easier debugging
- add nice heading comments for multi-line travis commands (style copied from mybinder.org-deploy)
- add a few travis files to .gitignore
- pin chartpress version so that updates there will not be used here except via explicit update