### PR TITLE
retry launch failures

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -438,6 +438,7 @@ class BuildHandler(BaseHandler):
         })
 
         launcher = self.settings['launcher']
+        retry_delay = launcher.retry_delay
         for i in range(launcher.retries):
             launch_starttime = time.perf_counter()
             username = launcher.username_from_repo(self.repo)
@@ -465,7 +466,9 @@ class BuildHandler(BaseHandler):
                     'phase': 'launching',
                     'message': 'Launch attempt {} failed, retrying...\n'.format(i + 1),
                 })
-                await gen.sleep((i + 1) * launcher.retry_delay)
+                await gen.sleep(retry_delay)
+                # exponential backoff for consecutive failures
+                retry_delay *= 2
                 continue
             else:
                 # success

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -443,13 +443,17 @@ class BuildHandler(BaseHandler):
             username = launcher.username_from_repo(self.repo)
             try:
                 server_info = await launcher.launch(image=self.image_name, username=username)
-                LAUNCH_TIME.labels(status='success', retries=i, **self.metric_labels).observe(time.perf_counter() - launch_starttime)
+                LAUNCH_TIME.labels(
+                    status='success', retries=i, **self.metric_labels
+                ).observe(time.perf_counter() - launch_starttime)
             except Exception as e:
                 if i + 1 == launcher.retries:
                     status = 'failure'
                 else:
                     status = 'retry'
-                LAUNCH_TIME.labels(status=status, retries=i, **self.metric_labels).observe(time.perf_counter() - launch_starttime)
+                LAUNCH_TIME.labels(
+                    status=status, retries=i, **self.metric_labels
+                ).observe(time.perf_counter() - launch_starttime)
 
                 if i + 1 == launcher.retries:
                     # last attempt failed, let it raise

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -30,7 +30,7 @@ BUILD_TIME = Histogram(
 LAUNCH_TIME = Histogram(
     'binderhub_launch_time_seconds',
     'Histogram of launch times',
-    ['status', 'provider', 'repo'],
+    ['status', 'provider', 'repo', 'retries'],
     buckets=BUCKETS)
 BUILDS_INPROGRESS = Gauge('binderhub_inprogress_builds', 'Builds currently in progress')
 LAUNCHES_INPROGRESS = Gauge('binderhub_inprogress_launches', 'Launches currently in progress')

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -56,7 +56,7 @@ class Launcher(LoggingConfigurable):
         req = HTTPRequest(self.hub_url + 'hub/api/' + url, *args, **kwargs)
         for i in range(1, self.retries + 1):
             try:
-                resp = await AsyncHTTPClient().fetch(req)
+                return await AsyncHTTPClient().fetch(req)
             except HTTPError as e:
                 # retry requests that fail with error codes greater than 500
                 # because they are likely intermittent issues in the cluster
@@ -67,7 +67,6 @@ class Launcher(LoggingConfigurable):
                     await gen.sleep(i * self.retry_delay)
                 else:
                     raise
-        return resp
 
     def username_from_repo(self, repo):
         """Generate a username for a git repo url

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -29,6 +29,10 @@ data:
   {{ if .Values.build.appendix -}}
   binder.appendix: {{ .Values.build.appendix | quote }}
   {{- end }}
+
+  binder.retries.count: {{ .Values.retries.count | quote }}
+  binder.retries.delay: {{ .Values.retries.delay | quote }}
+
   binder.hub-url: {{ .Values.hub.url | quote }}
   binder.base_url: {{ .Values.baseUrl | quote }}
 

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -11,7 +11,7 @@ rbac:
 
 retries:
   count: 4
-  delay: 10
+  delay: 4
 
 baseUrl: /
 nodeSelector: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -9,6 +9,10 @@ resources:
 rbac:
   enabled: true
 
+retries:
+  count: 4
+  delay: 10
+
 baseUrl: /
 nodeSelector: {}
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -71,6 +71,13 @@ if allow_origin:
         }
     })
 
+retries = get_config('binder.retries.count', None)
+if retries is not None:
+    c.Launcher.retries = retries
+
+retry_delay = get_config('binder.retries.delay', None)
+if retry_delay is not None:
+    c.Launcher.retry_delay = retry_delay
 
 for path in glob.glob('/etc/binderhub/config/extra-config.*.py'):
     load_subconfig(path)


### PR DESCRIPTION
Retries occur at two levels:

1. individual API requests, which will be retried in case of connection problems,
   which is ~all current failures, I think.
2. retry the full launch process (new user, etc.) in case of actual failure

TODO:

- [x] expose config in helm chart
- [x] decide metric updates. Should the launch timing be the user-visible time (including all retries in one time measurement), or time each launch attempt, e.g. adding 'retry' status for failed launches that will be attempted again.