### PR TITLE
bump jupyterhub

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-360849f"
+  version: "v0.7.0-4537a83"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
fixes for culler, which may be causing an outage of mybinder.org

updates to include https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/655 and thereby jupyterhub/jupyterhub#1807