### PR TITLE
rework image cleaner a bit

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -6,6 +6,7 @@ import logging
 import os
 from urllib.parse import urlparse
 
+import kubernetes.client
 import kubernetes.config
 from jinja2 import Environment, FileSystemLoader
 from tornado.httpclient import AsyncHTTPClient
@@ -360,6 +361,8 @@ class BinderHub(Application):
                 kubernetes.config.load_incluster_config()
             except kubernetes.config.ConfigException:
                 kubernetes.config.load_kube_config()
+            self.tornado_settings["kubernetes_client"] = kubernetes.client.CoreV1Api()
+
 
         # times 2 for log + build threads
         self.build_pool = ThreadPoolExecutor(self.concurrent_build_limit * 2)

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -88,7 +88,7 @@ class Build:
         docker_socket_path = urlparse(self.docker_host).path
         volumes = [client.V1Volume(
             name="docker-socket",
-            host_path=client.V1HostPathVolumeSource(path=docker_socket_path)
+            host_path=client.V1HostPathVolumeSource(path=docker_socket_path, type='Socket')
         )]
 
         if self.push_secret:

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -262,7 +262,7 @@ class BuildHandler(BaseHandler):
                 image_found = True
 
         # Launch a notebook server if the image already is built
-        kube = client.CoreV1Api()
+        kube = self.settings['kubernetes_client']
 
         if image_found:
             await self.emit({

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -67,3 +67,17 @@ def url_path_join(*pieces):
         result = '/'
 
     return result
+
+
+# FIXME: remove when instantiating a kubernetes client
+# doesn't create N-CPUs threads unconditionally.
+# monkeypatch threadpool in kubernetes api_client
+# to avoid instantiating ThreadPools.
+# This is known to work for kubernetes-4.0
+# and may need updating with later kubernetes clients
+
+from unittest.mock import Mock
+from kubernetes.client import api_client
+
+_dummy_pool = Mock()
+api_client.ThreadPool = lambda *args, **kwargs: _dummy_pool

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -32,32 +32,18 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: varlibdocker
+        - name: dockerlib-dind
           mountPath: /var/lib/docker
         - name: rundind
           mountPath: {{ .Values.dind.hostSocketDir }}
-      - name: image-cleaner
-        image: {{ .Values.imageCleaner.image.name }}:{{ .Values.imageCleaner.image.tag }}
-        volumeMounts:
-        - name: varlibdocker
-          mountPath: /var/lib/docker
-        - name: rundind
-          mountPath: {{ .Values.dind.hostSocketDir }}
-        command:
-        - python3
-        - /usr/local/bin/image-cleaner.py
-        env:
-        - name: PATH_TO_CHECK
-          value: /var/lib/docker
-        - name: INODE_AVAIL_THRESHOLD
-          value: {{ .Values.imageCleaner.inodeAvailThreshold | quote }}
-        - name: DOCKER_HOST
-          value: unix://{{ .Values.dind.hostSocketDir }}/docker.sock
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: varlibdocker
-        emptyDir: {}
+      - name: dockerlib-dind
+        hostPath:
+          path: {{ .Values.dind.hostLibDir }}
+          type: DirectoryOrCreate
       - name: rundind
         hostPath:
           path: {{ .Values.dind.hostSocketDir }}
+          type: DirectoryOrCreate
 {{- end }}

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -1,0 +1,64 @@
+{{ if .Values.imageCleaner.enabled -}}
+{{- $Values := .Values -}}
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-image-cleaner
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name:  {{ .Release.Name }}-image-cleaner
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-image-cleaner
+        app: binder
+        component: image-cleaner
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    spec:
+      containers:
+      {{- range $i, $kind := tuple "host" "dind" }}
+      {{- if or (and (eq $kind "dind") $Values.dind.enabled) (and (eq $kind "host") $Values.imageCleaner.host.enabled) }}
+      - name: image-cleaner-{{ $kind }}
+        image: {{ $Values.imageCleaner.image.name }}:{{ $Values.imageCleaner.image.tag }}
+        volumeMounts:
+        - name: dockerlib-{{ $kind }}
+          mountPath: /var/lib/docker
+        - name: dockersocket-{{ $kind }}
+          mountPath: /var/run/docker.sock
+        command:
+        - python3
+        - /usr/local/bin/image-cleaner.py
+        env:
+        - name: PATH_TO_CHECK
+          value: /var/lib/docker
+        - name: IMAGE_GC_THRESHOLD_HIGH
+          value: {{ $Values.imageCleaner.imageGCThresholdHigh | quote }}
+        - name: IMAGE_GC_THRESHOLD_LOW
+          value: {{ $Values.imageCleaner.imageGCThresholdLow | quote }}
+      {{- end }}
+      {{- end }}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: dockerlib-host
+        hostPath:
+          path: {{ .Values.imageCleaner.host.dockerLibDir }}
+      - name: dockersocket-host
+        hostPath:
+          path: {{ .Values.imageCleaner.host.dockerSocket }}
+          type: Socket
+      {{- if .Values.dind.enabled }}
+      - name: dockerlib-dind
+        hostPath:
+          path: {{ .Values.dind.hostLibDir }}
+          type: DirectoryOrCreate
+      - name: dockersocket-dind
+        hostPath:
+          path: {{ .Values.dind.hostSocketDir }}/docker.sock
+          type: Socket
+      {{- end }}
+
+{{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -159,13 +159,23 @@ dind:
       tag: 17.11.0-ce-dind
   storageDriver: overlay2
   hostSocketDir: /var/run/dind
+  hostLibDir: /var/lib/dind
 
 imageCleaner:
+  enabled: true
   image:
     name: jupyterhub/k8s-image-cleaner
     tag: local
     repository: jupyterhub/k8s-image-cleaner
-  inodeAvailThreshold: 0.8
+  # when 80% of inodes are used,
+  # cull images until it drops below 60%
+  imageGCThresholdHigh: 80
+  imageGCThresholdLow: 60
+  # cull images on the host docker as well as dind
+  host:
+    enabled: true
+    dockerSocket: /var/run/docker.sock
+    dockerLibDir: /var/lib/docker
 
 ingress:
   enabled: false

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -3,3 +3,5 @@ FROM python:3.6-alpine3.6
 ADD image-cleaner.py /usr/local/bin/image-cleaner.py
 
 RUN pip3 install --no-cache-dir docker==3.2.1
+
+CMD image-cleaner.py

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.6-alpine3.6
 
 ADD image-cleaner.py /usr/local/bin/image-cleaner.py
 
-RUN pip3 install --no-cache-dir docker
+RUN pip3 install --no-cache-dir docker==3.2.1

--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -48,7 +48,7 @@ def main():
     client = docker.from_env(version='auto')
     images = get_docker_images(client)
 
-    print(f'Pruning docker images when {path_to_check} has used {inode_gc_high}% inodes used')
+    print(f'Pruning docker images when {path_to_check} has {inode_gc_high}% inodes used')
 
     while True:
         inodes_used = get_inodes_used_percent(path_to_check)

--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -41,7 +41,7 @@ def main():
     client = docker.from_env(version='auto')
     images = get_docker_images(client)
 
-    print(f'Pruning docker images when {path_to_check} has less than {inode_avail_threshold * 100}% inodes free')
+    print(f'Pruning docker images when {path_to_check} has less than {inode_avail_threshold * 100:.1f}% inodes free')
 
     while True:
         inode_avail = get_inodes_available_fraction(path_to_check)
@@ -53,7 +53,7 @@ def main():
             if not images:
                 print(f'No images to delete but only {inode_avail * 100}% inodes available')
             else:
-                print(f'{inode_avail * 100}% inodes available, pruning from {len(images)} images')
+                print(f'{inode_avail * 100:.1f}% inodes available, pruning from {len(images)} images')
 
             while images and get_inodes_available_fraction(path_to_check) < inode_avail_threshold:
                 if not images:

--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -11,6 +11,7 @@ import os
 import time
 
 import docker
+import requests
 
 
 def get_inodes_used_percent(path):
@@ -60,7 +61,7 @@ def main():
             if not images:
                 print(f'No images to delete')
             else:
-                print(f'Pruning from {len(images)} images')
+                print(f'{len(images)} images available to prune')
 
             while images and get_inodes_used_percent(path_to_check) > inode_gc_low:
                 # Remove biggest image
@@ -83,6 +84,8 @@ def main():
                         print(str(e))
                     else:
                         raise
+                except requests.exceptions.ReadTimeout:
+                    print(f'Timeout removing {name}')
         time.sleep(60)
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'kubernetes==3.*',
+        'kubernetes==4.*',
         'escapism',
         'tornado',
         'traitlets',


### PR DESCRIPTION
- clean images on both dind and host docker,
  since host docker contains the vast majority of used images.
- run image cleaner as its own daemonset, rather than inside dind, since it should run even when dind doesn't. This also prevents the need to relaunch dind when the image cleaner changes, which takes a long time.
- prioritize deleting untagged images so we remove images such as failed build products first
- match image-gc config to kubernetes' own as much as possible:
  - units are percent instead of fractions (80 instead of 0.8)
  - units refer to 'used' rather than 'available' (80 means )
  - add high/low thresholds so when high threshold is exceeded, images are reclaimed until the low threshold is passed
  - config is now `imageGCThreshold[High|Low]`, matching the names in kubernetes

The default thresholds are 80/60: when 80% of inodes are used, cull images until the number drops below 60%

includes #539