### PR TITLE
Mark form field as "ignore this" for LastPass

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -23,7 +23,7 @@
         <input type="hidden" id="provider_prefix" value="gh"/>
         <div class="form-group row">
           <label for="repository">GitHub repo or URL</label>
-          <input class="form-control" type="text" id="repository" placeholder="GitHub repository name or link"/>
+          <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="GitHub repository name or link"/>
         </div>
         <div class="form-row row">
           <div class="form-group col-md-4">


### PR DESCRIPTION
LastPass keeps suggesting that it can fill out the repo link form field. I can't quite work out why it thinks this is a login form, so instead added this annotation to stop it from making suggestions.