### PR TITLE
Cache GitHub ref resolutions

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -348,7 +348,7 @@ class BinderHub(Application):
         # hook up tornado logging
         if self.debug:
             self.log_level = logging.DEBUG
-        tornado.options.logging = logging.getLevelName(self.log_level)
+        tornado.options.options.logging = logging.getLevelName(self.log_level)
         tornado.log.enable_pretty_logging()
         self.log = tornado.log.app_log
 

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -1,3 +1,5 @@
+"""Miscellaneous utilities"""
+from collections import OrderedDict
 from traitlets import Integer, TraitError
 
 
@@ -44,6 +46,33 @@ class ByteSpecification(Integer):
             raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
         else:
             return int(float(num) * self.UNIT_SUFFIXES[suffix])
+
+
+class Cache(OrderedDict):
+    """Basic LRU Cache with get/set"""
+    def __init__(self, max_size=1024):
+        self.max_size = max_size
+
+    def get(self, key, default=None):
+        """Get an item from the cache
+
+        same as dict.get
+        """
+        if key in self:
+            self.move_to_end(key)
+        return super().get(key, default)
+
+    def set(self, key, value):
+        """Store an item in the cache
+
+        - if already there, moves to the most recent
+        - if full, delete the oldest item
+        """
+        self[key] = value
+        self.move_to_end(key)
+        if len(self) > self.max_size:
+            first_key = next(iter(self))
+            self.pop(first_key)
 
 
 def url_path_join(*pieces):


### PR DESCRIPTION
Since the majority of launches are of stable/popular repos (e.g. ipython/ipython-in-depth/master)
Using ETag / If-None-Modified allows us to cache responses and reduce consumption of the API limit

No reduction in HTTP requests is made, but GitHub does not count cache hits against the rate limit. Cache is least-recently-used (LRU) with a max size of 1024 entries. Since each entry is a two-key dict, this should still be quite small.

Cache is only in memory, so relaunching BinderHub resets the cache.

closes #543