### PR TITLE
Enable template extension

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -480,7 +480,7 @@ class BinderHub(Application):
             (r'.*', Custom404),
         ]
         if self.extra_static_path:
-            handlers.insert(-2, (re.escape(self.extra_static_url_prefix) + r"(.*)",
+            handlers.insert(-1, (re.escape(self.extra_static_url_prefix) + r"(.*)",
                                  tornado.web.StaticFileHandler,
                                  {'path': self.extra_static_path}))
         handlers = self.add_url_prefix(self.base_url, handlers)

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -7,7 +7,7 @@ from tornado import web
 class BaseHandler(web.RequestHandler):
     @property
     def template_namespace(self):
-        return dict(static_url=self.static_url)
+        return dict(static_url=self.static_url, **self.settings.get('template_variables', {}))
 
     def set_default_headers(self):
         headers = self.settings.get('headers', {})

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -11,13 +11,16 @@
   <div class="row">
     <h4 class="text-center logo-subtext">(beta)</h4>
     <div class="col-lg-10 col-lg-offset-1">
+      {% block header %}
       <div id="header" class="text-center">
         <h3>Turn a GitHub repo into a collection of interactive notebooks</h3>
         <div id="explanation">
           Have a repository full of Jupyter notebooks? With Binder, open those notebooks in an executable environment, making your code immediately reproducible by anyone, anywhere.
         </div>
       </div>
+      {% endblock header %}
 
+      {% block form %}
       <form id="build-form" class="form jumbotron">
         <h4 id="form-header" class='row'>Build and launch a repository</h4>
         <input type="hidden" id="provider_prefix" value="gh"/>
@@ -130,8 +133,10 @@
           </div>
         </div>
       </form>
+      {% endblock form %}
     </div>
   </div>
+  {% block how_it_works %}
   <div id="how-it-works">
     <h3 class="text-center">How it works</h3>
 
@@ -162,6 +167,7 @@
       </div>
     </div>
   </div>
+  {% endblock how_it_works %}
 </div>
 {% endblock main %}
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -15,11 +15,11 @@
   <div class="container">
     <div class="row">
       <div id="logo-container">
-        <img id="logo" src="{{static_url("logo.svg")}}" width="390px"  />
+        <img id="logo" src={% block logo_image %}"{{static_url("logo.svg")}}"{% endblock logo_image %} width="390px"  />
       </div>
     </div>
   </div>
-  {% endblock %}
+  {% endblock logo %}
 
   {% block main %}
   {% endblock main %}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -44,6 +44,12 @@ data:
   {{- end }}
   {{ if .Values.template.path -}}
   template.path: {{ .Values.template.path | quote }}
+  {{ if .Values.template.static.path -}}
+  template.static.path: {{ .Values.template.static.path | quote }}
+  {{- end }}
+  {{ if .Values.template.static.urlPrefix -}}
+  template.static.url-prefix: {{ .Values.template.static.urlPrefix | quote }}
+  {{- end }}
   {{- end }}
 
   dind.enabled: {{ .Values.dind.enabled | quote }}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -39,6 +39,13 @@ data:
   gitlab.hostname: {{ .Values.gitlab.hostname | quote }}
   {{- end }}
 
+  {{ if .Values.template.variables -}}
+  template.variables: {{ toJson .Values.template.variables | quote }}
+  {{- end }}
+  {{ if .Values.template.path -}}
+  template.path: {{ .Values.template.path | quote }}
+  {{- end }}
+
   dind.enabled: {{ .Values.dind.enabled | quote }}
   {{ if .Values.dind.enabled }}
   dind.host-socket-dir: {{ .Values.dind.hostSocketDir | quote }}

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         checksum/config-map: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      {{ if .Values.initContainers -}}
+      initContainers:
+{{ toYaml .Values.initContainers | indent 6 }}
+      {{- end }}
       nodeSelector: {{ toJson .Values.nodeSelector }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: binderhub
@@ -47,6 +51,9 @@ spec:
         hostPath:
           path: /var/run/docker.sock
       {{- end }}
+      {{ if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{ end }}
       containers:
       - name: binder
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
@@ -61,6 +68,9 @@ spec:
           - mountPath: /var/run/docker.sock
             name: docker-socket
           {{- end }}
+          {{ if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+          {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 12}}
         imagePullPolicy: IfNotPresent

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -196,6 +196,12 @@ ingress:
 template:
   variables: {}
   path:
+  # to use extra static files in templates.
+  # they are looked up after binder base static files.
   static:
     path:
     urlPrefix: extra_static/
+
+initContainers: []
+extraVolumes: []
+extraVolumeMounts: []

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -192,3 +192,7 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
+
+template:
+  variables: {}
+  path:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -196,3 +196,6 @@ ingress:
 template:
   variables: {}
   path:
+  static:
+    path:
+    urlPrefix: extra_static/

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -68,6 +68,12 @@ if template_variables:
 template_path = get_config('template.path')
 if template_path:
     c.BinderHub.template_path = template_path
+    static_path = get_config('template.static.path')
+    if static_path:
+        c.BinderHub.extra_static_path = static_path
+    static_url_prefix = get_config('template.static.url-prefix')
+    if static_url_prefix:
+        c.BinderHub.extra_static_url_prefix = static_url_prefix
 
 cors = get_config('binder.cors', {})
 allow_origin = cors.get('allowOrigin')

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -62,6 +62,13 @@ gitlab_hostname = get_config('gitlab.hostname')
 if gitlab_hostname:
     c.GitHubRepoProvider.hostname = gitlab_hostname
 
+template_variables = get_config('template.variables')
+if template_variables:
+    c.BinderHub.template_variables = template_variables
+template_path = get_config('template.path')
+if template_path:
+    c.BinderHub.template_path = template_path
+
 cors = get_config('binder.cors', {})
 allow_origin = cors.get('allowOrigin')
 if allow_origin:


### PR DESCRIPTION
https://github.com/jupyterhub/binderhub/commit/6e194dde00f196edf31a095ef65572ac8c4db5df enables extension of base binder templates by supplying new templates under `template_path` and also adding new templates variables with `template_variables`.  `template_path` is where new templates are located. Base templates are loaded both with and without `templates/` prefix, so new templates can extend base templates by including `{% extends "templates/<template_name>.html" %}`, otherwise it overwrites the base template. An example configuration:
```bash
template:
  variables:
    var1: value1
    var2: value2
  path: /etc/binderhub/templates
```

I am not sure about https://github.com/jupyterhub/binderhub/commit/281b1cb2b172aed7f30847b2b1b9c187dff27de8. The idea was that users can supply extra static files to be used in new templates, so they are also served by binder app as other static files. To do that `extra_static_path` (where extra static files are located) must be defined and in templates source of extra static files must be defined as `"/<base_url>/<extra_static_url_prefix>/<static_file_path>"`. Do you think that this is a good idea?

related to https://github.com/jupyterhub/binderhub/issues/260
This PR is based on https://github.com/jupyterhub/jupyterhub/pull/1601