### PR TITLE
Stop the 'show logs' button from starting a new job.

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -123,7 +123,7 @@
         <div id="log-container" class="panel panel-default on-build hidden row">
           <div id="toggle-logs" class="panel-heading">
             Build logs
-            <button class="btn btn-link btn-xs pull-right">show</button>
+            <button type="button" class="btn btn-link btn-xs pull-right">show</button>
           </div>
           <div class="panel-body hidden">
             <div id="log"></div>


### PR DESCRIPTION
The type for the show logs button wasn't set and since buttons have [submit type by default](https://www.w3.org/TR/2011/WD-html5-20110525/the-button-element.html#the-button-element), clicking it would submit the form and cause a new job to start.