### PR TITLE
set PYTHONUNBUFFERED=1 in image-cleaner

### DIFF
--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.6-alpine3.6
 ADD image-cleaner.py /usr/local/bin/image-cleaner.py
 
 RUN pip3 install --no-cache-dir docker==3.2.1
-
+# set PYTHONUNBUFFERED to ensure output is produced
+ENV PYTHONUNBUFFERED=1
 CMD image-cleaner.py


### PR DESCRIPTION
Python seems to produce no output in some container scenarios without this env

I'm not sure why logging doesn't have this issue while printing does.