### PR TITLE
avoid debug-level logging from curl_httpclient

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -341,6 +341,12 @@ class BinderHub(Application):
             AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
         except ImportError as e:
             self.log.debug("Could not load pycurl: %s\npycurl is recommended if you have a large number of users.", e)
+        # set max verbosity of curl_httpclient at INFO
+        # because debug-logging from curl_httpclient
+        # includes every full request and response
+        if self.log_level < logging.INFO:
+            curl_log = logging.getLogger('tornado.curl_httpclient')
+            curl_log.setLevel(logging.INFO)
 
     def initialize(self, *args, **kwargs):
         """Load configuration settings."""

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 metadata:
   name: binder-config
 data:
+  binder.debug: {{ .Values.debug.enabled | quote }}
   binder.use-registry: {{ .Values.registry.enabled | quote }}
   {{ if .Values.registry.enabled -}}
   binder.push-secret: binder-secret

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -1,3 +1,6 @@
+debug:
+  enabled: false
+
 resources:
   requests:
     cpu: 0.2

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -17,7 +17,7 @@ def get_config(key, default=None):
     except FileNotFoundError:
         return default
 
-c.BinderHub.debug = True
+c.BinderHub.debug = get_config('binder.debug.enabled', False)
 
 c.BinderHub.docker_image_prefix = get_config('binder.registry.prefix')
 if get_config('binder.use-registry'):


### PR DESCRIPTION
curl_httpclient logs way too much (all requests and responses) at debug-level.

- Avoids setting log-level for curl lower than INFO, even if the rest of the app has debug logging enabled
- Stops setting log-level to debug in the helm chart