### PR TITLE
remove redundant ‘-container’ from binder container name

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           path: /var/run/docker.sock
       {{- end }}
       containers:
-      - name: binder-container
+      - name: binder
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         volumeMounts:
           - mountPath: /etc/binderhub/config/


### PR DESCRIPTION
it shows up in logs