### PR TITLE
bump jupyterhub chart

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-b4ea9e7"
+  version: "v0.7.0-673f0f1"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
Bump JupyterHub chart. The main relevant change for us is the update to jupyterhub 0.9b1. I will deploy this assuming it passes as part of the scheduled BinderHub deploy today.

Diff:

https://github.com/jupyterhub/zero-to-jupyterhub/compare/b4ea9e7...673f0f1