### PR TITLE
temp fix: disable cordoning

### DIFF
--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -43,6 +43,9 @@ def get_docker_images(client):
 
 def cordon(kube, node):
     """cordon a kubernetes node"""
+    # FIXME: cordoning permission doesn't work yet
+    print("CORDONING DISABLED")
+    return
     kube.patch_node(
         node,
         {
@@ -55,6 +58,8 @@ def cordon(kube, node):
 
 def uncordon(kube, node):
     """uncordon a kubernetes node"""
+    # FIXME: cordoning permission doesn't work yet
+    print("CORDONING DISABLED")
     kube.patch_node(
         node,
         {
@@ -75,8 +80,8 @@ def main():
         except Exception:
             kubernetes.config.load_kube_config()
         kube = kubernetes.client.CoreV1Api()
-        # verify that we can talk to the node
-        kube.read_node(node)
+        # FIXME: verify that we can talk to the node
+        # kube.read_node(node)
 
 
     path_to_check = os.getenv('PATH_TO_CHECK', '/var/lib/docker')


### PR DESCRIPTION
since permissions aren't quite right

It works in minikube, but not in production due to permission errors:

```
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"nodes \"gke-staging-default-pool-80145d64-q25t\" is forbidden: User \"system:serviceaccount:staging:image-cleaner\" cannot get nodes at the cluster scope: Unknown user \"system:serviceaccount:staging:image-cleaner\"","reason":"Forbidden","details":{"name":"gke-staging-default-pool-80145d64-q25t","kind":"nodes"},"code":403}
```

Presumably because the Role should have been a ClusterRole or something to that effect.