### PR TITLE
forcing node to be cordoned in image cleaner

### DIFF
--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -109,6 +109,8 @@ def main():
                 cordon(kube, node)
 
             while images and get_inodes_used_percent(path_to_check) > inode_gc_low:
+                # Ensure the node is still cordoned
+                cordon(kube, node)
                 # Remove biggest image
                 image = images.pop(0)
                 if image.tags:


### PR DESCRIPTION
Adds a quick `cordon(..` to the top of the image cleaner "while" loop so that we ensure the node is cordoned while cleaning is happening