### PR TITLE
reduce docker load in image cleaner

### DIFF
--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -42,6 +42,8 @@ spec:
               fieldPath: spec.nodeName
         - name: PATH_TO_CHECK
           value: /var/lib/docker
+        - name: IMAGE_GC_DELAY
+          value: {{ $Values.imageCleaner.delay | quote }}
         - name: IMAGE_GC_THRESHOLD_HIGH
           value: {{ $Values.imageCleaner.imageGCThresholdHigh | quote }}
         - name: IMAGE_GC_THRESHOLD_LOW

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -170,6 +170,8 @@ imageCleaner:
     name: jupyterhub/k8s-image-cleaner
     tag: local
     repository: jupyterhub/k8s-image-cleaner
+  # delete an image at most every 5 seconds
+  delay: 5
   # when 80% of inodes are used,
   # cull images until it drops below 60%
   imageGCThresholdHigh: 80

--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -105,6 +105,9 @@ def main():
             else:
                 logging.info(f'{len(images)} images available to prune')
 
+            start = time.perf_counter()
+            images_before = len(images)
+
             if node:
                 logging.info(f"Cordoning node {node}")
                 cordon(kube, node)
@@ -149,6 +152,12 @@ def main():
             if node:
                 logging.info(f"Uncordoning node {node}")
                 uncordon(kube, node)
+
+            # log what we did and how long it took
+            duration = time.perf_counter() - start
+            images_deleted = len(images) - images_before
+            logging.info(f"Deleted {images_deleted} images in {int(duration)} seconds")
+
         time.sleep(60)
 
 


### PR DESCRIPTION
- add IMAGE_GC_DELAY delay between deletions
- wait to move on to the next image after a deletion times out

This should hopefully prevent the image cleaner rendering docker itself being unresponsive for extended periods, which seems to happen when we greedily schedule image deletions one after another even when the requests timeout (itself an indication that docker isn't keeping up).