### PR TITLE
Bump the JupyterHub chart version to get rebuilt hub image

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-969bdad"
+  version: "v0.7.0-7d17a57"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/969bdad...7d17a57 touched the dockerfile to force a rebuild.

A full fix for chartpress is in https://github.com/jupyterhub/chartpress/pull/12