### PR TITLE
tell single-user containers to trust x-headers

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -119,6 +119,7 @@ jupyterhub:
                   '--port=%i' % self.port,
                   '--NotebookApp.base_url=%s' % self.server.base_url,
                   '--NotebookApp.token=%s' % self.user_options['token'],
+                  '--NotebookApp.trust_xheaders=True',
               ]
               allow_origin = cors.get('allowOrigin')
               if allow_origin:

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -28,6 +28,7 @@ hub:
                 '--port=%i' % self.port,
                 '--NotebookApp.base_url=%s' % self.server.base_url,
                 '--NotebookApp.token=%s' % self.user_options['token'],
+                '--NotebookApp.trust_xheaders=True',
                 '--NotebookApp.allow_origin=*',
             ] + self.args
 


### PR DESCRIPTION
for logging real ip addresses

counterpart to #584, which fixes logging of addresses in the Binder container. This fixes logging in user containers. This matches the default behavior of `jupyterhub-singleuser`, since it is necessarily always proxied (by CHP, even if no additional proxies are in front)

closes #524