### PR TITLE
nbviewer preview for github notebooks

### DIFF
--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -92,6 +92,7 @@ div#log-container {
 
 .preview {
   margin-top: 40px;
+  width: 70%;
 }
 
 #nbviewer-preview > iframe {

--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -89,3 +89,13 @@ div#log-container {
 .hidden {
     display: none;
 }
+
+.preview {
+  margin-top: 40px;
+}
+
+#nbviewer-preview > iframe {
+  width: 100%;
+  height: 80vh;
+  border: 1px solid #aaa;
+}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -24,6 +24,25 @@
   </div>
 </div>
 
+{% block preview %}
+<p class="preview-text text-center">
+Here's a preview on
+<a href="https://nbviewer.jupyter.org">nbviewer</a>
+while we start a server for you.
+</p>
+{# we can only produce an nbviewer URL for github right now #}
+{% set prefix, repo_ref = provider_spec.split('/', 1) %}
+{% if prefix == "gh" %}
+{% set repo, ref = repo_ref.rsplit('/', 1) %}
+<div id="nbviewer-preview">
+    <iframe
+        src="https://nbviewer.jupyter.org/github/{{repo}}/tree/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
+        style="width: 80%; margin-left: 10%; height: 80vh; border: 1px solid #aaa;"
+    >
+</div>
+{% endif %}
+{% endblock preview %}
+
 {% endblock main %}
 
 {% block footer %}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -25,20 +25,22 @@
 </div>
 
 {% block preview %}
-<p class="preview-text text-center">
-Here's a preview on
-<a href="https://nbviewer.jupyter.org">nbviewer</a>
-while we start a server for you.
-</p>
 {# we can only produce an nbviewer URL for github right now #}
 {% set prefix, repo_ref = provider_spec.split('/', 1) %}
 {% if prefix == "gh" %}
+<div class="preview container">
+<p class="preview-text text-center">
+Here's a non-interactive preview on
+<a href="https://nbviewer.jupyter.org">nbviewer</a>
+while we start a server for you.
+Your binder will open automatically when it is ready.
+</p>
 {% set repo, ref = repo_ref.rsplit('/', 1) %}
 <div id="nbviewer-preview">
-    <iframe
-        src="https://nbviewer.jupyter.org/github/{{repo}}/tree/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
-        style="width: 80%; margin-left: 10%; height: 80vh; border: 1px solid #aaa;"
-    >
+  <iframe
+    src="https://nbviewer.jupyter.org/github/{{repo}}/tree/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
+  ></iframe>
+</div>
 </div>
 {% endif %}
 {% endblock preview %}


### PR DESCRIPTION
Load nbviewer.jupyter.org in an iframe for quicker previews of notebooks while waiting for the Binder to launch:

<img width="748" alt="screen shot 2018-06-20 at 23 18 17" src="https://user-images.githubusercontent.com/151929/41685379-8501ec0c-74e0-11e8-80fd-7d83b65e625e.png">

only enabled for GitHub right now, which is the only provider currently supported by both services.

Still a WIP for various UI questions.

This implements a proposal in #501 where there is discussion about whether notebooks should get special treatment. I think it *is* appropriate to treat notebooks specially, as long as others don't suffer as a result. For instance, we could restrict this to only `if filepath.endswith('.ipynb')` so that we don't load nbviewer for repos that run something like rstudio. That said, the nbviewer file navigator is still useful for browsing any repo of files, not just notebooks, so maybe it's still useful.

cc @nthiery