### PR TITLE
remove the spurious hub.services.binder.apiToken in the docs

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -49,10 +49,6 @@ Create a file called ``secret.yaml`` and add the following::
             apiToken: "<output of FIRST `openssl rand -hex 32` command>"
       proxy:
         secretToken: "<output of SECOND `openssl rand -hex 32` command>"
-  hub:
-    services:
-      binder:
-        apiToken: "<output of FIRST `openssl rand -hex 32` command>"
 
 Next, we'll configure this file to connect with our registry.
 


### PR DESCRIPTION
removes the spurious `hub.services.binder.apiToken` in the docs.

issue: https://github.com/jupyterhub/binderhub/issues/592