### PR TITLE
[WIP] support authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ after_success:
 env:
   matrix:
   - TEST=main
+  - TEST=auth
   - TEST=helm
   global:
   - MINIKUBE_VERSION=0.24.1

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -266,6 +266,10 @@ class BinderHub(Application):
         help="""API token for talking to the JupyterHub API""",
         config=True,
     )
+
+    hub_api_url = Unicode(os.getenv('JUPYTERHUB_API_URL'),
+                          help="The URL of the Hub API")
+
     hub_url = Unicode(
         help="""
         The base URL of the JupyterHub instance where users will run.
@@ -452,6 +456,7 @@ class BinderHub(Application):
         self.launcher = Launcher(
             parent=self,
             hub_url=self.hub_url,
+            hub_api_url=self.hub_api_url,
             hub_api_token=self.hub_api_token,
             create_user=not self.auth_enabled,
         )

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -267,9 +267,6 @@ class BinderHub(Application):
         config=True,
     )
 
-    hub_api_url = Unicode(os.getenv('JUPYTERHUB_API_URL'),
-                          help="The URL of the Hub API")
-
     hub_url = Unicode(
         help="""
         The base URL of the JupyterHub instance where users will run.
@@ -456,7 +453,6 @@ class BinderHub(Application):
         self.launcher = Launcher(
             parent=self,
             hub_url=self.hub_url,
-            hub_api_url=self.hub_api_url,
             hub_api_token=self.hub_api_token,
             create_user=not self.auth_enabled,
         )
@@ -466,8 +462,6 @@ class BinderHub(Application):
             "docker_image_prefix": self.docker_image_prefix,
             "github_auth_token": self.github_auth_token,
             "debug": self.debug,
-            'hub_url': self.hub_url,
-            'hub_api_token': self.hub_api_token,
             'launcher': self.launcher,
             'appendix': self.appendix,
             "build_namespace": self.build_namespace,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -96,6 +96,11 @@ class BinderHub(Application):
             proposal.value = proposal.value + '/'
         return proposal.value
 
+    auth_enabled = Bool(
+        False,
+        help="If JupyterHub authentication enabled, don't create users during launch.",
+        config=True)
+
     port = Integer(
         8585,
         help="""
@@ -448,6 +453,7 @@ class BinderHub(Application):
             parent=self,
             hub_url=self.hub_url,
             hub_api_token=self.hub_api_token,
+            create_user=not self.auth_enabled,
         )
 
         self.tornado_settings.update({
@@ -479,6 +485,7 @@ class BinderHub(Application):
             'static_url_prefix': url_path_join(self.base_url, 'static/'),
             'template_variables': self.template_variables,
             'executor': self.executor,
+            'auth_enabled': self.auth_enabled,
         })
 
         handlers = [

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -233,18 +233,6 @@ class BinderHub(Application):
         config=True
     )
 
-    # TODO: Factor this out!
-    github_auth_token = Unicode(
-        None,
-        allow_none=True,
-        help="""
-        GitHub OAuth token to use for talking to the GitHub API.
-
-        Might get throttled otherwise!
-        """,
-        config=True
-    )
-
     debug = Bool(
         False,
         help="""
@@ -468,7 +456,6 @@ class BinderHub(Application):
         self.tornado_settings.update({
             "docker_push_secret": self.docker_push_secret,
             "docker_image_prefix": self.docker_image_prefix,
-            "github_auth_token": self.github_auth_token,
             "debug": self.debug,
             'launcher': self.launcher,
             'appendix': self.appendix,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -98,7 +98,9 @@ class BinderHub(Application):
 
     auth_enabled = Bool(
         False,
-        help="If JupyterHub authentication enabled, don't create users during launch.",
+        help="""If JupyterHub authentication enabled, 
+        require user to login (don't create temporary users during launch) and 
+        start the new server for the logged in user.""",
         config=True)
 
     port = Integer(

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -109,6 +109,11 @@ class BinderHub(Application):
         help="""If oauth is used, use `HubOAuth` as hub authentication class.""",
         config=True)
 
+    use_named_servers = Bool(
+        False,
+        help="Use named servers when authentication is enabled.",
+        config=True)
+
     port = Integer(
         8585,
         help="""
@@ -481,6 +486,7 @@ class BinderHub(Application):
             'executor': self.executor,
             'auth_enabled': self.auth_enabled,
             'use_oauth': self.use_oauth,
+            'use_named_servers': self.use_named_servers,
         })
         if self.auth_enabled and self.use_oauth:
             self.tornado_settings['cookie_secret'] = os.urandom(32)

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -28,6 +28,15 @@ class BaseHandler(HubAuthenticated, web.RequestHandler):
             self.set_header(header, value)
         self.set_header("access-control-allow-headers", "cache-control")
 
+    def get_spec_from_request(self, prefix):
+        """Re-extract spec from request.path.
+        Get the original, raw spec, without tornado's unquoting.
+        This is needed because tornado converts 'foo%2Fbar/ref' to 'foo/bar/ref'.
+        """
+        idx = self.request.path.index(prefix)
+        spec = self.request.path[idx + len(prefix) + 1:]
+        return spec
+
     def get_provider(self, provider_prefix, spec):
         """Construct a provider object"""
         providers = self.settings['repo_providers']

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -2,7 +2,7 @@
 
 from http.client import responses
 from tornado import web
-from jupyterhub.services.auth import HubAuthenticated, HubOAuthenticated
+from jupyterhub.services.auth import HubAuthenticated, HubOAuth
 import functools
 from urllib.parse import urlencode
 
@@ -35,6 +35,11 @@ def authenticated(method):
 
 class BaseHandler(HubAuthenticated, web.RequestHandler):
     """HubAuthenticated by default allows all successfully identified users (see allow_all property)."""
+
+    def initialize(self):
+        super().initialize()
+        if self.settings['use_oauth'] is True:
+            self.hub_auth_class = HubOAuth
 
     @property
     def template_namespace(self):

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -38,7 +38,7 @@ class BaseHandler(HubAuthenticated, web.RequestHandler):
 
     def initialize(self):
         super().initialize()
-        if self.settings['use_oauth'] is True:
+        if self.settings['auth_enabled'] and self.settings['use_oauth']:
             self.hub_auth_class = HubOAuth
 
     @property

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -2,10 +2,8 @@
 
 from http.client import responses
 from tornado import web
-# TODO HubOAuthenticated condition
 from jupyterhub.services.auth import HubAuthenticated, HubOAuthenticated
 import functools
-import urllib.parse as urlparse
 from urllib.parse import urlencode
 
 
@@ -35,16 +33,10 @@ def authenticated(method):
 
 
 class BinderHubAuthenticated(HubAuthenticated):
-    hub_services = None  # set of allowed services
-    hub_users = None  # set of allowed users
-    hub_groups = None  # set of allowed groups
-    allow_admin = True  # allow any admin user access
-
-    # def initialize(self, hub_auth):
-    def initialize(self):
-        # self.hub_auth = hub_auth
-        self.hub_auth.api_token = self.settings['hub_api_token']
-        self.hub_auth.hub_host = self.settings['hub_url'].rstrip('/')
+    # allow_all -> True: all successfully identified user or service should be allowed
+    hub_services = None
+    hub_users = None
+    hub_groups = None
 
 
 class BaseHandler(BinderHubAuthenticated, web.RequestHandler):

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -32,14 +32,9 @@ def authenticated(method):
     return wrapper
 
 
-class BinderHubAuthenticated(HubAuthenticated):
-    # allow_all -> True: all successfully identified user or service should be allowed
-    hub_services = None
-    hub_users = None
-    hub_groups = None
+class BaseHandler(HubAuthenticated, web.RequestHandler):
+    """HubAuthenticated by default allows all successfully identified users (allow_all property)."""
 
-
-class BaseHandler(BinderHubAuthenticated, web.RequestHandler):
     @property
     def template_namespace(self):
         return dict(static_url=self.static_url, **self.settings.get('template_variables', {}))

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -23,6 +23,7 @@ def authenticated(method):
                     #     next_url = self.request.full_url()
                     # else:
                     #     next_url = self.request.uri
+                    # always have relative url
                     next_url = self.request.uri
                     url += "?" + urlencode(dict(next=next_url))
                 self.redirect(url)
@@ -33,7 +34,7 @@ def authenticated(method):
 
 
 class BaseHandler(HubAuthenticated, web.RequestHandler):
-    """HubAuthenticated by default allows all successfully identified users (allow_all property)."""
+    """HubAuthenticated by default allows all successfully identified users (see allow_all property)."""
 
     @property
     def template_namespace(self):

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -450,11 +450,15 @@ class BuildHandler(BaseHandler):
         for i in range(launcher.retries):
             launch_starttime = time.perf_counter()
             if self.settings['auth_enabled']:
+                # get logged in user's name
                 user_model = self.hub_auth.get_user(self)
                 username = user_model['name']
-                server_name = 'server-{}'.format(launcher.username_from_repo(self.repo))
+                # user can launch multiple servers, so create a server name
+                server_name = launcher.username_from_repo(self.repo)
             else:
+                # create a name for temporary user
                 username = launcher.username_from_repo(self.repo)
+                # when no auth, 1 server per 1 temporary user, so server name can be empty
                 server_name = ''
             try:
                 server_info = await launcher.launch(image=self.image_name, username=username, server_name=server_name)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -11,14 +11,14 @@ import escapism
 
 import docker
 from tornado.concurrent import chain_future, Future
-from tornado import gen, web
+from tornado.web import Finish, authenticated
 from tornado.queues import Queue
 from tornado.iostream import StreamClosedError
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 from prometheus_client import Histogram, Gauge
 
-from .base import BaseHandler, authenticated
+from .base import BaseHandler
 from .build import Build, FakeBuild
 
 BUCKETS = [2, 5, 10, 15, 20, 25, 30, 60, 120, 240, 480, 960, 1920, float("inf")]
@@ -55,7 +55,7 @@ class BuildHandler(BaseHandler):
         except StreamClosedError:
             app_log.warning("Stream closed while handling %s", self.request.uri)
             # raise Finish to halt the handler
-            raise web.Finish()
+            raise Finish()
 
     def on_finish(self):
         """Stop keepalive when finish has been called"""

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -454,8 +454,11 @@ class BuildHandler(BaseHandler):
                 # get logged in user's name
                 user_model = self.hub_auth.get_user(self)
                 username = user_model['name']
-                # user can launch multiple servers, so create a server name
-                server_name = launcher.username_from_repo(self.repo)
+                if self.settings['use_named_servers']:
+                    # user can launch multiple servers, so create a unique server name
+                    server_name = launcher.username_from_repo(self.repo)
+                else:
+                    server_name = ''
             else:
                 # create a name for temporary user
                 username = launcher.username_from_repo(self.repo)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -462,7 +462,6 @@ class BuildHandler(BaseHandler):
             else:
                 # create a name for temporary user
                 username = launcher.username_from_repo(self.repo)
-                # when no auth, 1 server per 1 temporary user, so server name can be empty
                 server_name = ''
             try:
                 server_info = await launcher.launch(image=self.image_name, username=username,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -462,7 +462,8 @@ class BuildHandler(BaseHandler):
                 # when no auth, 1 server per 1 temporary user, so server name can be empty
                 server_name = ''
             try:
-                server_info = await launcher.launch(image=self.image_name, username=username, server_name=server_name)
+                server_info = await launcher.launch(image=self.image_name, username=username,
+                                                    server_name=server_name, repo=self.repo)
                 LAUNCH_TIME.labels(
                     status='success', retries=i, **self.metric_labels
                 ).observe(time.perf_counter() - launch_starttime)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -101,6 +101,7 @@ class BuildHandler(BaseHandler):
         self.finish()
 
     def initialize(self):
+        super().initialize()
         if self.settings['use_registry']:
             self.registry = self.settings['registry']
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -11,6 +11,7 @@ import escapism
 
 import docker
 from tornado.concurrent import chain_future, Future
+from tornado import gen
 from tornado.web import Finish, authenticated
 from tornado.queues import Queue
 from tornado.iostream import StreamClosedError

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -100,8 +100,7 @@ class BuildHandler(BaseHandler):
         self.write('data: {}\n\n'.format(evt))
         self.finish()
 
-    def initialize(self, *args, **kwargs):
-        super().initialize(*args, **kwargs)
+    def initialize(self):
         if self.settings['use_registry']:
             self.registry = self.settings['registry']
 

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -74,6 +74,9 @@ class Launcher(LoggingConfigurable):
                 # 599 due to connection issues such as Hub restarting
                 if e.code >= 500:
                     self.log.error("Error accessing Hub API (%s): (%s)", request_url, e)
+                    if i == self.retries:
+                        # last api request failed, raise the exception
+                        raise
                     await gen.sleep(retry_delay)
                     # exponential backoff for consecutive failures
                     retry_delay *= 2

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -109,7 +109,7 @@ class Launcher(LoggingConfigurable):
         # add a random suffix to avoid collisions for users on the same image
         return '{}-{}'.format(prefix, ''.join(random.choices(SUFFIX_CHARS, k=SUFFIX_LENGTH)))
 
-    async def launch(self, image, username, server_name=''):
+    async def launch(self, image, username, server_name='', repo=''):
         """Launch a server for a given image
 
         - creates the user on the Hub
@@ -137,7 +137,7 @@ class Launcher(LoggingConfigurable):
                 raise web.HTTPError(500, "Failed to create temporary user for %s" % image)
         # data to be passed into spawner's user_options during launch
         # and also to be returned to user when launch is successful
-        data = {'image': image}
+        data = {'image': image, 'repo': repo}
         if self.create_user:
             # if auth is enabled, user can reach this notebook via login.
             data['token'] = base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=\n')
@@ -148,9 +148,8 @@ class Launcher(LoggingConfigurable):
         # start server
         app_log.info("Starting server%s for user %s with image %s", _server_name, username, image)
         try:
-            url = 'users/{}/servers/{}'.format(username, server_name)
             resp = await self.api_request(
-                url,
+                'users/{}/servers/{}'.format(username, server_name),
                 method='POST',
                 body=json.dumps(data).encode('utf8'),
             )

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -122,7 +122,7 @@ class Launcher(LoggingConfigurable):
 
         - creates a temporary user on the Hub if authentication is not enabled
         - spawns a server for temporary/authenticated user
-        - generates a token if temporary user
+        - generates a token
         - returns a dict containing:
           - `url`: the URL of the server
           - `image`: image spec
@@ -154,10 +154,9 @@ class Launcher(LoggingConfigurable):
 
         # data to be passed into spawner's user_options during launch
         # and also to be returned to user when launch is successful
-        data = {'image': image, 'repo': repo}
-        if self.create_user:
-            # if auth is enabled, user can reach this notebook via login.
-            data['token'] = base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=\n')
+        data = {'image': image,
+                'repo': repo,
+                'token': base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=\n')}
 
         # server name to be used in logs
         _server_name = " {}".format(server_name) if server_name else ''

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -84,7 +84,7 @@ class Launcher(LoggingConfigurable):
                     raise
 
     def username_from_repo(self, repo):
-        """Generate a username for a git repo url
+        """Generate a username or server name for a git repo url
 
         e.g. minrk-binder-example-abc123
         from https://github.com/minrk/binder-example.git
@@ -112,11 +112,13 @@ class Launcher(LoggingConfigurable):
     async def launch(self, image, username, server_name='', repo=''):
         """Launch a server for a given image
 
-        - creates the user on the Hub
-        - spawns a server for that user
-        - generates a token
+        - creates a temporary user on the Hub if authentication is not enabled
+        - spawns a server for temporary/authenticated user
+        - generates a token if temporary user
         - returns a dict containing:
           - `url`: the URL of the server
+          - `image`: image spec
+          - `repo`: the url of the repo
           - `token`: the token for the server
         """
         # TODO: validate the image argument?

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -73,7 +73,7 @@ class Launcher(LoggingConfigurable):
                 # e.g. 502,504 due to ingress issues or Hub relocating,
                 # 599 due to connection issues such as Hub restarting
                 if e.code >= 500:
-                    self.log.error("Error accessing Hub API (%s): (%s)", request_url, e)
+                    self.log.error("Error accessing Hub API (using %s): %s", request_url, e)
                     if i == self.retries:
                         # last api request failed, raise the exception
                         raise

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -150,7 +150,7 @@ class Launcher(LoggingConfigurable):
             # check if user have a running server ('')
             user_data = await self.get_user_data(username)
             if server_name in user_data['servers']:
-                raise web.HTTPError(500, "User %s already has a running server." % username)
+                raise web.HTTPError(409, "User %s already has a running server." % username)
 
         # data to be passed into spawner's user_options during launch
         # and also to be returned to user when launch is successful

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -1,11 +1,11 @@
 """
 Main handler classes for requests
 """
-from tornado import web
+from tornado.web import HTTPError, authenticated
 from tornado.httputil import url_concat
 from tornado.log import app_log
 
-from .base import BaseHandler, authenticated
+from .base import BaseHandler
 
 
 class MainHandler(BaseHandler):
@@ -35,7 +35,7 @@ class ParameterizedMainHandler(BaseHandler):
         spec = self.request.path[idx + len(prefix) + 1:]
         try:
             self.get_provider(provider_prefix, spec=spec)
-        except web.HTTPError:
+        except HTTPError:
             raise
         except Exception as e:
             app_log.error(
@@ -44,7 +44,7 @@ class ParameterizedMainHandler(BaseHandler):
             )
             # FIXME: 400 assumes it's the user's fault (?)
             # maybe we should catch a special InvalidSpecError here
-            raise web.HTTPError(400, str(e))
+            raise HTTPError(400, str(e))
 
         self.render_template(
             "loading.html",

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -5,12 +5,13 @@ from tornado import web
 from tornado.httputil import url_concat
 from tornado.log import app_log
 
-from .base import BaseHandler
+from .base import BaseHandler, authenticated
 
 
 class MainHandler(BaseHandler):
     """Main handler for requests"""
 
+    @authenticated
     def get(self):
         self.render_template(
             "index.html",
@@ -24,6 +25,7 @@ class MainHandler(BaseHandler):
 class ParameterizedMainHandler(BaseHandler):
     """Main handler that allows different parameter settings"""
 
+    @authenticated
     def get(self, provider_prefix, _unescaped_spec):
         # re-extract spec from request.path
         # get the original, raw spec, without tornado's unquoting
@@ -59,6 +61,7 @@ class ParameterizedMainHandler(BaseHandler):
 class LegacyRedirectHandler(BaseHandler):
     """Redirect handler from legacy Binder"""
 
+    @authenticated
     def get(self, user, repo, urlpath=None):
         url = '/v2/gh/{user}/{repo}/master'.format(user=user, repo=repo)
         if urlpath is not None and urlpath.strip('/'):

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -1,8 +1,9 @@
-from .base import BaseHandler
+from .base import BaseHandler, authenticated
 from prometheus_client import REGISTRY, generate_latest, CONTENT_TYPE_LATEST
 
 
 class MetricsHandler(BaseHandler):
+    @authenticated
     async def get(self):
         self.set_header('Content-Type', CONTENT_TYPE_LATEST)
         self.write(generate_latest(REGISTRY))

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -1,9 +1,9 @@
-from .base import BaseHandler, authenticated
+from .base import BaseHandler
 from prometheus_client import REGISTRY, generate_latest, CONTENT_TYPE_LATEST
 
 
 class MetricsHandler(BaseHandler):
-    @authenticated
+
     async def get(self):
         self.set_header('Content-Type', CONTENT_TYPE_LATEST)
         self.write(generate_latest(REGISTRY))

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -34,8 +34,8 @@ function update_favicon(path) {
     document.getElementsByTagName('head')[0].appendChild(link);
 }
 
-function Image(provider_spec) {
-    this.provider_spec = provider_spec;
+function Image(providerSpec) {
+    this.providerSpec = providerSpec;
     this.callbacks = {};
     this.state = null;
 }
@@ -66,7 +66,7 @@ Image.prototype.changeState = function(state, data) {
 };
 
 Image.prototype.fetch = function() {
-    var apiUrl = BASE_URL + 'build/' + this.provider_spec;
+    var apiUrl = BASE_URL + 'build/' + this.providerSpec;
     this.eventSource = new EventSource(apiUrl);
     var that = this;
     this.eventSource.onerror = function (err) {
@@ -90,36 +90,39 @@ Image.prototype.close = function() {
         this.eventSource.close();
     }
 };
-
-Image.prototype.launch = function(url, token, filepath, pathType) {
+Image.prototype.launch = function(url, token, path, pathType) {
     // redirect a user to a running server with a token
-    if (filepath) {
+    if (path) {
       // strip trailing /
       url = url.replace(/\/$/, '');
+      path = decodeURIComponent(path);
+      // be insensitive to leading '/'
+      path = path.replace(/^\//, '');
       if (pathType === 'file') {
         // /tree is safe because it allows redirect to files
         // need more logic here if we support things other than notebooks
-        url = url + '/tree/' + encodeURI(filepath);
+        // strip trailing '/' - it causes ERR_TOO_MANY_REDIRECTS in user server
+        path = path.replace(/\/$/, '');
+        url = url + '/tree/' + path;
       } else {
         // pathType === 'url'
-        // be insensitive to leading '/'
-        filepath = filepath.replace(/^\//, '');
-        url = url + '/' + filepath;
+        url = url + '/' + path;
       }
-
     }
-    var sep = (url.indexOf('?') == -1) ? '?' : '&';
-    url = url + sep + $.param({token: token});
+    if (token) {
+        var sep = (url.indexOf('?') == -1) ? '?' : '&';
+        url = url + sep + $.param({token: token});
+    }
     window.location.href = url;
 };
 
-function v2url(provider_prefix, repository, ref, path, pathType) {
-  // return a v2 url from a provider_prefix, repository, ref, and (file|url)path
+function v2url(providerPrefix, repository, ref, path, pathType) {
+  // return a v2 url from a providerPrefix, repository, ref, and (file|url)path
   if (repository.length === 0) {
     // no repo, no url
     return null;
   }
-  var url = window.location.origin + BASE_URL + 'v2/' + provider_prefix + '/' + repository + '/' + ref;
+  var url = window.location.origin + BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
   if (path && path.length > 0) {
     url = url + '?' + pathType + 'path=' + encodeURIComponent(path);
   }
@@ -166,12 +169,10 @@ function updateRepoText() {
   $("label[for=ref]").text(tag_text);
 }
 
-
-function updateUrl() {
-  // update URLs and links (badges, etc.)
-  var provider_prefix = $('#provider_prefix').val().trim();
+function getBuildFormValues() {
+  var providerPrefix = $('#provider_prefix').val().trim();
   var repo = $('#repository').val().trim();
-  if (provider_prefix !== 'git') {
+  if (providerPrefix !== 'git') {
     repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
     repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, '');
   }
@@ -179,27 +180,39 @@ function updateUrl() {
   repo = repo.replace(/(^\/)|(\/?$)/g, '');
   // git providers encode the URL of the git repository as the repo
   // argument.
-  if (repo.includes("://") || provider_prefix === 'gl') {
+  if (repo.includes("://") || providerPrefix === 'gl') {
     repo = encodeURIComponent(repo);
   }
 
   var ref = $('#ref').val().trim() || 'master';
-  var filepath = $('#filepath').val().trim();
-  var url = v2url(provider_prefix, repo, ref, filepath, getPathType());
-  // update URL references
-  $("#badge-link").attr('href', url);
-  return url;
+  // trim trailing or leading '/' on ref
+  ref = ref.replace(/(^\/)|(\/?$)/g, '');
+  var path = $('#filepath').val().trim();
+  return {'providerPrefix': providerPrefix, 'repo': repo,
+          'ref': ref, 'path': path, 'pathType': getPathType()}
 }
 
-function updateUrlDiv() {
-  var url = updateUrl();
+function updateUrlDiv(formValues) {
+  if (formValues === undefined) {
+      formValues = getBuildFormValues();
+  }
+  var url = v2url(
+               formValues.providerPrefix,
+               formValues.repo,
+               formValues.ref,
+               formValues.path,
+               formValues.pathType
+            );
+
   if ((url||'').trim().length > 0){
+    // update URLs and links (badges, etc.)
+    $("#badge-link").attr('href', url);
     $('#basic-url-snippet').text(url);
     $('#markdown-badge-snippet').text(markdownBadge(url));
     $('#rst-badge-snippet').text(rstBadge(url));
   } else {
     ['#basic-url-snippet', '#markdown-badge-snippet', '#rst-badge-snippet' ].map(function(item, ind){
-      var el = $(item)
+      var el = $(item);
       el.text(el.attr('data-default'));
     })
   }
@@ -214,22 +227,21 @@ function markdownBadge(url) {
   return '[![Binder](' + BADGE_URL + ')](' + url + ')'
 }
 
-
 function rstBadge(url) {
   // return rst badge snippet
   return '.. image:: ' + BADGE_URL + ' :target: ' + url
 }
 
-function build(spec, log, filepath, pathType) {
+function build(providerSpec, log, path, pathType) {
   update_favicon(BASE_URL + "favicon_building.ico");
-  // split provider prefix off of spec
-  var repo = decodeURIComponent(spec.slice(spec.indexOf('/') + 1));
+  // split provider prefix off of providerSpec
+  var spec = providerSpec.slice(providerSpec.indexOf('/') + 1);
 
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
-    $('div#loader-text p').text("Loading repository: " + repo);
+    $('div#loader-text p').text("Loading repository: " + spec);
     window.setTimeout(function() {
-      $('div#loader-text p').html("Repository " + repo + " is taking longer than usual to load, hang tight!")
+      $('div#loader-text p').html("Repository " + spec + " is taking longer than usual to load, hang tight!")
     }, 120000);
   }
 
@@ -238,7 +250,7 @@ function build(spec, log, filepath, pathType) {
 
   $('.on-build').removeClass('hidden');
 
-  var image = new Image(spec);
+  var image = new Image(providerSpec);
 
   image.onStateChange('*', function(oldState, newState, data) {
     if (data.message !== undefined) {
@@ -266,7 +278,7 @@ function build(spec, log, filepath, pathType) {
     $('#phase-failed').removeClass('hidden');
 
     $("#loader").addClass("paused");
-    $('div#loader-text p').html("Repository " + repo + " has failed to load!<br />See the logs for details.");
+    $('div#loader-text p').html("Repository " + spec + " has failed to load!<br />See the logs for details.");
     update_favicon("/favicon_fail.ico");
     // If we fail for any reason, we will show logs!
     log.show();
@@ -274,7 +286,7 @@ function build(spec, log, filepath, pathType) {
     // Show error on loading page
     if ($('div#loader-text').length > 0) {
       $('#loader').addClass("error");
-      $('div#loader-text p').html('Error loading ' + repo + '!<br /> See logs below for details.');
+      $('div#loader-text p').html('Error loading ' + spec + '!<br /> See logs below for details.');
     }
     image.close();
   });
@@ -290,7 +302,8 @@ function build(spec, log, filepath, pathType) {
 
   image.onStateChange('ready', function(oldState, newState, data) {
     image.close();
-    image.launch(data.url, data.token, filepath, pathType);
+    // user server is ready, redirect to there
+    image.launch(data.url, data.token, path, pathType);
   });
 
   image.fetch();
@@ -376,33 +389,19 @@ function indexMain() {
     });
 
     $('#build-form').submit(function() {
-        var repo = $('#repository').val().trim();
-        var ref =  $('#ref').val().trim() || 'master';
-        var provider_prefix =  $('#provider_prefix').val().trim();
-        if (provider_prefix !== 'git') {
-          repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
-          repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, '');
-        }
-        // trim trailing or leading '/' on repo
-        repo = repo.replace(/(^\/)|(\/?$)/g, '');
-        // git providers encode the URL of the git repository as the
-        // repo argument.
-        if (repo.includes("://") || provider_prefix === 'gl') {
-          repo = encodeURIComponent(repo);
-        }
-        var url = updateUrl();
-        updateUrlDiv(url);
+        var formValues = getBuildFormValues();
+        updateUrlDiv(formValues);
         build(
-          provider_prefix + '/' + repo + '/' + ref,
+          formValues.providerPrefix + '/' + formValues.repo + '/' + formValues.ref,
           log,
-          $("#filepath").val().trim(),
-          getPathType()
+          formValues.path,
+          formValues.pathType
         );
         return false;
     });
 }
 
-function loadingMain(spec, ref) {
+function loadingMain(providerSpec) {
   var log = setUpLog();
   // retrieve filepath/urlpath from URL
   var params = new URL(location.href).searchParams;
@@ -416,10 +415,7 @@ function loadingMain(spec, ref) {
       pathType = 'file';
     }
   }
-  if (path) {
-    path = decodeURIComponent(path);
-  }
-  build(spec, log, path, pathType);
+  build(providerSpec, log, path, pathType);
   return false;
 }
 

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -193,7 +193,7 @@ function getBuildFormValues() {
 }
 
 function updateUrlDiv(formValues) {
-  if (formValues === undefined) {
+  if (typeof formValues === "undefined") {
       formValues = getBuildFormValues();
   }
   var url = v2url(
@@ -367,11 +367,11 @@ function indexMain() {
     updatePathText();
     updateRepoText();
 
-    $('#repository').on('keyup paste change', updateUrlDiv);
+    $('#repository').on('keyup paste change', function(event) {updateUrlDiv();});
 
-    $('#ref').on('keyup paste change', updateUrlDiv);
+    $('#ref').on('keyup paste change', function(event) {updateUrlDiv();});
 
-    $('#filepath').on('keyup paste change', updateUrlDiv);
+    $('#filepath').on('keyup paste change', function(event) {updateUrlDiv();});
 
     $('#toggle-badge-snippet').on('click', function() {
         var badgeSnippets = $('#badge-snippets');

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -25,9 +25,7 @@
 </div>
 
 {% block preview %}
-{# we can only produce an nbviewer URL for github right now #}
-{% set prefix, org_repo_ref = provider_spec.split('/', 1) %}
-{% if prefix == "gh" %}
+{% if nbviewer_ul %}
 <div class="preview container">
 <p class="preview-text text-center">
 Here's a non-interactive preview on
@@ -35,11 +33,8 @@ Here's a non-interactive preview on
 while we start a server for you.
 Your binder will open automatically when it is ready.
 </p>
-{% set org, repo, ref = org_repo_ref.split('/', 2) %}
 <div id="nbviewer-preview">
-  <iframe
-    src="https://nbviewer.jupyter.org/github/{{org}}/{{repo}}/{{'blob' if filepath else 'tree'}}/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
-  ></iframe>
+  <iframe src="{{ nbviewer_ul }}"></iframe>
 </div>
 </div>
 {% endif %}

--- a/binderhub/tests/test_auth.py
+++ b/binderhub/tests/test_auth.py
@@ -1,0 +1,26 @@
+"""Test authentication"""
+import pytest
+from urllib.parse import quote
+from .utils import async_requests
+
+
+@pytest.mark.parametrize(
+    'path,authenticated',
+    [
+        ('', True),  # main page
+        ('v2/gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd', True),
+        ('metrics', False),
+    ]
+)
+@pytest.mark.gen_test
+def test_auth(app_with_auth, path, authenticated):
+    url = f'{app_with_auth.service_url}{path}'
+    r = yield async_requests.get(url)
+    assert r.status_code == 200
+    if authenticated:
+        next_url = f'{app_with_auth.base_url}{path}'
+        assert r.url == f'{app_with_auth.hub_url}hub/login?next={quote(next_url, safe="")}'
+
+        r = yield async_requests.post(r.url, data={'username': 'dummy', 'password': 'dummy'})
+        assert r.status_code == 200
+    assert r.url == url

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -23,7 +23,7 @@ def test_build(app, needs_build, needs_launch, always_build, slug, pytestconfig)
     # can't use mark.github_api since only some tests here use GitHub
     if slug.startswith('gh/') and "not github_api" in pytestconfig.getoption('markexpr'):
         pytest.skip("Skipping GitHub API test")
-    build_url = f"{app.url}/build/{slug}"
+    build_url = f"{app.url}build/{slug}"
     r = yield async_requests.get(build_url, stream=True)
     r.raise_for_status()
     events = []

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -10,10 +10,10 @@ from .utils import async_requests
 
 @pytest.mark.parametrize(
     "old_url, new_url", [
-        ("/repo/minrk/ligo-binder", "/v2/gh/minrk/ligo-binder/master"),
-        ("/repo/minrk/ligo-binder/", "/v2/gh/minrk/ligo-binder/master"),
+        ("repo/minrk/ligo-binder", "/v2/gh/minrk/ligo-binder/master"),
+        ("repo/minrk/ligo-binder/", "/v2/gh/minrk/ligo-binder/master"),
         (
-            "/repo/minrk/ligo-binder/notebooks/index.ipynb",
+            "repo/minrk/ligo-binder/notebooks/index.ipynb",
             "/v2/gh/minrk/ligo-binder/master?urlpath=%2Fnotebooks%2Findex.ipynb",
         ),
     ]
@@ -95,7 +95,7 @@ def test_loading_page(app, provider_prefix, repo, ref, path, path_type, status_c
     spec = f'{repo}/{ref}'
     provider_spec = f'{provider_prefix}/{spec}'
     query = f'{path_type}path={path}' if path else ''
-    uri = f'/v2/{provider_spec}?{query}'
+    uri = f'v2/{provider_spec}?{query}'
     r = yield async_requests.get(app.url + uri)
     assert r.status_code == status_code, f"{r.status_code} {uri}"
     if status_code == 200:

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -7,6 +7,7 @@ import pytest
 
 from .utils import async_requests
 
+
 @pytest.mark.parametrize(
     "old_url, new_url", [
         ("/repo/minrk/ligo-binder", "/v2/gh/minrk/ligo-binder/master"),
@@ -73,10 +74,33 @@ def test_main_page(app):
         assert r.status_code == 200, f"{r.status_code} {url}"
 
 
+@pytest.mark.parametrize(
+    'provider_prefix,repo,ref,path,path_type,status_code',
+    [
+        ('gh', 'minrk/ligo-binder', 'master', '', '', 200),
+        ('gh', 'minrk%2Fligo-binder', 'master', '', '', 400),
+        ('gh', 'minrk/ligo-binder', 'master/', '', '', 200),
+
+        ('gh', 'minrk/ligo-binder', 'b8259dac9eb4aa5f2d65d8881f2da94a4952a195', 'index.ipynb', 'file', 200),
+        ('gh', 'minrk/ligo-binder', 'b8259dac9eb4aa5f2d65d8881f2da94a4952a195', '%2Fnotebooks%2Findex.ipynb', 'url', 200),
+
+        ('gh', 'berndweiss/gesis-meta-analysis-2018', 'master', 'notebooks', 'file', 200),
+        ('gh', 'berndweiss/gesis-meta-analysis-2018', 'master/', '%2Fnotebooks%2F', 'file', 200),
+        ('gh', 'berndweiss/gesis-meta-analysis-2018', 'master', '%2Fnotebooks%2F0-0-index.ipynb', 'file', 200),
+    ]
+)
 @pytest.mark.gen_test
-def test_loading_page(app):
-    sha = 'b8259dac9eb4aa5f2d65d8881f2da94a4952a195'
-    r = yield async_requests.get(app.url + f'/v2/gh/minrk/ligo-binder/{sha}?filepath=index.ipynb')
-    assert r.status_code == 200
-    soup = BeautifulSoup(r.text, 'html5lib')
-    assert soup.find(id='log-container')
+def test_loading_page(app, provider_prefix, repo, ref, path, path_type, status_code):
+    # repo = f'{user}/{repo_name}'
+    spec = f'{repo}/{ref}'
+    provider_spec = f'{provider_prefix}/{spec}'
+    query = f'{path_type}path={path}' if path else ''
+    uri = f'/v2/{provider_spec}?{query}'
+    r = yield async_requests.get(app.url + uri)
+    assert r.status_code == status_code, f"{r.status_code} {uri}"
+    if status_code == 200:
+        soup = BeautifulSoup(r.text, 'html5lib')
+        assert soup.find(id='log-container')
+        nbviewer_url = soup.find(id='nbviewer-preview').find('iframe').attrs['src']
+        r = yield async_requests.get(nbviewer_url)
+        assert r.status_code == 200, f"{r.status_code} {nbviewer_url}"

--- a/ci/test-auth
+++ b/ci/test-auth
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+./testing/minikube/install-hub --auth
+# DEBUG: give the hub a chance to wake up
+sleep 10
+export ASYNC_TEST_TIMEOUT=15
+pytest -vsx --cov binderhub/tests/test_auth.py
+helm delete --purge binder-test-hub

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,4 @@ pytest-tornado
 requests
 ruamel.yaml>=0.15
 https://github.com/jupyterhub/chartpress/archive/271c75e.tar.gz
-jupyterhub==0.9.1
+jupyterhub==0.9.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pytest-tornado
 requests
 ruamel.yaml>=0.15
 https://github.com/jupyterhub/chartpress/archive/271c75e.tar.gz
+jupyterhub==0.9.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,5 @@ pytest-cov
 pytest-tornado
 requests
 ruamel.yaml>=0.15
-https://github.com/jupyterhub/chartpress/archive/271c75e.tar.gz
-jupyterhub==0.9.2
+https://github.com/jupyterhub/chartpress/archive/2f26733f6ebf9e2b76bd9cfa3b8a8439daa0b16c.tar.gz
+jupyterhub

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -37,6 +37,12 @@ data:
   binder.hub-url: {{ .Values.hub.url | quote }}
   binder.base_url: {{ .Values.baseUrl | quote }}
 
+  {{- if and (eq .Values.jupyterhub.auth.type "custom") (eq .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
+  binder.auth-enabled: "false"
+  {{- else }}
+  binder.auth-enabled: "true"
+  {{- end }}
+
   {{ if .Values.github.hostname -}}
   github.hostname: {{ .Values.github.hostname | quote }}
   {{- end }}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -43,6 +43,7 @@ data:
   {{- if and .Values.jupyterhub.hub.services.binder.oauth_client_id }}
   binder.use-oauth: "true"
   {{- end }}
+  binder.use-named-servers: {{ .Values.jupyterhub.hub.allowNamedServers | quote }}
   {{- end }}
 
   {{ if .Values.github.hostname -}}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -34,8 +34,7 @@ data:
   binder.retries.count: {{ .Values.retries.count | quote }}
   binder.retries.delay: {{ .Values.retries.delay | quote }}
 
-  binder.hub-url: {{ .Values.hub.url | quote }}
-  binder.base_url: {{ .Values.baseUrl | quote }}
+  binder.base-url: {{ .Values.baseUrl | quote }}
 
   {{- if and (eq .Values.jupyterhub.auth.type "custom") (eq .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
   binder.auth-enabled: "false"

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -40,6 +40,9 @@ data:
   binder.auth-enabled: "false"
   {{- else }}
   binder.auth-enabled: "true"
+  {{- if and .Values.jupyterhub.hub.services.binder.oauth_client_id }}
+  binder.use-oauth: "true"
+  {{- end }}
   {{- end }}
 
   {{ if .Values.github.hostname -}}

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -84,6 +84,21 @@ spec:
             secretKeyRef:
               name: binder-secret
               key: "binder.hub-token"
+        - name: JUPYTERHUB_URL
+          value: {{ .Values.hub.url | trimSuffix "/" | quote }}
+        - name: JUPYTERHUB_API_URL
+          value: "$(JUPYTERHUB_URL)/hub/api/"
+        {{- if and (eq .Values.jupyterhub.auth.type "custom") (eq .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
+        {{- else }}
+        - name: JUPYTERHUB_SERVICE_PREFIX
+          value: {{ .Values.baseUrl | quote }}
+        - name: JUPYTERHUB_BASE_URL
+          value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
+        - name: JUPYTERHUB_CLIENT_ID
+          value: "TODO"
+        - name: JUPYTERHUB_OAUTH_CALLBACK_URL
+          value: "TODO"
+        {{- end }}
         {{ if .Values.github.clientId -}}
         - name: GITHUB_CLIENT_ID
           valueFrom:

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -95,10 +95,15 @@ spec:
           value: {{ .Values.baseUrl | quote }}
         - name: JUPYTERHUB_BASE_URL
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
+        {{- if and .Values.jupyterhub.hub.services.binder.oauth_client_id }}
+        # oauth is used
         - name: JUPYTERHUB_CLIENT_ID
-          value: "TODO"
+          value: {{ .Values.jupyterhub.hub.services.binder.oauth_client_id | quote}}
+        {{- if and .Values.jupyterhub.hub.services.binder.oauth_redirect_uri }}
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
-          value: "TODO"
+          value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{ if .Values.github.clientId -}}
         - name: GITHUB_CLIENT_ID

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -89,6 +89,7 @@ spec:
         - name: JUPYTERHUB_API_URL
           value: "$(JUPYTERHUB_URL)/hub/api/"
         {{- if and (eq .Values.jupyterhub.auth.type "custom") (eq .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
+        # auth is not enabled
         {{- else }}
         - name: JUPYTERHUB_SERVICE_PREFIX
           value: {{ .Values.baseUrl | quote }}

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -95,11 +95,11 @@ spec:
           value: {{ .Values.baseUrl | quote }}
         - name: JUPYTERHUB_BASE_URL
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
-        {{- if and .Values.jupyterhub.hub.services.binder.oauth_client_id }}
+        {{- if .Values.jupyterhub.hub.services.binder.oauth_client_id }}
         # oauth is used
         - name: JUPYTERHUB_CLIENT_ID
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_client_id | quote}}
-        {{- if and .Values.jupyterhub.hub.services.binder.oauth_redirect_uri }}
+        {{- if .Values.jupyterhub.hub.services.binder.oauth_redirect_uri }}
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
         {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -135,7 +135,6 @@ jupyterhub:
               self.image_spec = self.user_options['image']
               return super().start()
 
-        # NOTE use a modified BinderSpawner when authentication is enabled
         c.JupyterHub.spawner_class = BinderSpawner
     extraConfigMap:
       cors: *cors
@@ -154,8 +153,6 @@ jupyterhub:
       # disable login (users created exclusively via API)
       className: "nullauthenticator.NullAuthenticator"
   singleuser:
-    # NOTE set cmd as jupyterhub-singleuser when authentication is enabled
-    # nullauthenticator doesn't work with jhub-singleuser and jhub installation is required in single user image
     # start jupyter notebook
     cmd: jupyter-notebook
     events: false

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -13,6 +13,7 @@ retries:
   count: 4
   delay: 4
 
+# NOTE set baseUrl to '<jupyterhub_base_url>/services/binder/' when auth is enabled.
 baseUrl: /
 nodeSelector: {}
 

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -82,6 +82,7 @@ hub:
 jupyterhub:
   cull:
     enabled: true
+    # NOTE set false when authentication is enabled
     users: true
   hub:
     rbac:
@@ -106,9 +107,6 @@ jupyterhub:
 
         # get cors config from config-map
         cors = get_config_map('custom.cors', {})
-
-        # disable login (users created exclusively via API)
-        c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
 
         # image & token are set via spawn options
         from kubespawner import KubeSpawner
@@ -137,6 +135,8 @@ jupyterhub:
               return super().start()
 
         c.JupyterHub.spawner_class = BinderSpawner
+        # NOTE set True when authentication is enabled
+        c.JupyterHub.allow_named_servers = False
 
     extraConfigMap:
       cors: *cors
@@ -144,8 +144,15 @@ jupyterhub:
       binder:
         admin: true
         apiToken:
-
+  auth:
+    type: custom
+    custom:
+      # disable login (users created exclusively via API)
+      className: "nullauthenticator.NullAuthenticator"
   singleuser:
+    # NOTE set cmd as jupyterhub-singleuser when authentication is enabled
+    # nullauthenticator doesn't work with jhub-singleuser and jhub installation is required in single user image
+    # cmd: jupyterhub-singleuser
     # start jupyter notebook
     cmd: jupyter-notebook
     events: false

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -135,11 +135,8 @@ jupyterhub:
               self.image_spec = self.user_options['image']
               return super().start()
 
-        # NOTE use modified BinderSpawner when authentication is enabled
+        # NOTE use a modified BinderSpawner when authentication is enabled
         c.JupyterHub.spawner_class = BinderSpawner
-        # NOTE set True when authentication is enabled
-        c.JupyterHub.allow_named_servers = False
-
     extraConfigMap:
       cors: *cors
     services:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -135,6 +135,7 @@ jupyterhub:
               self.image_spec = self.user_options['image']
               return super().start()
 
+        # NOTE use modified BinderSpawner when authentication is enabled
         c.JupyterHub.spawner_class = BinderSpawner
         # NOTE set True when authentication is enabled
         c.JupyterHub.allow_named_servers = False
@@ -155,7 +156,6 @@ jupyterhub:
   singleuser:
     # NOTE set cmd as jupyterhub-singleuser when authentication is enabled
     # nullauthenticator doesn't work with jhub-singleuser and jhub installation is required in single user image
-    # cmd: jupyterhub-singleuser
     # start jupyter notebook
     cmd: jupyter-notebook
     events: false

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -146,6 +146,9 @@ jupyterhub:
       binder:
         # NOTE set 'url' when authentication is enabled.
         # because cookie 'jupyterhub-services', which is used for authentication, is available under '/services/'.
+        # NOTE set oauth_client_id for oauth
+        # oauth_redirect_uri is '/base_url/oauth_callback' by default
+        # apiToken is used as the client_secret for oauth requests
         admin: true
         apiToken:
   auth:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -92,6 +92,7 @@ jupyterhub:
         import os
         import sys
         import yaml
+        from tornado import web
         def get_config_map(key, default=None):
             """
             Find a configmap item of a given name & return it
@@ -142,6 +143,8 @@ jupyterhub:
       cors: *cors
     services:
       binder:
+        # NOTE set 'url' when authentication is enabled.
+        # because cookie 'jupyterhub-services', which is used for authentication, is available under '/services/'.
         admin: true
         apiToken:
   auth:

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -40,7 +40,7 @@ if os.path.exists('/etc/binderhub/config/binder.appendix'):
     with open('/etc/binderhub/config/binder.appendix') as f:
         c.BinderHub.appendix = f.read()
 
-c.BinderHub.hub_url = get_config('binder.hub-url')
+c.BinderHub.hub_url = os.environ['JUPYTERHUB_URL'] + '/'
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
 
 c.BinderHub.google_analytics_code = get_config('binder.google-analytics-code', None)
@@ -48,7 +48,7 @@ google_analytics_domain = get_config('binder.google-analytics-domain', None)
 if google_analytics_domain:
     c.BinderHub.google_analytics_domain = google_analytics_domain
 
-c.BinderHub.base_url = get_config('binder.base_url')
+c.BinderHub.base_url = get_config('binder.base-url')
 
 c.BinderHub.auth_enabled = get_config('binder.auth-enabled', False)
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -51,6 +51,7 @@ if google_analytics_domain:
 c.BinderHub.base_url = get_config('binder.base-url')
 
 c.BinderHub.auth_enabled = get_config('binder.auth-enabled', False)
+c.BinderHub.use_oauth = get_config('binder.use-oauth', False)
 
 if get_config('dind.enabled', False):
     c.BinderHub.build_docker_host = 'unix://{}/docker.sock'.format(

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -52,6 +52,7 @@ c.BinderHub.base_url = get_config('binder.base-url')
 
 c.BinderHub.auth_enabled = get_config('binder.auth-enabled', False)
 c.BinderHub.use_oauth = get_config('binder.use-oauth', False)
+c.BinderHub.use_named_servers = get_config('binder.use-named-servers', False)
 
 if get_config('dind.enabled', False):
     c.BinderHub.build_docker_host = 'unix://{}/docker.sock'.format(

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -50,6 +50,8 @@ if google_analytics_domain:
 
 c.BinderHub.base_url = get_config('binder.base_url')
 
+c.BinderHub.auth_enabled = get_config('binder.auth-enabled', False)
+
 if get_config('dind.enabled', False):
     c.BinderHub.build_docker_host = 'unix://{}/docker.sock'.format(
         get_config('dind.host-socket-dir')

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -50,9 +50,11 @@ if google_analytics_domain:
 
 c.BinderHub.base_url = get_config('binder.base-url')
 
-c.BinderHub.auth_enabled = get_config('binder.auth-enabled', False)
-c.BinderHub.use_oauth = get_config('binder.use-oauth', False)
-c.BinderHub.use_named_servers = get_config('binder.use-named-servers', False)
+auth_enabled = get_config('binder.auth-enabled', False)
+if auth_enabled:
+    c.BinderHub.auth_enabled = auth_enabled
+    c.BinderHub.use_oauth = get_config('binder.use-oauth', False)
+    c.BinderHub.use_named_servers = get_config('binder.use-named-servers', False)
 
 if get_config('dind.enabled', False):
     c.BinderHub.build_docker_host = 'unix://{}/docker.sock'.format(

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,2 +1,3 @@
 pycurl==7.43.0.1
 tornado==4.5.3
+jupyterhub==0.9.0

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,3 +1,3 @@
 pycurl==7.43.0.1
 tornado==4.5.3
-jupyterhub==0.9.0
+jupyterhub==0.9.1

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,3 +1,3 @@
 pycurl==7.43.0.1
 tornado==4.5.3
-jupyterhub==0.9.1
+jupyterhub==0.9.2

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -7,7 +7,7 @@ for testing binderhub
 Gets the jupyterhub chart version from the binderhub helm chart
 to ensure we are testing against a reasonable version.
 """
-
+import sys
 import os
 import pipes
 from subprocess import check_call, check_output
@@ -15,6 +15,8 @@ import time
 
 from kubernetes import client, config
 from ruamel import yaml
+
+auth_enabled = '--auth' in sys.argv
 
 namespace = os.environ.get('BINDER_TEST_NAMESPACE') or 'binder-test'
 name = 'binder-test-hub'
@@ -48,6 +50,9 @@ args = [
     f'--namespace={namespace}',
     '-f', os.path.join(here, 'jupyterhub-helm-config.yaml'),
 ]
+if auth_enabled:
+    print('\nAuthentication is enabled')
+    args.extend(['-f', os.path.join(here, 'jupyterhub-helm-auth-config.yaml')])
 is_running = name in check_output(['helm', 'list', '-q']).decode('utf8', 'replace').split()
 if is_running:
     cmd = ['helm', 'upgrade', name]

--- a/testing/minikube/jupyterhub-helm-auth-config.yaml
+++ b/testing/minikube/jupyterhub-helm-auth-config.yaml
@@ -1,0 +1,9 @@
+hub:
+  services:
+    binder:
+      url: http://10.0.2.2:8585
+
+auth:
+  type: dummy
+  dummy:
+    password: 'dummy'

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -13,13 +13,12 @@ hub:
     binder:
       admin: true
       apiToken: "aec7d32df938c0f55e54f09244a350cb29ea612907ed4f07be13d9553d18a8e4"
+  allowNamedServers: false
   extraConfig:
     binder: |
-      # disable login (users created exclusively via API)
-      c.JupyterHub.authenticator_class = 'nullauthenticator.NullAuthenticator'
-
       # image & token are set via spawn options
       from kubespawner import KubeSpawner
+      from tornado import web
 
       class BinderSpawner(KubeSpawner):
         def get_args(self):
@@ -53,6 +52,11 @@ singleuser:
     type: none
   memory:
     guarantee: null
+auth:
+  type: custom
+  custom:
+    # disable login (users created exclusively via API)
+    className: "nullauthenticator.NullAuthenticator"
 
 prePuller:
   enabled: false


### PR DESCRIPTION
Hi, last days I was working on adding an optional jhub authentication for binder. Firstly, comments on https://github.com/jupyterhub/binderhub/issues/323 helped a lot, thanks!

It is not completed yet and I won't be available next 2 weeks. So I thought I can make this PR and maybe get some feedback from you if I am going on the right way. It would be great for me, if you can review my changes.

Current situation: 
- if `auth.custom.className`set as "nullauthenticator.NullAuthenticator" (default configuration), authentication is not enabled and binderhub works with fake users as before.
- if `auth` set to anything different from `NullAuthenticator`, authentication is enabled and when user comes to binder page, it is redirected to jhub login page. But after user logs in there is `Too many redirections` error. I think this is because `HubAuthenticated.get_current_user` can't gets the user and redirects back to login page and log in page redirects back to binder page (because user is logged in).

Sorry if I miss something to mention in this PR. I had today less time than planned to work on this.