### PR TITLE
Change nbviewer preview URL

### DIFF
--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -38,7 +38,7 @@ Your binder will open automatically when it is ready.
 {% set repo, ref = repo_ref.rsplit('/', 1) %}
 <div id="nbviewer-preview">
   <iframe
-    src="https://nbviewer.jupyter.org/github/{{repo}}/tree/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
+    src="https://nbviewer.jupyter.org/github/{{repo}}/blob/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
   ></iframe>
 </div>
 </div>


### PR DESCRIPTION
With the old URL (currently deployed) https://mybinder.org/v2/gh/norvig/pytudes/master?filepath=ipynb%2FTSP.ipynb shows a "400 Bad request" because `/tree/` is part of the URL. If I visit nbviewer directly and browse to the same notebook the URL contains `/blob/`.