### PR TITLE
use blob urls if filepath is defined

### DIFF
--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -38,7 +38,7 @@ Your binder will open automatically when it is ready.
 {% set repo, ref = repo_ref.rsplit('/', 1) %}
 <div id="nbviewer-preview">
   <iframe
-    src="https://nbviewer.jupyter.org/github/{{repo}}/tree/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
+    src="https://nbviewer.jupyter.org/github/{{repo}}/{{'blob' if filepath else 'tree'}}/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
   ></iframe>
 </div>
 </div>


### PR DESCRIPTION
nbviewer redirects /blob/ requests for directories to /tree/ but not reliably vice versa

/tree/ is required when the root of a repo is requested, though (i.e. no filepath given)