### PR TITLE
copybutton extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'autodoc_traits',
+    'sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -6,3 +6,4 @@ docker
 kubernetes
 escapism
 requests
+sphinx-copybutton


### PR DESCRIPTION
Adds the copybutton extension that I put together to add copy buttons to code blocks. Here's what the built site looks like:

https://predictablynoisy.com/binderhub/setup-binderhub.html#install-binderhub