### PR TITLE
bumping jupyterhub chart version for culler fix

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-90c6371"
+  version: "v0.7.0-def0465"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
Need to wait to merge this until https://travis-ci.org/jupyterhub/zero-to-jupyterhub-k8s/builds/401920554 passes so the chart is published

cc @minrk 