### PR TITLE
Fix some syntax errors, remove unused include

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ before_install:
 install:
 - export PATH=$PWD/bin:$PATH
 - ./ci/install.sh
-- pip install --no-cache-dir . -r dev-requirements.txt
+- pip install -r dev-requirements.txt
 - npm install
 - npm run webpack
 # sphinx requirements
-- pip install --no-cache-dir . -r docs/doc-requirements.txt
+- pip install -r doc/doc-requirements.txt
 script:
 - export BINDER_TEST_NAMESPACE=binder-test-$TEST
 - travis_wait ./ci/test-$TEST
-- cd docs && make html
+- cd doc && make html
 after_failure:
 - |
   # get pod logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,12 @@ install:
 - pip install --no-cache-dir . -r dev-requirements.txt
 - npm install
 - npm run webpack
+# sphinx requirements
+- pip install --no-cache-dir . -r docs/doc-requirements.txt
 script:
 - export BINDER_TEST_NAMESPACE=binder-test-$TEST
 - travis_wait ./ci/test-$TEST
+- cd docs && make html
 after_failure:
 - |
   # get pod logs

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -W -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = BinderHub
 SOURCEDIR     = .
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -W -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/create-cloud-resources.rst
+++ b/doc/create-cloud-resources.rst
@@ -23,9 +23,6 @@ Setting up Kubernetes on `Google Cloud <https://cloud.google.com/>`_
    If you would like to help with adding instructions for other cloud
    providers, `please contact us <https://github.com/jupyterhub/binderhub/issues>`_!
 
-.. include:: k8s.txt
-   :start-after: Setting up Kubernetes on `Google Cloud <https://cloud.google.com/>`_
-   :end-before: .. _microsoft-azure:
 
 Install Helm
 ------------

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -33,12 +33,13 @@ After a user clicks a Binder link, the following chain of events happens:
    ``ref`` (git commit hash, branch, or tag).
 3. **If the image doesn't exist**, BinderHub creates a ``build`` pod that uses
    `repo2docker <https://github.com/jupyter/repo2docker>`_ to do the following:
-      * Fetch the repository associated with the link
-      * Build a Docker container image containing the environment specified in
-        `configuration files <https://mybinder.readthedocs.io/en/latest/using.html#supported-configuration-files>`_
-        in the repository.
-      * Push that image to a Docker registry, and send the registry information
-        to the BinderHub for future reference.
+
+   - Fetch the repository associated with the link
+   - Build a Docker container image containing the environment specified in
+     `configuration files <https://mybinder.readthedocs.io/en/latest/using.html#supported-configuration-files>`_
+     in the repository.
+   - Push that image to a Docker registry, and send the registry information
+     to the BinderHub for future reference.
 4. BinderHub sends the Docker image registry to **JupyterHub**.
 5. JupyterHub creates a Kubernetes pod for the user that serves the built Docker image
    for the repository.


### PR DESCRIPTION
I removed the `k8s.txt` include because it was broken (and not being included at the moment). From the contents of `k8s.txt` and where it was being included I couldn't quite work out what should be included/in `k8s.txt`.

This also sets up travis so it runs the docs build as part of a PR to make sure we don't break the docs and don't notice.