### PR TITLE
if build.nodeSelector is defined, use it to assign dind pods to nodes

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -18,6 +18,7 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      nodeSelector: {{ toJson .Values.build.nodeSelector }}
       {{ if .Values.dind.initContainers -}}
       initContainers:
 {{ toYaml .Values.dind.initContainers | indent 10 }}


### PR DESCRIPTION
so we don’t run dind on nodes where there won’t be any builds