### PR TITLE
truncate initial build logs

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -140,6 +140,14 @@ class BinderHub(Application):
         config=True,
     )
 
+    log_tail_lines = Integer(
+        100,
+        help="""
+        Limit number of log lines to show when connecting to an already running build.
+        """,
+        config=True,
+    )
+
     docker_push_secret = Unicode(
         'docker-push-secret',
         allow_none=True,
@@ -437,6 +445,7 @@ class BinderHub(Application):
             "builder_image_spec": self.builder_image_spec,
             'build_node_selector': self.build_node_selector,
             'build_pool': self.build_pool,
+            'log_tail_lines': self.log_tail_lines,
             'per_repo_quota': self.per_repo_quota,
             'repo_providers': self.repo_providers,
             'use_registry': self.use_registry,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -33,7 +33,7 @@ class Build:
     """
     def __init__(self, q, api, name, namespace, git_url, ref, builder_image,
                  image_name, push_secret, memory_limit, docker_host, node_selector,
-                 appendix=''):
+                 appendix='', log_tail_lines=100):
         self.q = q
         self.api = api
         self.git_url = git_url
@@ -48,6 +48,7 @@ class Build:
         self.docker_host = docker_host
         self.node_selector = node_selector
         self.appendix = appendix
+        self.log_tail_lines = log_tail_lines
 
     def get_cmd(self):
         """Get the cmd to run to build the image"""
@@ -162,6 +163,7 @@ class Build:
                 self.name,
                 self.namespace,
                 follow=True,
+                tail_lines=self.log_tail_lines,
                 _preload_content=False):
             # verify that the line is JSON
             line = line.decode('utf-8')

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -29,6 +29,7 @@ data:
   {{ if .Values.build.appendix -}}
   binder.appendix: {{ .Values.build.appendix | quote }}
   {{- end }}
+  binder.log-tail-lines: {{ .Values.build.logTailLines | quote }}
 
   binder.retries.count: {{ .Values.retries.count | quote }}
   binder.retries.delay: {{ .Values.retries.delay | quote }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -24,6 +24,7 @@ build:
   repo2dockerImage: jupyter/repo2docker:687788f
   nodeSelector: {}
   appendix:
+  logTailLines: 100
 
 perRepoQuota: 100
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -34,6 +34,7 @@ c.BinderHub.per_repo_quota = get_config('binder.per-repo-quota', 0)
 
 c.BinderHub.builder_image_spec = get_config('binder.repo2docker-image')
 c.BinderHub.build_node_selector = get_config('binder.build-node-selector', {})
+c.BinderHub.log_tail_lines = get_config('binder.log-tail-lines', 100)
 
 if os.path.exists('/etc/binderhub/config/binder.appendix'):
     with open('/etc/binderhub/config/binder.appendix') as f:


### PR DESCRIPTION
to the last N lines prior to connecting if there are more than N lines of logs already.

Applies when connecting to running builds with a lot of logs already. Shouldn't affect builds that the current request is starting, but should mitigate the cost of many watchers connecting to watch a long-running build that produces a lot of output, which caused the latest [mybinder.org outage](https://github.com/jupyterhub/mybinder.org-deploy/pull/680).

adds `BinderHub.log_tail_lines` config, which is passed as `tail_lines` to the kubernetes log command. In the helm chart as `build.logTailLines`.

Default is 100 lines.

This is the equivalent of the command-line:

    kubectl logs --tail 100 -f build-pod-name