### PR TITLE
Do not re-use build pool for launches

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -395,7 +395,7 @@ class BuildHandler(BaseHandler):
         total_pods = 0
 
         # TODO: run a watch to keep this up to date in the background
-        pool = self.settings['build_pool']
+        pool = self.settings['executor']
         f = pool.submit(kube.list_namespaced_pod,
             self.settings["build_namespace"],
             label_selector='app=jupyterhub,component=singleuser-server',

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -82,7 +82,6 @@ class Launcher(LoggingConfigurable):
         from https://github.com/minrk/binder-example.git
         """
         # start with url path
-        print
         if '://' not in repo and _ssh_repo_pat.match(repo):
             # ssh url
             path = repo.split(':', 1)[1]
@@ -104,7 +103,6 @@ class Launcher(LoggingConfigurable):
 
     async def launch(self, image, username):
         """Launch a server for a given image
-
 
         - creates the user on the Hub
         - spawns a server for that user


### PR DESCRIPTION
when the build queue is full, it shouldn't prevent launches of already built images, which it was doing.