### PR TITLE
Use underscore in python package name

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,10 +6,9 @@ dependencies:
 - traitlets>=4.1
 - tornado>=4.1
 - sphinx>=1.4, !=1.5.4
-- pip
 - pip:
   - recommonmark==0.4.0
   - docker
   - kubernetes==3.*
   - prometheus_client
-  - sphinx-copybutton
+  - sphinx_copybutton


### PR DESCRIPTION
Closes #627 

Also, reset build in RTD parameters to use conda as specified in rtd.yml file.