### PR TITLE
[WIP] fix preview on loading page when branch has slashes in it

### DIFF
--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -26,7 +26,7 @@
 
 {% block preview %}
 {# we can only produce an nbviewer URL for github right now #}
-{% set prefix, repo_ref = provider_spec.split('/', 1) %}
+{% set prefix, org_repo_ref = provider_spec.split('/', 1) %}
 {% if prefix == "gh" %}
 <div class="preview container">
 <p class="preview-text text-center">
@@ -35,10 +35,10 @@ Here's a non-interactive preview on
 while we start a server for you.
 Your binder will open automatically when it is ready.
 </p>
-{% set repo, ref = repo_ref.rsplit('/', 1) %}
+{% set org, repo, ref = org_repo_ref.split('/', 2) %}
 <div id="nbviewer-preview">
   <iframe
-    src="https://nbviewer.jupyter.org/github/{{repo}}/{{'blob' if filepath else 'tree'}}/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
+    src="https://nbviewer.jupyter.org/github/{{org}}/{{repo}}/{{'blob' if filepath else 'tree'}}/{{ref}}/{% if filepath %}{{ filepath }}{% endif %}"
   ></iframe>
 </div>
 </div>


### PR DESCRIPTION
Hello,

I was trying to load this Binder:
https://mybinder.org/v2/gh/dib-lab/khmer/feature/nodegraph_distance?filepath=notebooks%2Fdebug_graphs.ipynb
where the branch is `feature/nodegraph_distance` (yes, who name branches with slashes in it? :wave:). It fails to load the preview in the loading page because it's trying to load 
https://nbviewer.jupyter.org/github/dib-lab/khmer/feature/blob/nodegraph_distance/notebooks/debug_graphs.ipynb
instead of
https://nbviewer.jupyter.org/github/dib-lab/khmer/blob/feature/nodegraph_distance/notebooks/debug_graphs.ipynb

![image](https://user-images.githubusercontent.com/6642/43929477-035c805a-9bea-11e8-91a4-6c2b8eabdef9.png)

And I just found out that nbviewer also has issue with branches with slashes in the URL: https://github.com/jupyter/nbviewer/issues/665 so I think I'll try to go fix it there and come back to this one later :smiley: 

Update: there is a closed PR in nbviewer to deal with this https://github.com/jupyter/nbviewer/pull/411