### PR TITLE
adding escapism to docs build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'autodoc_traits',
-    'sphinx_copybutton'
+    'sphinx_copybutton.sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - kubernetes==3.*
   - prometheus_client
   - sphinx_copybutton
+  - escapism


### PR DESCRIPTION
I noticed that RTD is returning an error because escapism isn't installed, this adds it to environment.yml in the docs

edit: gonna self-merge this since the docs will be broken until it's merged!