### PR TITLE
bump jupyterhub chart 8c0aeef...d5a68a3

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-8c0aeef"
+  version: "v0.7.0-d5a68a3"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
To be deployed Tuesday 08.14

bumps dependencies in the hub chart. Mainly kubespawner, jupyterhub relevant here. This should get the jupyterhub self-restart after consecutive failures that may help with the current reflector issues. It also has some reflector changes in kubespawner that may help as well.

Compare links:

- helm chart: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/8c0aeef...d5a68a3
- kubespawner: https://github.com/jupyterhub/kubespawner/compare/7ae9900...e8f446c3
- jupyterhub: https://github.com/jupyterhub/jupyterhub/compare/0.9.1...0.9.2