### PR TITLE
Keep watching build pod status

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -155,11 +155,9 @@ class Build:
                     if f['type'] == 'DELETED':
                         self.progress('pod.phasechange', 'Deleted')
                         return
-                    if self.stop_event.is_set():
-                        app_log.info("Stopping watch of %s", self.name)
-                        return
                     self.pod = f['object']
-                    self.progress('pod.phasechange', self.pod.status.phase)
+                    if not self.stop_event.is_set():
+                        self.progress('pod.phasechange', self.pod.status.phase)
                     if self.pod.status.phase == 'Succeeded':
                         self.cleanup()
                     elif self.pod.status.phase == 'Failed':

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -287,7 +287,7 @@ class BuildHandler(BaseHandler):
         else:
             push_secret = None
 
-        BuildClass = FakeBuild if self.settings.get('fake_build', None) else Build
+        BuildClass = FakeBuild if self.settings.get('fake_build') else Build
         binder_url = '{proto}://{host}{base_url}v2/{provider}/{spec}'.format(
             proto=self.request.protocol,
             host=self.request.host,
@@ -320,7 +320,7 @@ class BuildHandler(BaseHandler):
         with BUILDS_INPROGRESS.track_inprogress():
             build_starttime = time.perf_counter()
             pool = self.settings['build_pool']
-            """----- Build starts here -----"""
+            # Start building
             submit_future = pool.submit(build.submit)
             # TODO: hook up actual error handling when this fails
             IOLoop.current().add_callback(lambda : submit_future)
@@ -366,7 +366,7 @@ class BuildHandler(BaseHandler):
                     # We expect logs to be already JSON structured anyway
                     event = progress['payload']
                     payload = json.loads(event)
-                    if payload.get('phase', None) == 'failure':
+                    if payload.get('phase') == 'failure':
                         failed = True
                         BUILD_TIME.labels(status='failure', **self.metric_labels).observe(time.perf_counter() - build_starttime)
 


### PR DESCRIPTION
Do not stop watching a build pod's state changes

If a client disconnects from the build log we have to continue to watch
for status changes of the build pod in order to clean it up when it
completes or fails.

I think this is the source of the behaviour we are seeing since the last deploy:

![pod-activity](https://user-images.githubusercontent.com/1448859/44116815-d2dffbf6-a011-11e8-9cc6-03302c086d3a.png)

where over time build pods in "Completed" state pile up. I think this happens when someone starts a build and then disconnects/closes their browser tab. We stop the watch and so never notice that the pod is now done and clean it up. We introduced the behaviour of stopping watches recently to cope with very long running/never ending builds that are also very popular. They would use up all the threads in the thread pool. Having many threads also used a lot of resources.

Not sure this solution is ideal as it can now happen that there is one space left in the thread pool to start the build but not another one to stream the logs because a watch is still on for a previously created build pod's status. This will lead to confusing behaviour for a user.

A way out would be to make two thread pools: one for build pod state changes and one for log streaming, with the build pod state pool being smaller than the log streaming pool.