### PR TITLE
Bump chartpress dependency to work around ruamel.yaml changes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,4 @@ pytest-cov
 pytest-tornado
 requests
 ruamel.yaml>=0.15
-https://github.com/jupyterhub/chartpress/archive/271c75e.tar.gz
+https://github.com/jupyterhub/chartpress/archive/2f26733f6ebf9e2b76bd9cfa3b8a8439daa0b16c.tar.gz


### PR DESCRIPTION
Bring in a newer version of chartpress to fix build errors like https://travis-ci.org/jupyterhub/binderhub/jobs/416092817 due to ruamel.yaml changing the type of objects.

The changes this brings in https://github.com/jupyterhub/chartpress/compare/271c75e...2f26733f6ebf9e2b76bd9cfa3b8a8439daa0b16c