### PR TITLE
Added access-control-allow-headers

### DIFF
--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -13,6 +13,7 @@ class BaseHandler(web.RequestHandler):
         headers = self.settings.get('headers', {})
         for header, value in headers.items():
             self.set_header(header, value)
+        self.set_header("access-control-allow-headers","cache-control")
 
     def get_provider(self, provider_prefix, spec):
         """Construct a provider object"""

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -13,7 +13,7 @@ class BaseHandler(web.RequestHandler):
         headers = self.settings.get('headers', {})
         for header, value in headers.items():
             self.set_header(header, value)
-        self.set_header("access-control-allow-headers","cache-control")
+        self.set_header("access-control-allow-headers", "cache-control")
 
     def get_provider(self, provider_prefix, spec):
         """Construct a provider object"""


### PR DESCRIPTION
#315 
Remediates an issue where requests made from a serviceworker were denied due to a lack of access-control-allow-headers: "cache-control"