### PR TITLE
avoid stopping build-pod watch when nobody’s looking

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -167,9 +167,10 @@ class Build:
                 raise
             finally:
                 w.stop()
-            if self.stop_event.is_set():
-                app_log.info("Stopping watch of %s", self.name)
-                return
+            # TODO: watch/cleanup build pod existence in a dedicated thread
+            # if self.stop_event.is_set():
+            #     app_log.info("Stopping watch of %s", self.name)
+            #     return
 
     def stream_logs(self):
         """Stream a pod's logs"""


### PR DESCRIPTION
Finishes #637 by commenting-out remaining check of stop_event

We should switch this over to a dedicated thread watching *all* build pods and deleting the stopped ones, rather than a watch thread for each build pod, but this will fix the accumulating build pods for now.