### PR TITLE
bump jupyterhub chart d5a68a3...8ac37f9

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -39,7 +39,7 @@ kubectl get nodes
 kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 
 echo "installing helm"
-curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz \
+curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz \
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 chmod +x bin/helm
 

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-d5a68a3"
+  version: "v0.7.0-8ac37f9"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
kubespawner is bumped to 0.9b2

chart changes (mostly docs):

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/d5a68a3...8ac37f9

kubespawner changes (mostly testing, adds some validation and attempts to fix reflector issues):

https://github.com/jupyterhub/kubespawner/compare/e8f446c3...v0.9.0b2