### PR TITLE
delete build pods periodically Periodically watch and cleanup build pods

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -425,6 +425,7 @@ class BinderHub(Application):
         self.log = tornado.log.app_log
 
         self.init_pycurl()
+        self.log.info("Are you there god?")
 
         # initialize kubernetes config
         if self.builder_required:

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -123,17 +123,17 @@ class Build:
 
             if delete:
                 deleted += 1
-            try:
-                kube.delete_namespaced_pod(
-                    name=build.metadata.name,
-                    namespace=namespace,
-                    body=client.V1DeleteOptions(grace_period_seconds=0))
-            except client.rest.ApiException as e:
-                if e.status == 404:
-                    # Is ok, someone else has already deleted it
-                    pass
-                else:
-                    raise
+                try:
+                    kube.delete_namespaced_pod(
+                        name=build.metadata.name,
+                        namespace=namespace,
+                        body=client.V1DeleteOptions(grace_period_seconds=0))
+                except client.rest.ApiException as e:
+                    if e.status == 404:
+                        # Is ok, someone else has already deleted it
+                        pass
+                    else:
+                        raise
 
         if deleted:
             app_log.info("Deleted %i/%i build pods", deleted, len(builds))

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -109,6 +109,9 @@ class Build:
                     "name": self.name,
                     "component": "binderhub-build",
                 },
+                annotations={
+                    "binder-repo": self.git_url,
+                },
             ),
             spec=client.V1PodSpec(
                 containers=[

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -2,6 +2,8 @@
 Contains build of a docker image from a git repository.
 """
 
+from collections import defaultdict
+import datetime
 import json
 import threading
 from urllib.parse import urlparse
@@ -80,6 +82,63 @@ class Build:
 
         return cmd
 
+    @classmethod
+    def cleanup_builds(cls, kube, namespace, max_age):
+        """Delete stopped build pods and build pods that have aged out"""
+        builds = kube.list_namespaced_pod(
+            namespace=namespace,
+            label_selector='component=binderhub-build',
+        ).items
+        phases = defaultdict(int)
+        app_log.debug("%i build pods", len(builds))
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        start_cutoff = now - datetime.timedelta(seconds=max_age)
+        deleted = 0
+        for build in builds:
+            phase = build.status.phase
+            phases[phase] += 1
+            annotations = build.metadata.annotations or {}
+            repo = annotations.get("binder-repo", "unknown")
+            delete = False
+            if build.status.phase in {'Failed', 'Succeeded', 'Evicted'}:
+                # log Deleting Failed build build-image-...
+                # print(build.metadata)
+                app_log.info(
+                    "Deleting %s build %s (repo=%s)",
+                    build.status.phase,
+                    build.metadata.name,
+                    repo,
+                )
+                delete = True
+            else:
+                # check age
+                started = build.status.start_time
+                if max_age and started and started < start_cutoff:
+                    app_log.info(
+                        "Deleting long-running build %s (repo=%s)",
+                        build.metadata.name,
+                        repo,
+                    )
+                    delete = True
+
+            if delete:
+                deleted += 1
+            try:
+                kube.delete_namespaced_pod(
+                    name=build.metadata.name,
+                    namespace=namespace,
+                    body=client.V1DeleteOptions(grace_period_seconds=0))
+            except client.rest.ApiException as e:
+                if e.status == 404:
+                    # Is ok, someone else has already deleted it
+                    pass
+                else:
+                    raise
+
+        if deleted:
+            app_log.info("Deleted %i/%i build pods", deleted, len(builds))
+        app_log.debug("Build phase summary: %s", json.dumps(phases, sort_keys=True, indent=1))
+
     def progress(self, kind, obj):
         """Put the current action item into the queue for execution."""
         self.main_loop.add_callback(self.q.put, {'kind': kind, 'payload': obj})
@@ -146,7 +205,7 @@ class Build:
             app_log.info("Started build %s", self.name)
 
         app_log.info("Watching build pod %s", self.name)
-        while True:
+        while not self.stop_event.is_set():
             w = watch.Watch()
             try:
                 for f in w.stream(
@@ -170,10 +229,9 @@ class Build:
                 raise
             finally:
                 w.stop()
-            # TODO: watch/cleanup build pod existence in a dedicated thread
-            # if self.stop_event.is_set():
-            #     app_log.info("Stopping watch of %s", self.name)
-            #     return
+            if self.stop_event.is_set():
+                app_log.info("Stopping watch of %s", self.name)
+                return
 
     def stream_logs(self):
         """Stream a pod's logs"""

--- a/ci/test-main
+++ b/ci/test-main
@@ -7,5 +7,5 @@ set -ex
 # DEBUG: give the hub a chance to wake up
 sleep 10
 export ASYNC_TEST_TIMEOUT=15
-pytest -vsx --cov binderhub
+pytest --log-cli-level=10 -vsx --cov binderhub
 helm delete --purge binder-test-hub

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -30,6 +30,8 @@ data:
   binder.appendix: {{ .Values.build.appendix | quote }}
   {{- end }}
   binder.log-tail-lines: {{ .Values.build.logTailLines | quote }}
+  binder.build-max-age: {{ .Values.build.maxAge | quote }}
+  binder.build-cleanup-interval: {{ .Values.build.cleanupInterval | quote }}
 
   binder.retries.count: {{ .Values.retries.count | quote }}
   binder.retries.delay: {{ .Values.retries.delay | quote }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -25,6 +25,9 @@ build:
   nodeSelector: {}
   appendix:
   logTailLines: 100
+  # 14400 is 4 hours
+  maxAge: 14400
+  cleanupInterval: 120
 
 perRepoQuota: 100
 

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -29,6 +29,14 @@ if get_config('binder.use-registry'):
 c.BinderHub.docker_push_secret = get_config('binder.push-secret')
 c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
+cleanup_interval = get_config('binder.build-cleanup-interval', None)
+if cleanup_interval is not None:
+    c.BinderHub.build_cleanup_interval = cleanup_interval
+
+max_age = get_config('binder.build-max-age', None)
+if max_age is not None:
+    c.BinderHub.build_max_age = max_age
+
 c.BinderHub.use_registry = get_config('binder.use-registry', True)
 c.BinderHub.per_repo_quota = get_config('binder.per-repo-quota', 0)
 


### PR DESCRIPTION
Adds config:

- `build_max_age` (max age to stop long-running builds)
- `build_cleanup_interval` (interval on which to check for stopped and/or too-long pods)

Fixes:

- fixes builds orphaned when binderhub restarts
- removes need to keep a watch for each build tied to each request beyond the lifetime of the request (solves #637 without reverting #628)

I elected to not do this with a watch because it's simpler this way,
and given that watches have proven to be unreliable and require restarting every 30-60 seconds, this is actually *less* costly resource-wise than running a robust watch.