### PR TITLE
bump jupyterhub chart 8ac37f9...8fca5fa

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7.0-8ac37f9"
+  version: "0.8.0-8fca5fa"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
this gets the new user scheduler, which should improve packing and scale-down

https://github.com/jupyterhub/zero-to-jupyterhub/compare/8ac37f9...8fca5fa