### PR TITLE
update documentation for increasing GitHub API limit

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -230,10 +230,12 @@ an API access token to raise your API limit to 5000 requests an hour.
 
 2. Store your new token somewhere secure (e.g. keychain, netrc, etc.)
 
-3. Before running your BinderHub server, run the following::
+3. Update ``secret.yaml`` by entering the following::
 
-       export GITHUB_ACCESS_TOKEN=<insert_token_value_here>
+    github:
+      accessToken: <insert_token_value_here>
 
+This value will be loaded into `GITHUB_ACCESS_TOKEN` environment variable and
 BinderHub will automatically use the token stored in this variable when making
 API requests to GitHub. See the `GitHub authentication documentation
 <https://developer.github.com/v3/guides/getting-started/#authentication>`_ for


### PR DESCRIPTION
Documentation for increasing GitHub API limit is updated to use `github.accessToken` in secret.yaml.