### PR TITLE
raise exception if last api call fails

### DIFF
--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -53,7 +53,8 @@ class Launcher(LoggingConfigurable):
         """Make an API request to JupyterHub"""
         headers = kwargs.setdefault('headers', {})
         headers.update({'Authorization': 'token %s' % self.hub_api_token})
-        req = HTTPRequest(self.hub_url + 'hub/api/' + url, *args, **kwargs)
+        request_url = self.hub_url + 'hub/api/' + url
+        req = HTTPRequest(request_url, *args, **kwargs)
         retry_delay = self.retry_delay
         for i in range(1, self.retries + 1):
             try:
@@ -68,7 +69,10 @@ class Launcher(LoggingConfigurable):
                 # e.g. 502,504 due to ingress issues or Hub relocating,
                 # 599 due to connection issues such as Hub restarting
                 if e.code >= 500:
-                    self.log.error("Error accessing Hub API (%s)", e)
+                    self.log.error("Error accessing Hub API (using %s): %s", request_url, e)
+                    if i == self.retries:
+                        # last api request failed, raise the exception
+                        raise
                     await gen.sleep(retry_delay)
                     # exponential backoff for consecutive failures
                     retry_delay *= 2


### PR DESCRIPTION
When `launcher.api_request` fails with `e.code >= 500`, no exception is raised. It should raise an exception after the last try. But now `launcher.api_request` returns `None` even it fails and then it causes server errors and user is not informed properly.