### PR TITLE
stop trimming trailing / on files

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -95,10 +95,11 @@ Image.prototype.launch = function(url, token, path, pathType) {
     if (path) {
       // strip trailing /
       url = url.replace(/\/$/, '');
-      // trim trailing and leading '/'
-      // trailing '/' causes ERR_TOO_MANY_REDIRECTS in user server
-      path = path.replace(/(^\/)|(\/?$)/g, '');
+      // trim leading '/'
+      path = path.replace(/(^\/)/g, '');
       if (pathType === 'file') {
+        // trim trailing / on file paths
+        path = path.replace(/(\/$)/g, '');
         // /tree is safe because it allows redirect to files
         // need more logic here if we support things other than notebooks
         url = url + '/tree/' + encodeURI(path);


### PR DESCRIPTION
regression in #660 to fix #456 applied to urlpath in addition to filepath, when it should only have applied to filepath

Trailing / on a urlpath can be important to routing, so we shouldn't strip it. If there is an error with a urlpath that doesn't work, it is not the responsibility of Binder to fix it.

closes https://github.com/jupyterhub/mybinder.org-deploy/issues/731