### PR TITLE
Allow admins to add extra scripts to footer

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -86,6 +86,16 @@ class BinderHub(Application):
         config=True
     )
 
+    extra_footer_scripts = Unicode(
+        '',
+        help="""
+        Extra bits of JavaScript that should be loaded in footer of each page.
+
+        Omit the <script> tag. This should be primarily used for
+        analytics code.
+        """
+    )
+
     base_url = Unicode(
         '/',
         help="The base URL of the entire application",
@@ -474,6 +484,7 @@ class BinderHub(Application):
             'traitlets_config': self.config,
             'google_analytics_code': self.google_analytics_code,
             'google_analytics_domain': self.google_analytics_domain,
+            'extra_footer_scripts': self.extra_footer_scripts,
             'jinja2_env': jinja_env,
             'build_memory_limit': self.build_memory_limit,
             'build_docker_host': self.build_docker_host,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -18,6 +18,7 @@ class MainHandler(BaseHandler):
             submit=False,
             google_analytics_code=self.settings['google_analytics_code'],
             google_analytics_domain=self.settings['google_analytics_domain'],
+            extra_footer_scripts=self.settings['extra_footer_scripts'],
         )
 
 
@@ -60,6 +61,7 @@ class ParameterizedMainHandler(BaseHandler):
             submit=True,
             google_analytics_code=self.settings['google_analytics_code'],
             google_analytics_domain=self.settings['google_analytics_domain'],
+            extra_footer_scripts=self.settings['extra_footer_scripts'],
         )
 
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -52,6 +52,10 @@
   }
   </script>
   {% endif %}
+  {% if extra_footer_scripts %}
+  <script>
+    {{ extra_footer_scripts }}
+  </script>
   {% endblock body %}
 </body>
 </html>

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -19,6 +19,10 @@ data:
   {{ if .Values.googleAnalyticsDomain -}}
   binder.google-analytics-domain: {{ .Values.googleAnalyticsDomain | quote }}
   {{- end }}
+  {{ if .Values.extraFooterScripts }}
+  binder.extra-footer-scripts: |
+{{ .Values.extraFooterScripts | indent 4 }}
+  {{- end }}
   binder.cors: {{ toJson .Values.cors | quote }}
   binder.per-repo-quota: {{ .Values.perRepoQuota | quote }}
   binder.registry.prefix: {{ .Values.registry.prefix | quote }}

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -58,6 +58,8 @@ google_analytics_domain = get_config('binder.google-analytics-domain', None)
 if google_analytics_domain:
     c.BinderHub.google_analytics_domain = google_analytics_domain
 
+c.BinderHub.extra_footer_scripts = get_config('binder.extra-footer-scripts', '')
+
 c.BinderHub.base_url = get_config('binder.base-url')
 
 if get_config('dind.enabled', False):


### PR DESCRIPTION
This lets us add tracking & other arbitrary JS without having
to add support for each of them specifically.

The Google Analytics code should be moved to use this instead
too.

Ref https://github.com/jupyterhub/mybinder.org-deploy/issues/725