### PR TITLE
Mark footer scripts as safe

### DIFF
--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -55,7 +55,7 @@
   {% if extra_footer_scripts %}
   {% for script in extra_footer_scripts|dictsort %}
   <script>
-    {{ script }}
+    {{ script|safe }}
   </script>
   {% endfor %}
   {% endif %}


### PR DESCRIPTION
This is admin provided JS, so we gotta count it as safe.
Currently, this gets double escaped.

Followup #670 