### PR TITLE
Mark extra_footer_scripts as safe

### DIFF
--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -55,7 +55,7 @@
   {% if extra_footer_scripts %}
   {% for script in extra_footer_scripts|dictsort %}
   <script>
-    {{ script|safe }}
+    {{ script[1]|safe }}
   </script>
   {% endfor %}
   {% endif %}


### PR DESCRIPTION
dictsort returns tuples (like .items()), not values.

Followup #670 

