### PR TITLE
Less opinionated ingress template

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -1,34 +1,32 @@
 {{- if .Values.ingress.enabled -}}
+{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: binderhub
-  {{- if or (and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego")) .Values.ingress.annotations }}
+{{- with .Values.ingress.annotations }}
   annotations:
-    {{- if eq .Values.ingress.https.type  "kube-lego" }}
-    kubernetes.io/tls-acme: "true"
-    {{ end -}}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
-  {{- end }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ $ingressPath }}
             backend:
               serviceName: binder
               servicePort: 8585
-    {{- end }}
-{{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
-  tls:
-    - secretName: kubelego-tls-binder-{{ .Release.Name }}
-      hosts:
-        {{- range $host := .Values.ingress.hosts }}
-        - {{ $host }}
-        {{- end }}
+  {{- end }}
 {{- end }}
-{{- end -}}

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -9,16 +9,6 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
-  {{- end }}
-{{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ . | quote }}
@@ -29,4 +19,14 @@ spec:
               serviceName: binder
               servicePort: 8585
   {{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -1,32 +1,44 @@
 {{- if .Values.ingress.enabled -}}
-{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: binderhub
-{{- with .Values.ingress.annotations }}
+  {{- if or (and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego")) .Values.ingress.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    {{- if eq .Values.ingress.https.type  "kube-lego" }}
+    kubernetes.io/tls-acme: "true"
+    {{ end -}}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
-          - path: {{ $ingressPath }}
+          - path: /
             backend:
               serviceName: binder
               servicePort: 8585
-  {{- end }}
-{{- if .Values.ingress.tls }}
+    {{- end }}
+{{- if .Values.ingress.https.enabled }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- if eq .Values.ingress.https.type "kube-lego" }}
+    - secretName: kubelego-tls-binder-{{ .Release.Name }}
+      hosts:
+        {{- range $host := .Values.ingress.hosts }}
+        - {{ $host }}
+        {{- end }}
+  {{- else }}
+    {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
+    {{- end }}
   {{- end }}
 {{- end }}
-{{- end }}
+{{- end -}}


### PR DESCRIPTION
## Description
Changes the `ingress.yaml` template file to be less opinionated, particularly about the use of the `kube-lego` project for TLS . The template is based off of the ingress template generated from `helm create <chart-name>` from Helm client v2.11.0. 

## Motivation and Context
Resolves issue https://github.com/jupyterhub/binderhub/issues/676. Basically, I thought it was strange that the ingress template required usage of `kube-lego`.

## How Has This Been Tested?

Locally tested with the following values:

```yaml
ingress:
  annotations:
    external-dns.alpha.kubernetes.io/hostname: binderhub.company.com
    kubernetes.io/ingress.class: nginx-external
    nginx.ingress.kubernetes.io/configuration-snippet: |
      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
      more_set_headers "X-Content-Type-Options: nosniff";
      more_set_headers "X-Frame-Options: SAMEORIGIN";
      more_set_headers "X-XSS-Protection: 1; mode=block";
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    nginx.ingress.kubernetes.io/ingress.class: nginx-external
  enabled: true
  path: /
  hosts:
  - binderhub.company.com
  tls:
  - hosts:
    - binderhub.company.com
    secretName: star-company-com-tls
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.