### PR TITLE
Bump default r2d version

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -293,7 +293,7 @@ class BinderHub(Application):
     )
 
     builder_image_spec = Unicode(
-        'jupyter/repo2docker:687788f',
+        'jupyter/repo2docker:2ebc87b',
         help="""
         The builder image to be used for doing builds
         """,

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -27,7 +27,7 @@ image:
   tag: local
 
 build:
-  repo2dockerImage: jupyter/repo2docker:46f056a
+  repo2dockerImage: jupyter/repo2docker:2ebc87b
   nodeSelector: {}
   appendix:
   logTailLines: 100


### PR DESCRIPTION
BinderHub by default seemed to be using a much older
version of repo2docker by default than what we are
using in mybinder.org. This commit brings them to
sync.