### PR TITLE
passthrough BinderHub config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+helm-chart
+!helm-chart/images

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -185,7 +185,7 @@ class BinderHub(Application):
         config=True,
     )
 
-    docker_push_secret = Unicode(
+    push_secret = Unicode(
         'binder-push-secret',
         allow_none=True,
         help="""
@@ -194,12 +194,12 @@ class BinderHub(Application):
         config=True
     )
 
-    docker_image_prefix = Unicode(
+    image_prefix = Unicode(
         "",
         help="""
         Prefix for all built docker images.
 
-        If you are pushing to gcr.io, you would have this be:
+        If you are pushing to gcr.io, this would start with:
             gcr.io/<your-project-name>/
 
         Set according to whatever registry you are pushing to.
@@ -278,7 +278,7 @@ class BinderHub(Application):
         help="""
         Kubernetes namespace to spawn build pods in.
 
-        Note that the docker_push_secret must refer to a secret in this namespace.
+        Note that the push_secret must refer to a secret in this namespace.
         """,
         config=True
     )
@@ -286,7 +286,7 @@ class BinderHub(Application):
     build_image = Unicode(
         'jupyter/repo2docker:2ebc87b',
         help="""
-        The builder image to be used for doing builds
+        The repo2docker image to be used for doing builds
         """,
         config=True
     )
@@ -463,8 +463,8 @@ class BinderHub(Application):
         self.event_log = EventLog(parent=self)
 
         self.tornado_settings.update({
-            "docker_push_secret": self.docker_push_secret,
-            "docker_image_prefix": self.docker_image_prefix,
+            "push_secret": self.push_secret,
+            "image_prefix": self.image_prefix,
             "debug": self.debug,
             'launcher': self.launcher,
             'appendix': self.appendix,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -185,7 +185,7 @@ class BinderHub(Application):
     )
 
     docker_push_secret = Unicode(
-        'docker-push-secret',
+        'binder-push-secret',
         allow_none=True,
         help="""
         A kubernetes secret object that provides credentials for pushing built images.

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -283,7 +283,7 @@ class BinderHub(Application):
         config=True
     )
 
-    builder_image_spec = Unicode(
+    build_image = Unicode(
         'jupyter/repo2docker:2ebc87b',
         help="""
         The builder image to be used for doing builds
@@ -469,7 +469,7 @@ class BinderHub(Application):
             'launcher': self.launcher,
             'appendix': self.appendix,
             "build_namespace": self.build_namespace,
-            "builder_image_spec": self.builder_image_spec,
+            "build_image": self.build_image,
             'build_node_selector': self.build_node_selector,
             'build_pool': self.build_pool,
             'log_tail_lines': self.log_tail_lines,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -280,6 +280,9 @@ class BinderHub(Application):
         help="""API token for talking to the JupyterHub API""",
         config=True,
     )
+    @default('hub_api_token')
+    def _default_hub_token(self):
+        return os.environ.get('JUPYTERHUB_API_TOKEN', '')
 
     hub_url = Unicode(
         help="""

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -209,7 +209,7 @@ class BinderHub(Application):
     )
 
     docker_registry_host = Unicode(
-        "",
+        "https://registry.hub.docker.com",
         help="""
         Docker registry host.
         """,
@@ -225,15 +225,24 @@ class BinderHub(Application):
 
     @default('docker_auth_host')
     def _docker_auth_host_default(self):
+        if self.docker_registry_host.endswith(".docker.com"):
+            return "https://index.docker.io/v1"
         return self.docker_registry_host
 
     docker_token_url = Unicode(
-        "",
         help="""
         Url to request docker registry authentication token.
         """,
         config=True
     )
+    @default("docker_token_url")
+    def _default_token_url(self):
+        if self.docker_registry_host == "https://gcr.io":
+            return "https://gcr.io/v2/token?service=gcr.io"
+        elif self.docker_registry_host.endswith(".docker.com"):
+            return "https://auth.docker.io/token?service=registry.docker.io"
+        else:
+            return ""
 
     build_memory_limit = ByteSpecification(
         0,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -34,7 +34,7 @@ class Build:
         API instead of having to invent our own locking code.
 
     """
-    def __init__(self, q, api, name, namespace, repo_url, ref, git_credentials, builder_image,
+    def __init__(self, q, api, name, namespace, repo_url, ref, git_credentials, build_image,
                  image_name, push_secret, memory_limit, docker_host, node_selector,
                  appendix='', log_tail_lines=100):
         self.q = q
@@ -45,7 +45,7 @@ class Build:
         self.namespace = namespace
         self.image_name = image_name
         self.push_secret = push_secret
-        self.builder_image = builder_image
+        self.build_image = build_image
         self.main_loop = IOLoop.current()
         self.memory_limit = memory_limit
         self.docker_host = docker_host
@@ -180,7 +180,7 @@ class Build:
             spec=client.V1PodSpec(
                 containers=[
                     client.V1Container(
-                        image=self.builder_image,
+                        image=self.build_image,
                         name="builder",
                         args=self.get_cmd(),
                         image_pull_policy='Always',

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -316,7 +316,7 @@ class BuildHandler(BaseHandler):
             ref=ref,
             image_name=image_name,
             push_secret=push_secret,
-            builder_image=self.settings['builder_image_spec'],
+            build_image=self.settings['build_image'],
             memory_limit=self.settings['build_memory_limit'],
             docker_host=self.settings['build_docker_host'],
             node_selector=self.settings['build_node_selector'],

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -240,7 +240,7 @@ class BuildHandler(BaseHandler):
 
         # generate a complete build name (for GitHub: `build-{user}-{repo}-{ref}`)
 
-        image_prefix = self.settings['docker_image_prefix']
+        image_prefix = self.settings['image_prefix']
 
         # Enforces max 255 characters before image
         safe_build_slug = self._safe_build_slug(provider.get_build_slug(), limit=255 - len(image_prefix))
@@ -290,7 +290,7 @@ class BuildHandler(BaseHandler):
         q = Queue()
 
         if self.settings['use_registry']:
-            push_secret = self.settings['docker_push_secret']
+            push_secret = self.settings['push_secret']
         else:
             push_secret = None
 

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -11,65 +11,101 @@ from tornado.httputil import url_concat
 from traitlets.config import LoggingConfigurable
 from traitlets import Dict, Unicode, default
 
+DEFAULT_DOCKER_REGISTRY_URL = "https://registry.hub.docker.com"
+DEFAULT_DOCKER_AUTH_URL = "https://index.docker.io/v1"
+
 
 class DockerRegistry(LoggingConfigurable):
-    registry_host = Unicode(
-        "https://registry.hub.docker.com",
+    url = Unicode(
+        DEFAULT_DOCKER_REGISTRY_URL,
         help="""
-        Docker registry host.
+        Docker registry url.
 
-        Default: same as auth_host,
-        no need to set this if using docker hub or registry host
-        is the same as the auth host.
-        """,
-        config=True,
-    )
-    @default('registry_host')
-    def _default_registry_host(self):
-        auth_host = self.auth_host
-        url = urlparse(auth_host)
-        # special-case docker, where these are different
-        if ('.' + url.hostname).endswith(('.docker.io', '.docker.com')):
-            return 'https://registry.hub.docker.com'
-        # default to the same as the auth host, if not defined
-        return "{}://{}".format(url.scheme, url.netloc)
+        Default: retrieved from docker config.json
 
-    auth_host = Unicode(
-        help="""
-        Docker authentication host.
-
-        Default: first entry in docker config.json if found,
-        otherwise the default docker auth host.
-
-        No need to set this if docker config contains
-        the right auth host.
+        Only set this if:
+        - not using docker hub, and
+        - more than one registry is configured in docker config.json
         """,
         config=True,
     )
 
-    @default('auth_host')
-    def _auth_host_default(self):
-        config_path = os.path.expanduser('~/.docker/config.json')
-        default = "https://index.docker.io/v1"
+    @default("url")
+    def _default_url(self):
         cfg = self._docker_config
         auths = cfg.get("auths", {})
-        # by default: return the first host in our docker config file
-        return next(iter(auths.keys()), default)
+        if not auths:
+            return DEFAULT_DOCKER_REGISTRY_URL
+
+        # default to first entry in docker config.json auths
+        auth_config_url = next(iter(auths.keys()))
+        if "://" not in auth_config_url:
+            # auth key can be just a hostname,
+            # which assumes https
+            auth_config_url = "https://" + auth_config_url
+
+        if auth_config_url.rstrip("/") == DEFAULT_DOCKER_AUTH_URL:
+            # default docker config key is the v1 registry,
+            # but we will talk to the v2 api
+            return DEFAULT_DOCKER_REGISTRY_URL
+
+        return auth_config_url
+
+    auth_config_url = Unicode(
+        DEFAULT_DOCKER_AUTH_URL,
+        help="""
+        Docker auth configuration url.
+
+        Used to lookup auth data in docker config.json.
+
+        Not used if url, username, and password are set.
+
+        Default: same as url
+
+        Only set if:
+        - Not using Docker Hub
+        - registry url is not the auth key in docker config.json
+        """,
+        config=True,
+    )
+
+    @default("auth_config_url")
+    def _auth_config_url_default(self):
+        url = urlparse(self.url)
+        cfg = self._docker_config
+        auths = cfg.get("auths", {})
+        # check for our url in docker config.json
+        # there can be some variation, so try a few things.
+
+        # in ~all cases, the registry url will appear in config.json
+        if self.url in auths:
+            # this will
+            return self.url
+        # ...but the config key is allowed to lack https://, so check just hostname
+        if url.hostname in auths:
+            return url.hostname
+        # default docker special-case, where auth and registry urls are different
+        if ("." + url.hostname).endswith((".docker.io", ".docker.com")):
+            return DEFAULT_DOCKER_AUTH_URL
+
+        # url not found, leave the most likely default
+        return self.url
 
     docker_config_path = Unicode(
         os.path.join(
-            os.environ.get('DOCKER_CONFIG', os.path.expanduser('~/.docker')),
-            'config.json',
+            os.environ.get("DOCKER_CONFIG", os.path.expanduser("~/.docker")),
+            "config.json",
         ),
         help=""""
         path to docker config.json
 
-        Default: ~/.docker/config.json
+        Default: ~/.docker/config.json (respects $DOCKER_CONFIG if set)
         """,
         config=True,
     )
     _docker_config = Dict()
-    @default('_docker_config')
+
+    @default("_docker_config")
     def _load_docker_config(self):
         if not os.path.exists(self.docker_config_path):
             self.log.warning("No docker config at %s", self.docker_config_path)
@@ -86,75 +122,86 @@ class DockerRegistry(LoggingConfigurable):
         """,
         config=True,
     )
+
     @default("token_url")
     def _default_token_url(self):
-        if self.registry_host == "https://gcr.io":
-            return "https://gcr.io/v2/token?service=gcr.io"
-        elif self.registry_host.endswith(".docker.com"):
+        url = urlparse(self.url)
+        if ("." + url.hostname).endswith(".gcr.io"):
+            return "https://{0}/v2/token?service={0}".format(url.hostname)
+        elif self.url.endswith(".docker.com"):
             return "https://auth.docker.io/token?service=registry.docker.io"
         else:
+            # is gcr.io's token url common? If so, it might be worth defaulting
+            # to https://registry.host/v2/token?service=registry.host
             return ""
 
     username = Unicode(
         help="""
         Username for authenticating with docker registry
 
-        Default: retrieved from docker config.
+        Default: retrieved from docker config.json.
         """,
         config=True,
     )
-    @default('username')
+
+    @default("username")
     def _default_username(self):
         b64_auth = None
-        if self.auth_host in self._docker_config.get('auths', {}):
-            b64_auth = self._docker_config['auths'][self.auth_host].get('auth')
+        if self.auth_config_url in self._docker_config.get("auths", {}):
+            b64_auth = self._docker_config["auths"][self.auth_config_url].get("auth")
 
         if not b64_auth:
-            self.log.warning("No username for docker registry at %s", self.auth_host)
-            return ''
+            self.log.warning(
+                "No username for docker registry at %s", self.auth_config_url
+            )
+            return ""
 
-        return base64.b64decode(
-            b64_auth.encode('utf-8')
-        ).decode('utf-8').split(':', 1)[0]
+        return (
+            base64.b64decode(b64_auth.encode("utf-8")).decode("utf-8").split(":", 1)[0]
+        )
 
     password = Unicode(
         help="""
         Password for authenticating with docker registry
 
-        Default: retrieved from docker config.
+        Default: retrieved from docker config.json.
         """,
         config=True,
     )
-    @default('password')
+
+    @default("password")
     def _default_password(self):
         b64_auth = None
-        if self.auth_host in self._docker_config.get('auths', {}):
-            b64_auth = self._docker_config['auths'][self.auth_host].get('auth')
+        if self.auth_config_url in self._docker_config.get("auths", {}):
+            b64_auth = self._docker_config["auths"][self.auth_config_url].get("auth")
 
         if not b64_auth:
-            self.log.warning("No password for docker registry at %s", self.auth_host)
-            return ''
+            self.log.warning(
+                "No password for docker registry at %s", self.auth_config_url
+            )
+            return ""
 
-        return base64.b64decode(
-            b64_auth.encode('utf-8')
-        ).decode('utf-8').split(':', 1)[1]
+        return (
+            base64.b64decode(b64_auth.encode("utf-8")).decode("utf-8").split(":", 1)[1]
+        )
 
     @gen.coroutine
     def get_image_manifest(self, image, tag):
         client = httpclient.AsyncHTTPClient()
         # first, get a token to perform the manifest request
+        if not self.token_url:
+            raise ValueError("No token URL for authenticating with {}".format(self.url))
         auth_req = httpclient.HTTPRequest(
-            url_concat(self.token_url,
-                       {'scope': 'repository:{}:pull'.format(image)}),
+            url_concat(self.token_url, {"scope": "repository:{}:pull".format(image)}),
             auth_username=self.username,
             auth_password=self.password,
         )
         auth_resp = yield client.fetch(auth_req)
-        token = json.loads(auth_resp.body.decode('utf-8', 'replace'))['token']
+        token = json.loads(auth_resp.body.decode("utf-8", "replace"))["token"]
 
         req = httpclient.HTTPRequest(
-            '{}/v2/{}/manifests/{}'.format(self.registry_host, image, tag),
-            headers={'Authorization': 'Bearer {}'.format(token)},
+            "{}/v2/{}/manifests/{}".format(self.url, image, tag),
+            headers={"Authorization": "Bearer {}".format(token)},
         )
         try:
             resp = yield client.fetch(req)
@@ -165,4 +212,4 @@ class DockerRegistry(LoggingConfigurable):
             else:
                 raise
         else:
-            return json.loads(resp.body.decode('utf-8'))
+            return json.loads(resp.body.decode("utf-8"))

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -4,29 +4,147 @@ Interaction with the Docker Registry
 import base64
 import json
 import os
+from urllib.parse import urlparse
 
 from tornado import gen, httpclient
 from tornado.httputil import url_concat
+from traitlets.config import LoggingConfigurable
+from traitlets import Dict, Unicode, default
 
 
-class DockerRegistry:
-    def __init__(self, auth_host, auth_token_url, registry_host):
-        with open(os.path.expanduser('~/.docker/config.json')) as f:
-            raw_auths = json.load(f)['auths']
+class DockerRegistry(LoggingConfigurable):
+    registry_host = Unicode(
+        "https://registry.hub.docker.com",
+        help="""
+        Docker registry host.
 
-        self.username, self.password = base64.b64decode(
-            raw_auths[auth_host]['auth'].encode('utf-8')
-        ).decode('utf-8').split(':', 1)
+        Default: same as auth_host,
+        no need to set this if using docker hub or registry host
+        is the same as the auth host.
+        """,
+        config=True,
+    )
+    @default('registry_host')
+    def _default_registry_host(self):
+        auth_host = self.auth_host
+        url = urlparse(auth_host)
+        # special-case docker, where these are different
+        if ('.' + url.hostname).endswith(('.docker.io', '.docker.com')):
+            return 'https://registry.hub.docker.com'
+        # default to the same as the auth host, if not defined
+        return "{}://{}".format(url.scheme, url.netloc)
 
-        self.auth_token_url = auth_token_url
-        self.registry_host = registry_host
+    auth_host = Unicode(
+        help="""
+        Docker authentication host.
+
+        Default: first entry in docker config.json if found,
+        otherwise the default docker auth host.
+
+        No need to set this if docker config contains
+        the right auth host.
+        """,
+        config=True,
+    )
+
+    @default('auth_host')
+    def _auth_host_default(self):
+        config_path = os.path.expanduser('~/.docker/config.json')
+        default = "https://index.docker.io/v1"
+        cfg = self._docker_config
+        auths = cfg.get("auths", {})
+        # by default: return the first host in our docker config file
+        return next(iter(auths.keys()), default)
+
+    docker_config_path = Unicode(
+        os.path.join(
+            os.environ.get('DOCKER_CONFIG', os.path.expanduser('~/.docker')),
+            'config.json',
+        ),
+        help=""""
+        path to docker config.json
+
+        Default: ~/.docker/config.json
+        """,
+        config=True,
+    )
+    _docker_config = Dict()
+    @default('_docker_config')
+    def _load_docker_config(self):
+        if not os.path.exists(self.docker_config_path):
+            self.log.warning("No docker config at %s", self.docker_config_path)
+            return {}
+        self.log.info("Loading docker config %s", self.docker_config_path)
+        with open(self.docker_config_path) as f:
+            return json.load(f)
+
+    token_url = Unicode(
+        help="""
+        URL to request docker registry authentication token.
+
+        No need to set if using Docker Hub or gcr.io
+        """,
+        config=True,
+    )
+    @default("token_url")
+    def _default_token_url(self):
+        if self.registry_host == "https://gcr.io":
+            return "https://gcr.io/v2/token?service=gcr.io"
+        elif self.registry_host.endswith(".docker.com"):
+            return "https://auth.docker.io/token?service=registry.docker.io"
+        else:
+            return ""
+
+    username = Unicode(
+        help="""
+        Username for authenticating with docker registry
+
+        Default: retrieved from docker config.
+        """,
+        config=True,
+    )
+    @default('username')
+    def _default_username(self):
+        b64_auth = None
+        if self.auth_host in self._docker_config.get('auths', {}):
+            b64_auth = self._docker_config['auths'][self.auth_host].get('auth')
+
+        if not b64_auth:
+            self.log.warning("No username for docker registry at %s", self.auth_host)
+            return ''
+
+        return base64.b64decode(
+            b64_auth.encode('utf-8')
+        ).decode('utf-8').split(':', 1)[0]
+
+    password = Unicode(
+        help="""
+        Password for authenticating with docker registry
+
+        Default: retrieved from docker config.
+        """,
+        config=True,
+    )
+    @default('password')
+    def _default_password(self):
+        b64_auth = None
+        if self.auth_host in self._docker_config.get('auths', {}):
+            b64_auth = self._docker_config['auths'][self.auth_host].get('auth')
+
+        if not b64_auth:
+            self.log.warning("No password for docker registry at %s", self.auth_host)
+            return ''
+
+        return base64.b64decode(
+            b64_auth.encode('utf-8')
+        ).decode('utf-8').split(':', 1)[1]
 
     @gen.coroutine
     def get_image_manifest(self, image, tag):
         client = httpclient.AsyncHTTPClient()
         # first, get a token to perform the manifest request
         auth_req = httpclient.HTTPRequest(
-            url_concat(self.auth_token_url,
+            url_concat(self.token_url,
                        {'scope': 'repository:{}:pull'.format(image)}),
             auth_username=self.username,
             auth_password=self.password,

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -61,7 +61,7 @@ def test_git_credentials_passed_to_podspec_upon_submit():
     build = Build(
         mock.MagicMock(), api=mock.MagicMock(), name='test_build',
         namespace='build_namespace', repo_url=mock.MagicMock(), ref=mock.MagicMock(),
-        git_credentials=git_credentials, builder_image=mock.MagicMock(),
+        git_credentials=git_credentials, build_image=mock.MagicMock(),
         image_name=mock.MagicMock(), push_secret=mock.MagicMock(),
         memory_limit=mock.MagicMock(), docker_host='http://mydockerregistry.local',
         node_selector=mock.MagicMock())

--- a/binderhub/tests/test_registry.py
+++ b/binderhub/tests/test_registry.py
@@ -12,8 +12,8 @@ from binderhub.registry import DockerRegistry
 
 def test_registry_defaults(tmpdir):
     registry = DockerRegistry(docker_config_path=str(tmpdir.join("doesntexist.json")))
-    assert registry.registry_host == "https://registry.hub.docker.com"
-    assert registry.auth_host == "https://index.docker.io/v1"
+    assert registry.url == "https://registry.hub.docker.com"
+    assert registry.auth_config_url == "https://index.docker.io/v1"
     assert (
         registry.token_url == "https://auth.docker.io/token?service=registry.docker.io"
     )
@@ -37,6 +37,7 @@ def test_registry_username_password(tmpdir):
     registry = DockerRegistry(docker_config_path=str(config_json))
     assert registry.username == "user"
     assert registry.password == "pass"
+    assert registry.url == "https://registry.hub.docker.com"
 
 
 def test_registry_gcr_defaults(tmpdir):
@@ -53,8 +54,8 @@ def test_registry_gcr_defaults(tmpdir):
             f,
         )
     registry = DockerRegistry(docker_config_path=str(config_json))
-    assert registry.registry_host == "https://gcr.io"
-    assert registry.auth_host == "https://gcr.io"
+    assert registry.url == "https://gcr.io"
+    assert registry.auth_config_url == "https://gcr.io"
     assert registry.token_url == "https://gcr.io/v2/token?service=gcr.io"
     assert registry.username == "_json_key"
     assert registry.password == "{...}"
@@ -138,10 +139,10 @@ async def test_get_image_manifest(tmpdir, request):
             f,
         )
     registry = DockerRegistry(
-        docker_config_path=str(config_json), token_url=url + "/token", auth_host=url
+        docker_config_path=str(config_json), token_url=url + "/token", url=url
     )
-    assert registry.registry_host == url
-    assert registry.auth_host == url
+    assert registry.url == url
+    assert registry.auth_config_url == url
     assert registry.token_url == url + "/token"
     assert registry.username == username
     assert registry.password == password

--- a/binderhub/tests/test_registry.py
+++ b/binderhub/tests/test_registry.py
@@ -1,0 +1,149 @@
+"""Tests for the registry"""
+import base64
+import json
+import os
+
+import pytest
+
+from tornado.web import Application, RequestHandler, HTTPError
+
+from binderhub.registry import DockerRegistry
+
+
+def test_registry_defaults(tmpdir):
+    registry = DockerRegistry(docker_config_path=str(tmpdir.join("doesntexist.json")))
+    assert registry.registry_host == "https://registry.hub.docker.com"
+    assert registry.auth_host == "https://index.docker.io/v1"
+    assert (
+        registry.token_url == "https://auth.docker.io/token?service=registry.docker.io"
+    )
+    assert registry.username == ""
+    assert registry.password == ""
+
+
+def test_registry_username_password(tmpdir):
+    config_json = tmpdir.join("dockerconfig.json")
+    with config_json.open("w") as f:
+        json.dump(
+            {
+                "auths": {
+                    "https://index.docker.io/v1": {
+                        "auth": base64.encodebytes(b"user:pass").decode("ascii")
+                    }
+                }
+            },
+            f,
+        )
+    registry = DockerRegistry(docker_config_path=str(config_json))
+    assert registry.username == "user"
+    assert registry.password == "pass"
+
+
+def test_registry_gcr_defaults(tmpdir):
+    config_json = tmpdir.join("dockerconfig.json")
+    with config_json.open("w") as f:
+        json.dump(
+            {
+                "auths": {
+                    "https://gcr.io": {
+                        "auth": base64.encodebytes(b"_json_key:{...}").decode("ascii")
+                    }
+                }
+            },
+            f,
+        )
+    registry = DockerRegistry(docker_config_path=str(config_json))
+    assert registry.registry_host == "https://gcr.io"
+    assert registry.auth_host == "https://gcr.io"
+    assert registry.token_url == "https://gcr.io/v2/token?service=gcr.io"
+    assert registry.username == "_json_key"
+    assert registry.password == "{...}"
+
+# Mock the registry API calls made by get_image_manifest
+
+class MockTokenHandler(RequestHandler):
+    """Mock handler for the registry token handler"""
+
+    def initialize(self, test_handle):
+        self.test_handle = test_handle
+
+    def get(self):
+        scope = self.get_argument("scope")
+        auth_header = self.request.headers.get("Authorization", "")
+        if not auth_header.startswith("Basic "):
+            raise HTTPError(401, "No basic auth")
+        b64_auth = auth_header[6:].encode("ascii")
+        decoded = base64.decodebytes(b64_auth).decode("utf8")
+        username, password = decoded.split(":", 2)
+        if username != self.test_handle["username"]:
+            raise HTTPError(403, "Bad username %r" % username)
+        if password != self.test_handle["password"]:
+            raise HTTPError(403, "Bad password %r" % password)
+        self.test_handle["token"] = token = base64.encodebytes(os.urandom(5)).decode(
+            "ascii"
+        ).rstrip()
+        self.set_header("Content-Type", "application/json")
+        self.write(json.dumps({"token": token}))
+
+
+class MockManifestHandler(RequestHandler):
+    """Mock handler for the registry token handler"""
+
+    def initialize(self, test_handle):
+        self.test_handle = test_handle
+
+    def get(self, image, tag):
+        auth_header = self.request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise HTTPError(401, "No bearer auth")
+        token = auth_header[7:]
+        if token != self.test_handle["token"]:
+            raise HTTPError(403, "%s != %s" % (token, self.test_handle["token"]))
+        self.set_header("Content-Type", "application/json")
+        # get_image_manifest never looks at the contents here
+        self.write(json.dumps({"image": image, "tag": tag}))
+
+
+@pytest.mark.gen_test
+async def test_get_image_manifest(tmpdir, request):
+    username = "asdf"
+    password = "asdf;ouyag"
+    test_handle = {"username": username, "password": password}
+    app = Application(
+        [
+            (r"/token", MockTokenHandler, {"test_handle": test_handle}),
+            (
+                r"/v2/([^/]+)/manifests/([^/]+)",
+                MockManifestHandler,
+                {"test_handle": test_handle},
+            ),
+        ]
+    )
+    ip = "127.0.0.1"
+    port = 10504
+    url = f"http://{ip}:{port}"
+    app.listen(port, ip)
+    config_json = tmpdir.join("dockerconfig.json")
+    with config_json.open("w") as f:
+        json.dump(
+            {
+                "auths": {
+                    url: {
+                        "auth": base64.encodebytes(
+                            f"{username}:{password}".encode("utf8")
+                        ).decode("ascii")
+                    }
+                }
+            },
+            f,
+        )
+    registry = DockerRegistry(
+        docker_config_path=str(config_json), token_url=url + "/token", auth_host=url
+    )
+    assert registry.registry_host == url
+    assert registry.auth_host == url
+    assert registry.token_url == url + "/token"
+    assert registry.username == username
+    assert registry.password == password
+    manifest = await registry.get_image_manifest("myimage", "abc123")
+    assert manifest == {"image": "myimage", "tag": "abc123"}

--- a/binderhub/tests/utils.py
+++ b/binderhub/tests/utils.py
@@ -1,5 +1,6 @@
 """Testing utilities"""
 import io
+from urllib.parse import urlparse
 
 from tornado import gen
 from tornado.httputil import HTTPHeaders
@@ -39,6 +40,9 @@ class MockAsyncHTTPClient(AsyncHTTPClient.configurable_default()):
 
     def _record_response(self, url_key, response):
         """Record a response in self.records"""
+        if urlparse(url_key).hostname in ('127.0.0.1', 'localhost'):
+            # don't record localhost requests
+            return
         self.records[url_key] = {
             'code': response.code,
             'headers': dict(response.headers),

--- a/ci/test-helm
+++ b/ci/test-helm
@@ -8,9 +8,18 @@ set -ex
 export IP=$(ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
 export BINDER_TEST_URL=http://$IP:30901
 export HUB_URL=http://$IP:30902
-echo -e "hub:\n  url: $HUB_URL" > helm-chart/travis-binder.yaml
+
+cat <<EOF > helm-chart/travis-binder.yaml
+config:
+  BinderHub:
+    hub_url: http://$IP:30902
+EOF
+
 if [[ ! -z "$GITHUB_ACCESS_TOKEN" ]]; then
-  echo -e "github:\n  accessToken: '$GITHUB_ACCESS_TOKEN'" >> helm-chart/travis-binder.yaml
+  cat <<EOF >> helm-chart/travis-binder.yaml
+  GitHubRepoProvider:
+    access_token: '$GITHUB_ACCESS_TOKEN'
+EOF
 fi
 
 if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -61,10 +61,11 @@ our ``gcr.io`` registry account. Below we show the structure of the YAML you
 need to insert. Note that the first line is not indented at all::
 
   registry:
+    authHost: https://gcr.io
     # below is the content of the JSON file downloaded earlier for the container registry from Service Accounts
     # it will look something like the following (with actual values instead of empty strings)
     # paste the content after `gcrKey: |` below
-    gcrKey: |
+    password: |
       {
       "type": "<REPLACE>",
       "project_id": "<REPLACE>",
@@ -81,9 +82,9 @@ need to insert. Note that the first line is not indented at all::
 
 .. tip::
 
-   * The content you put just after ``gcrKey: |`` must all line up at the same
+   * The content you put just after ``password: |`` must all line up at the same
      tab level.
-   * Don't forget the ``|`` after the ``gcrKey:`` label.
+   * Don't forget the ``|`` after the ``password:`` label.
 
 If you are using Docker Hub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,7 +116,6 @@ your ``config.yaml`` file::
   config:
     BinderHub:
       use_registry: true
-      docker_registry_host: https://gcr.io
       docker_image_prefix: gcr.io/<google-project-id>/<prefix>-
 
 
@@ -125,20 +125,16 @@ your ``config.yaml`` file::
      pasted above. It is the text that is in the ``project_id`` field. This is
      the project *ID*, which may be different from the project *name*.
    * **``<prefix>``** can be any string, and will be prepended to image names. We
-     recommend something descriptive such as ``binder-dev`` or ``binder-prod``.
+     recommend something descriptive such as ``binder-dev-`` or ``binder-prod-`` (ending with a `-` is useful).
 
 If you are using Docker Hub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Using Docker Hub is slightly more involved as the registry is not being run
-by the same platform that runs BinderHub.
 
 Update ``config.yaml`` by entering the following::
 
   config:
     BinderHub:
       use_registry: true
-      docker_registry_host: https://registry.hub.docker.com
       docker_image_prefix: <docker-id|organization-name>/<prefix>-
 
 .. note::
@@ -147,6 +143,39 @@ Update ``config.yaml`` by entering the following::
      This can be your Docker ID account or an organization that your account belongs to.
    * **``<prefix>``** can be any string, and will be prepended to image names. We
      recommend something descriptive such as ``binder-dev`` or ``binder-prod``.
+
+If you are using a custom registry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Authenticating with a Docker registry is slightly more complicated.
+BinderHub knows how to talk to gcr.io and DockerHub,
+but if you are using another registry, you will have to provide more information, in the form of three different urls:
+
+- auth host
+- registry host (if different from auth host)
+- token url
+
+First, setup the docker configuration::
+
+    registry:
+      authHost: "https://myregistry.io"
+      username: xxx
+      password: yyy
+
+Second, you will need to instruct BinderHub about two additional URLs::
+
+    config:
+      BinderHub:
+        use_registry: true
+        docker_image_prefix: "your-registry.io/<prefix>-"
+      DockerRegistry:
+        token_url: "https://myregistry.io/v2/token?service="
+        registry_host: "https://registry.myregistry.io"
+
+The two URLs will come from your registry.
+``registry_host`` only needs to be specified if it is different
+from the ``authHost`` that you specified above.
+
 
 Install BinderHub
 -----------------

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -116,7 +116,7 @@ your ``config.yaml`` file::
   config:
     BinderHub:
       use_registry: true
-      docker_image_prefix: gcr.io/<google-project-id>/<prefix>-
+      image_prefix: gcr.io/<google-project-id>/<prefix>-
 
 
 .. note::
@@ -135,7 +135,7 @@ Update ``config.yaml`` by entering the following::
   config:
     BinderHub:
       use_registry: true
-      docker_image_prefix: <docker-id|organization-name>/<prefix>-
+      image_prefix: <docker-id|organization-name>/<prefix>-
 
 .. note::
 
@@ -167,7 +167,7 @@ Second, you will need to instruct BinderHub about two additional URLs::
     config:
       BinderHub:
         use_registry: true
-        docker_image_prefix: "your-registry.io/<prefix>-"
+        image_prefix: "your-registry.io/<prefix>-"
       DockerRegistry:
         token_url: "https://myregistry.io/v2/token?service="
         registry_host: "https://registry.myregistry.io"

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -43,12 +43,12 @@ Create ``secret.yaml`` file
 Create a file called ``secret.yaml`` and add the following::
 
   jupyterhub:
-      hub:
-        services:
-          binder:
-            apiToken: "<output of FIRST `openssl rand -hex 32` command>"
-      proxy:
-        secretToken: "<output of SECOND `openssl rand -hex 32` command>"
+    hub:
+      services:
+        binder:
+          apiToken: "<output of FIRST `openssl rand -hex 32` command>"
+    proxy:
+      secretToken: "<output of SECOND `openssl rand -hex 32` command>"
 
 Next, we'll configure this file to connect with our registry.
 
@@ -63,8 +63,8 @@ need to insert. Note that the first line is not indented at all::
   registry:
     # below is the content of the JSON file downloaded earlier for the container registry from Service Accounts
     # it will look something like the following (with actual values instead of empty strings)
-    # paste the content after `password: |` below
-    password: |
+    # paste the content after `gcrKey: |` below
+    gcrKey: |
       {
       "type": "<REPLACE>",
       "project_id": "<REPLACE>",
@@ -81,9 +81,9 @@ need to insert. Note that the first line is not indented at all::
 
 .. tip::
 
-   * The content you put just after ``password: |`` must all line up at the same
+   * The content you put just after ``gcrKey: |`` must all line up at the same
      tab level.
-   * Don't forget the ``|`` after the ``password:`` label.
+   * Don't forget the ``|`` after the ``gcrKey:`` label.
 
 If you are using Docker Hub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -112,9 +112,12 @@ If you are using ``gcr.io``
 To configure BinderHub to use ``gcr.io``, simply add the following to
 your ``config.yaml`` file::
 
-  registry:
-    prefix:  gcr.io/<google-project-id>/<prefix>
-    enabled: true
+  config:
+    BinderHub:
+      use_registry: true
+      docker_registry_host: https://gcr.io
+      docker_image_prefix: gcr.io/<google-project-id>/<prefix>-
+
 
 .. note::
 
@@ -132,16 +135,15 @@ by the same platform that runs BinderHub.
 
 Update ``config.yaml`` by entering the following::
 
-  registry:
-    enabled: true
-    prefix: <docker-id/organization-name>/<prefix>
-    host: https://registry.hub.docker.com
-    authHost: https://index.docker.io/v1
-    authTokenUrl: https://auth.docker.io/token?service=registry.docker.io
+  config:
+    BinderHub:
+      use_registry: true
+      docker_registry_host: https://registry.hub.docker.com
+      docker_image_prefix: <docker-id|organization-name>/<prefix>-
 
 .. note::
 
-   * **``<docker-id/organization-name>``** is where you want to store Docker images.
+   * **``<docker-id|organization-name>``** is where you want to store Docker images.
      This can be your Docker ID account or an organization that your account belongs to.
    * **``<prefix>``** can be any string, and will be prepended to image names. We
      recommend something descriptive such as ``binder-dev`` or ``binder-prod``.

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -61,10 +61,10 @@ our ``gcr.io`` registry account. Below we show the structure of the YAML you
 need to insert. Note that the first line is not indented at all::
 
   registry:
-    authHost: https://gcr.io
+    host: https://gcr.io
     # below is the content of the JSON file downloaded earlier for the container registry from Service Accounts
     # it will look something like the following (with actual values instead of empty strings)
-    # paste the content after `gcrKey: |` below
+    # paste the content after `password: |` below
     password: |
       {
       "type": "<REPLACE>",
@@ -151,14 +151,14 @@ Authenticating with a Docker registry is slightly more complicated.
 BinderHub knows how to talk to gcr.io and DockerHub,
 but if you are using another registry, you will have to provide more information, in the form of three different urls:
 
-- auth host
+- auth host (added to ``docker/config.json`` from ``registry.host``)
 - registry host (if different from auth host)
 - token url
 
-First, setup the docker configuration::
+First, setup the docker configuration with the host used for authentication::
 
     registry:
-      authHost: "https://myregistry.io"
+      host: "https://myregistry.io"
       username: xxx
       password: yyy
 
@@ -174,7 +174,11 @@ Second, you will need to instruct BinderHub about two additional URLs::
 
 The two URLs will come from your registry.
 ``registry_host`` only needs to be specified if it is different
-from the ``authHost`` that you specified above.
+from the ``registry.host`` that you specified above.
+
+The ``registry.host`` is the host used in docker ``config.json``,
+whereas ``DockerRegistry.registry_host`` is the URL
+These are typically the same, but can differ.
 
 
 Install BinderHub

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -189,12 +189,13 @@ of the JupyterHub we just deployed.::
 Copy the IP address under ``EXTERNAL-IP``. This is the IP of your
 JupyterHub. Now, add the following lines to ``config.yaml`` file::
 
-  hub:
-    url: http://<IP in EXTERNAL-IP>
+  config:
+    BinderHub:
+      hub_url: http://<IP in EXTERNAL-IP>
 
 Next, upgrade the helm chart to deploy this change::
 
-  helm upgrade <name-from-above> jupyterhub/binderhub --version=v0.1.0-85ac189  -f secret.yaml -f config.yaml
+  helm upgrade <name-from-above> jupyterhub/binderhub --version=v0.1.0-...  -f secret.yaml -f config.yaml
 
 Try out your BinderHub Deployment
 ---------------------------------
@@ -234,8 +235,9 @@ an API access token to raise your API limit to 5000 requests an hour.
 
 3. Update ``secret.yaml`` by entering the following::
 
-    github:
-      accessToken: <insert_token_value_here>
+    config:
+      GitHubRepoProvider:
+        access_token: <insert_token_value_here>
 
 This value will be loaded into `GITHUB_ACCESS_TOKEN` environment variable and
 BinderHub will automatically use the token stored in this variable when making

--- a/helm-chart/binderhub/templates/NOTES.txt
+++ b/helm-chart/binderhub/templates/NOTES.txt
@@ -1,3 +1,148 @@
+{{- define "removedConfig" }}
+
+It looks like you still have some unsupported configuration!
+
+The binderhub chart has removed special-handling
+of many simple configurables in the BinderHub source code.
+Instead, the Python traits configuration is exposed directly.
+
+See https://binderhub.readthedocs.io/en/latest/reference/ref-index.html
+for what can be configured.
+
+In general, it works like:
+
+config:
+  ClassName:
+    trait_name: value
+
+e.g. to set config on BinderHub, e.g., use:
+
+config:
+  BinderHub:
+    use_registry: false
+
+or on GitHubRepoProvider:
+
+config:
+  GitHubRepoProvider:
+    access_token: "..."
+
+
+----------------------------------
+Specific unsupported config found:
+
+
+{{- if .Values.hub }}
+
+Special handling of hub.url is removed. Set config.BinderHub.hub_url instead:
+
+config:
+  BinderHub:
+    hub_url: {{ .Values.hub.url }}
+{{- end }}
+
+{{- if .Values.github }}
+
+Top-level github configuration is removed.
+Use:
+
+config:
+  GitHubRepoProvider:
+    access_token: {{ .Values.github.accessToken }}
+    client_id: {{ .Values.github.clientId }}
+    client_secret: {{ .Values.github.clientSecret }}
+{{- end }}
+
+{{- if .Values.gitlab }}
+
+Top-level gitlab configuration is removed.
+Use:
+
+config:
+  GitLabRepoProvider:
+    access_token: {{ .Values.gitlab.accessToken }}
+    private_token: {{ .Values.gitlab.privateToken }}
+{{- end }}
+
+{{- if ne (typeOf .Values.registry.enabled) "<nil>" }}
+
+registry.enabled is removed. Use:
+
+config:
+  BinderHub:
+    use_registry: {{ .Values.registry.enabled }}
+{{- end }}
+
+{{- if .Values.registry.authHost }}
+
+registry.authHost is removed.
+
+Use:
+
+  registry:
+    host: {{ .Values.registry.authHost }}
+
+to set auth host.
+
+{{- if ne .Values.registry.host .Values.registry.authHost }}
+
+If registry url and auth host differ, use:
+
+registry:
+  host: {{ .Values.registry.authHost }}
+config:
+  DockerRegistry:
+    registry_host: {{ .Values.registry.host }}
+
+{{- end }}
+{{- end }}
+
+{{- if .Values.registry.tokenUrl }}
+
+special-handling of .registry.tokenUrl is removed.
+Use:
+
+config:
+  DockerRegistry:
+    token_url: {{ .Values.registry.tokenUrl }}
+
+{{- end }}
+
+{{- if .Values.registry.prefix }}
+
+registry.prefix is removed. Use:
+
+config:
+  BinderHub:
+    docker_image_prefix: {{.Values.registry.prefix }}
+
+{{- end }}
+
+{{- if or .Values.build .Values.perRepoQuota }}
+
+build is removed. Use:
+
+config:
+  BinderHub:
+    appendix: {{ .Values.build.appendix }}
+    build_cleanup_interval: {{ .Values.build.cleanupInterval }}
+    build_image: {{ .Values.build.repo2dockerImage }}
+    build_max_age: {{ .Values.build.maxAge }}
+    build_namespace: {{ .Values.build.namespace }}
+    build_node_selector: {{ .Values.build.nodeSelector }}
+    log_tail_lines: {{ .Values.build.logTailLines }}
+    per_repo_quota: {{ .Values.perRepoQuota }}
+{{- end }}
+
+{{- /* end removedConfig */ -}}
+{{- end }}
+
+
+{{- if (or .Values.hub .Values.build .Values.github .Values.gitlab .Values.perRepoQuota .Values.registry.authHost .Values.registry.tokenUrl .Values.registry.prefix (ne (typeOf .Values.registry.enabled) "<nil>")) }}
+{{- fail (include "removedConfig" .) }}
+{{- end }}
+
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.hostname }}
   http://{{- .Values.ingress.hostname }}

--- a/helm-chart/binderhub/templates/NOTES.txt
+++ b/helm-chart/binderhub/templates/NOTES.txt
@@ -114,7 +114,7 @@ registry.prefix is removed. Use:
 
 config:
   BinderHub:
-    docker_image_prefix: {{.Values.registry.prefix }}
+    image_prefix: {{.Values.registry.prefix }}
 
 {{- end }}
 

--- a/helm-chart/binderhub/templates/NOTES.txt
+++ b/helm-chart/binderhub/templates/NOTES.txt
@@ -15,7 +15,7 @@ config:
   ClassName:
     trait_name: value
 
-e.g. to set config on BinderHub, e.g., use:
+e.g. to set config on BinderHub, use:
 
 config:
   BinderHub:
@@ -27,6 +27,8 @@ config:
   GitHubRepoProvider:
     access_token: "..."
 
+where ``BinderHub.use_registry`` and ``GitHubRepoProvider.access_token``
+are traits to be configured.
 
 ----------------------------------
 Specific unsupported config found:
@@ -80,19 +82,20 @@ registry.authHost is removed.
 Use:
 
   registry:
-    host: {{ .Values.registry.authHost }}
+    url: {{ .Values.registry.authHost }}
 
-to set auth host.
+to set the registry url.
 
-{{- if ne .Values.registry.host .Values.registry.authHost }}
+{{- if and .Values.registry.host (ne .Values.registry.host .Values.registry.authHost) }}
 
-If registry url and auth host differ, use:
+If registry url and auth url differ, use:
 
 registry:
-  host: {{ .Values.registry.authHost }}
+  url: {{ .Values.registry.authHost }}
 config:
   DockerRegistry:
-    registry_host: {{ .Values.registry.host }}
+    url: {{ .Values.registry.host }}
+    config_url: {{ .Values.registry.authHost }}
 
 {{- end }}
 {{- end }}
@@ -138,7 +141,7 @@ config:
 {{- end }}
 
 
-{{- if (or .Values.hub .Values.build .Values.github .Values.gitlab .Values.perRepoQuota .Values.registry.authHost .Values.registry.tokenUrl .Values.registry.prefix (ne (typeOf .Values.registry.enabled) "<nil>")) }}
+{{- if (or .Values.hub .Values.build .Values.github .Values.gitlab .Values.perRepoQuota  .Values.registry.host .Values.registry.authHost .Values.registry.tokenUrl .Values.registry.prefix (ne (typeOf .Values.registry.enabled) "<nil>")) }}
 {{- fail (include "removedConfig" .) }}
 {{- end }}
 

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -19,24 +19,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Render docker config.json for the registry-publishing secret.
 */}}
 {{- define "registryDockerConfig" -}}
-{{- if .Values.registry.gcrKey }}
+
+{{- /* default auth host */ -}}
+{{- $authHost := (default "https://index.docker.io/v1" .Values.registry.host) }}
+
+{{- /* default username if unspecified
+  (_json_key for gcr.io, <token> otherwise)
+*/ -}}
+
+{{- if not .Values.registry.username }}
+  {{- if eq $authHost "https://gcr.io" }}
+    {{- $_ := set .Values.registry "username" "_json_key" }}
+  {{- else }}
+    {{- $_ := set .Values.registry "username" "<token>" }}
+  {{- end }}
+{{- end }}
+{{- $username := .Values.registry.username -}}
+
 {
   "auths": {
-    "https://gcr.io": {
-      "auth": "{{ printf "_json_key:%s" .Values.registry.gcrKey | b64enc }}"
-    }
-  }
-}
-{{- else if .Values.registry.password }}
-{{- $username := (default "<token>" .Values.registry.username )}}
-{
-  "auths": {
-    "https://index.docker.io/v1": {
+    "{{ $authHost }}": {
       "auth": "{{ printf "%s:%s" $username .Values.registry.password | b64enc }}"
     }
   }
 }
-{{- else }}
-{{ .Values.registry.dockerConfigJson }}
-{{- end }}
 {{- end }}

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -16,6 +16,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "imagePullSecret" }}
-{{- $authHost := default .Values.registry.host .Values.registry.authHost -}}
+{{- $cfg := .Values.config.BinderHub }}
+{{- $authHost := default $cfg.docker_host $cfg.docker_auth_host -}}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $authHost (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
 {{- end }}

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -14,3 +14,29 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Render docker config.json for the registry-publishing secret.
+*/}}
+{{- define "registryDockerConfig" -}}
+{{- if .Values.registry.gcrKey }}
+{
+  "auths": {
+    "https://gcr.io": {
+      "auth": "{{ printf "_json_key:%s" .Values.registry.gcrKey | b64enc }}"
+    }
+  }
+}
+{{- else if .Values.registry.password }}
+{{- $username := (default "<token>" .Values.registry.username )}}
+{
+  "auths": {
+    "https://index.docker.io/v1": {
+      "auth": "{{ printf "%s:%s" $username .Values.registry.password | b64enc }}"
+    }
+  }
+}
+{{- else }}
+{{ .Values.registry.dockerConfigJson }}
+{{- end }}
+{{- end }}

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -20,15 +20,15 @@ Render docker config.json for the registry-publishing secret.
 */}}
 {{- define "registryDockerConfig" -}}
 
-{{- /* default auth host */ -}}
-{{- $authHost := (default "https://index.docker.io/v1" .Values.registry.host) }}
+{{- /* default auth url */ -}}
+{{- $url := (default "https://index.docker.io/v1" .Values.registry.url) }}
 
 {{- /* default username if unspecified
   (_json_key for gcr.io, <token> otherwise)
 */ -}}
 
 {{- if not .Values.registry.username }}
-  {{- if eq $authHost "https://gcr.io" }}
+  {{- if eq $url "https://gcr.io" }}
     {{- $_ := set .Values.registry "username" "_json_key" }}
   {{- else }}
     {{- $_ := set .Values.registry "username" "<token>" }}
@@ -38,7 +38,7 @@ Render docker config.json for the registry-publishing secret.
 
 {
   "auths": {
-    "{{ $authHost }}": {
+    "{{ $url }}": {
       "auth": "{{ printf "%s:%s" $username .Values.registry.password | b64enc }}"
     }
   }

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -14,9 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "imagePullSecret" }}
-{{- $cfg := .Values.config.BinderHub }}
-{{- $authHost := default $cfg.docker_host $cfg.docker_auth_host -}}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" $authHost (printf "%s:%s" .Values.registry.username .Values.registry.password | b64enc) | b64enc }}
-{{- end }}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -3,80 +3,17 @@ apiVersion: v1
 metadata:
   name: binder-config
 data:
-  binder.debug: {{ .Values.debug.enabled | quote }}
-  binder.use-registry: {{ .Values.registry.enabled | quote }}
-  {{ if .Values.registry.enabled -}}
-  binder.push-secret: binder-secret
-  binder.registry.host: {{ .Values.registry.host | quote }}
-  {{ if .Values.registry.authHost -}}
-  binder.registry.auth-host: {{ .Values.registry.authHost | quote }}
-  {{- end }}
-  binder.registry.auth-token-url: {{ .Values.registry.authTokenUrl | quote }}
-  {{ end -}}
-  {{ if .Values.googleAnalyticsCode -}}
-  binder.google-analytics-code: {{ .Values.googleAnalyticsCode | quote }}
-  {{- end }}
-  {{ if .Values.googleAnalyticsDomain -}}
-  binder.google-analytics-domain: {{ .Values.googleAnalyticsDomain | quote }}
-  {{- end }}
-  {{ if .Values.extraFooterScripts }}
-  binder.extra-footer-scripts: {{ toJson .Values.extraFooterScripts | quote }}
-  {{- end }}
-  binder.cors: {{ toJson .Values.cors | quote }}
-  binder.per-repo-quota: {{ .Values.perRepoQuota | quote }}
-  binder.registry.prefix: {{ .Values.registry.prefix | quote }}
-  binder.repo2docker-image: {{ .Values.build.repo2dockerImage | quote }}
-  {{ if .Values.build.nodeSelector -}}
-  binder.build-node-selector: {{ toJson .Values.build.nodeSelector | quote }}
-  {{- end }}
-  {{ if .Values.build.appendix -}}
-  binder.appendix: {{ .Values.build.appendix | quote }}
-  {{- end }}
-  binder.log-tail-lines: {{ .Values.build.logTailLines | quote }}
-  binder.build-max-age: {{ .Values.build.maxAge | quote }}
-  binder.build-cleanup-interval: {{ .Values.build.cleanupInterval | quote }}
-
-  binder.retries.count: {{ .Values.retries.count | quote }}
-  binder.retries.delay: {{ .Values.retries.delay | quote }}
-
-  binder.hub-url: {{ .Values.hub.url | quote }}
-  binder.base-url: {{ .Values.baseUrl | quote }}
-
-  {{- if and (eq .Values.jupyterhub.auth.type "custom") (eq .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
-  binder.auth-enabled: "false"
-  {{- else }}
-  binder.auth-enabled: "true"
-  binder.use-named-servers: {{ .Values.jupyterhub.hub.allowNamedServers | quote }}
-  {{- end }}
-
-  {{ if .Values.github.hostname -}}
-  github.hostname: {{ .Values.github.hostname | quote }}
-  {{- end }}
-  {{ if .Values.gitlab.hostname -}}
-  gitlab.hostname: {{ .Values.gitlab.hostname | quote }}
-  {{- end }}
-
-  {{ if .Values.template.variables -}}
-  template.variables: {{ toJson .Values.template.variables | quote }}
-  {{- end }}
-  {{ if .Values.template.path -}}
-  template.path: {{ .Values.template.path | quote }}
-  {{ if .Values.template.static.path -}}
-  template.static.path: {{ .Values.template.static.path | quote }}
-  {{- end }}
-  {{ if .Values.template.static.urlPrefix -}}
-  template.static.url-prefix: {{ .Values.template.static.urlPrefix | quote }}
-  {{- end }}
-  {{- end }}
-
-  dind.enabled: {{ .Values.dind.enabled | quote }}
-  {{ if .Values.dind.enabled }}
-  dind.host-socket-dir: {{ .Values.dind.hostSocketDir | quote }}
-  {{ end }}
-
-  {{ if .Values.extraConfig }}
-  {{ range $key, $value := .Values.extraConfig -}}
-  extra-config.{{ $key }}.py: |
-{{ $value | indent 4 }}
-  {{- end }}
-  {{- end }}
+{{- /* only pick relevant subset of values. Including too much here can trigger unnecessary binderhub pod restarts */}}
+{{- $values := pick .Values "dind" "config" "extraConfig" }}
+{{- /* make a copy to avoid modifying the original */ -}}
+{{- $_ := set $values "config" (merge dict .Values.config) }}
+{{- $_ := set $values.config "BinderHub" (merge dict .Values.config.BinderHub) }}
+{{- /* trim secret values. Update here if new secrets are added! */ -}}
+{{- if $values.config.GitHubRepoProvider }}
+{{- $_ := set $values.config.GitHubRepoProvider (omit .Values.config.GitHubRepoProvider "client_secret" "access_token") }}
+{{- end }}
+{{- if $values.config.GitLabRepoProvider }}
+{{- $_ := set $values.config.GitLabRepoProvider (omit .Values.config.GitLabRepoProvider "private_token" "access_token") }}
+{{- end }}
+  values.yaml: |
+    {{- $values | toYaml | nindent 4 }}

--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: binder-config
 data:
-{{- /* only pick relevant subset of values. Including too much here can trigger unnecessary binderhub pod restarts */}}
+{{- /* Important: only pick relevant subset of values. Including too much here can trigger unnecessary binderhub pod restarts */}}
 {{- $values := pick .Values "dind" "config" "extraConfig" }}
 {{- /* make a copy to avoid modifying the original */ -}}
 {{- $_ := set $values "config" (merge dict .Values.config) }}

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -41,10 +41,13 @@ spec:
       - name: config
         configMap:
           name: binder-config
-      {{ if .Values.registry.enabled -}}
-      - name: docker-secret
+      - name: secret-config
         secret:
           secretName: binder-secret
+      {{ if .Values.config.BinderHub.use_registry -}}
+      - name: docker-secret
+        secret:
+          secretName: binder-push-secret
       {{ else -}}
       - name: docker-socket
         hostPath:
@@ -59,7 +62,9 @@ spec:
         volumeMounts:
           - mountPath: /etc/binderhub/config/
             name: config
-          {{ if .Values.registry.enabled -}}
+          - mountPath: /etc/binderhub/secret/
+            name: secret-config
+          {{ if .Values.config.BinderHub.use_registry -}}
           - mountPath: /root/.docker
             name: docker-secret
             readOnly: true
@@ -83,10 +88,6 @@ spec:
             secretKeyRef:
               name: binder-secret
               key: "binder.hub-token"
-        - name: JUPYTERHUB_URL
-          value: {{ .Values.hub.url | trimSuffix "/" | quote }}
-        - name: JUPYTERHUB_API_URL
-          value: "$(JUPYTERHUB_URL)/hub/api/"
         {{- if or (ne .Values.jupyterhub.auth.type "custom") (ne .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
         # auth is enabled
         - name: JUPYTERHUB_SERVICE_PREFIX
@@ -99,41 +100,6 @@ spec:
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
         {{- end }}
-        {{- end }}
-        {{ if .Values.github.clientId -}}
-        - name: GITHUB_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: binder-secret
-              key: "github.client-id"
-        {{- end }}
-        {{ if .Values.github.clientSecret -}}
-        - name: GITHUB_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: binder-secret
-              key: "github.client-secret"
-        {{- end }}
-        {{ if .Values.github.accessToken -}}
-        - name: GITHUB_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: binder-secret
-              key: "github.access-token"
-        {{- end }}
-        {{ if .Values.gitlab.accessToken -}}
-        - name: GITLAB_ACCESS_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: binder-secret
-              key: "gitlab.access-token"
-        {{- end }}
-        {{ if .Values.gitlab.privateToken -}}
-        - name: GITLAB_PRIVATE_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: binder-secret
-              key: "gitlab.private-token"
         {{- end }}
         ports:
           - containerPort: 8585

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -19,7 +19,7 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
-      nodeSelector: {{ toJson .Values.build.nodeSelector }}
+      nodeSelector: {{ toJson .Values.config.BinderHub.build_node_selector  }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}-image-cleaner
       {{- end }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -22,5 +22,5 @@ metadata:
   name: binder-push-secret
 type: Opaque
 data:
-  config.json: {{ template "imagePullSecret" . }}
+  config.json: {{ .Values.registry.dockerConfigJson | b64enc | quote }}
 {{- end }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -4,22 +4,23 @@ metadata:
   name: binder-secret
 type: Opaque
 data:
-  {{ if .Values.registry.enabled -}}
-  config.json: {{ template "imagePullSecret" . }}
-  {{- end }}
+  {{- $values :=  dict "config" dict }}
+  {{- $cfg := .Values.config }}
   binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
-  {{ if .Values.github.clientId -}}
-  github.client-id: {{ .Values.github.clientId | b64enc | quote }}
+  {{- if $cfg.GitHubRepoProvider }}
+  {{- $_ := set $values.config "GitHubRepoProvider" (pick $cfg.GitHubRepoProvider "client_id" "client_secret" "access_token")}}
   {{- end }}
-  {{ if .Values.github.clientSecret -}}
-  github.client-secret: {{ .Values.github.clientSecret | b64enc | quote }}
+  {{- if $cfg.GitLabRepoProvider }}
+  {{- $_ := set $values.config "GitLabRepoProvider" (pick $cfg.GitLabRepoProvider "access_token" "private_token")}}
   {{- end }}
-  {{ if .Values.github.accessToken -}}
-  github.access-token: {{ .Values.github.accessToken | b64enc | quote }}
-  {{- end }}
-  {{ if .Values.gitlab.accessToken -}}
-  gitlab.access-token: {{ .Values.gitlab.accessToken | b64enc | quote }}
-  {{- end }}
-  {{ if .Values.gitlab.privateToken -}}
-  gitlab.private-token: {{ .Values.gitlab.privateToken | b64enc | quote }}
-  {{- end }}
+  values.yaml: {{ $values | toYaml | b64enc | quote }}
+---
+{{- if .Values.config.BinderHub.use_registry }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: binder-push-secret
+type: Opaque
+data:
+  config.json: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -22,5 +22,5 @@ metadata:
   name: binder-push-secret
 type: Opaque
 data:
-  config.json: {{ .Values.registry.dockerConfigJson | b64enc | quote }}
+  config.json: {{ include "registryDockerConfig" . | b64enc | quote }}
 {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -18,8 +18,10 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: local
 
+# registry here is only used to create docker config.json
 registry:
-  # key in 'auths' in docker config.json
+  # key in 'auths' in docker config.json,
+  # ~always the registry url
   url:
   # registry username+password
   username:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -19,7 +19,13 @@ image:
   tag: local
 
 registry:
-  dockerConfigJson: ""
+  # full override
+  dockerConfigJson:
+  # gcr shortcut
+  gcrKey:
+  # docker.io username+password
+  username:
+  password:
 
 service:
   type: LoadBalancer

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -19,10 +19,8 @@ image:
   tag: local
 
 registry:
-  # full override
-  dockerConfigJson:
-  # gcr shortcut
-  gcrKey:
+  # docker config.json hot for auth
+  host:
   # docker.io username+password
   username:
   password:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -19,9 +19,9 @@ image:
   tag: local
 
 registry:
-  # docker config.json hot for auth
-  host:
-  # docker.io username+password
+  # key in 'auths' in docker config.json
+  url:
+  # registry username+password
   username:
   password:
 

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -18,6 +18,9 @@ image:
   name: jupyterhub/k8s-binderhub
   tag: local
 
+registry:
+  dockerConfigJson: ""
+
 service:
   type: LoadBalancer
   labels: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -1,6 +1,3 @@
-debug:
-  enabled: false
-
 pdb:
   enabled: true
   minAvailable: 1
@@ -15,39 +12,11 @@ resources:
 rbac:
   enabled: true
 
-retries:
-  count: 4
-  delay: 4
-
-baseUrl: /
 nodeSelector: {}
 
 image:
   name: jupyterhub/k8s-binderhub
   tag: local
-
-build:
-  repo2dockerImage: jupyter/repo2docker:2ebc87b
-  nodeSelector: {}
-  appendix:
-  logTailLines: 100
-  # 14400 is 4 hours
-  maxAge: 14400
-  cleanupInterval: 120
-
-perRepoQuota: 100
-
-googleAnalyticsCode:
-googleAnalyticsDomain:
-
-registry:
-  enabled: false
-  prefix: binderhub-local/
-  host: https://gcr.io
-  authHost:
-  authTokenUrl: https://gcr.io/v2/token?service=gcr.io
-  username: _json_key
-  password:
 
 service:
   type: LoadBalancer
@@ -56,18 +25,8 @@ service:
     prometheus.io/scrape: 'true'
   nodePort:
 
-github:
-  hostname:
-  # either id + secret...
-  clientId:
-  clientSecret:
-  # ...or access_token
-  accessToken:
-
-gitlab:
-  hostname:
-  accessToken:
-  privateToken:
+config:
+  BinderHub: {}
 
 extraConfig: {}
 
@@ -84,9 +43,6 @@ extraConfig: {}
 
 cors: &cors
   allowOrigin:
-
-hub:
-  url:
 
 jupyterhub:
   cull:
@@ -143,7 +99,7 @@ jupyterhub:
     type: custom
     custom:
       # disable login (users created exclusively via API)
-      className: "nullauthenticator.NullAuthenticator"
+      className: nullauthenticator.NullAuthenticator
   singleuser:
     # start jupyter notebook
     cmd: jupyter-notebook
@@ -201,15 +157,6 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
-
-template:
-  variables: {}
-  path:
-  # to use extra static files in templates.
-  # they are looked up after binder base static files.
-  static:
-    path:
-    urlPrefix: extra_static/
 
 initContainers: []
 extraVolumes: []

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -19,4 +19,5 @@ ADD helm-chart/images/binderhub/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir *.whl -r /tmp/requirements.txt
 
 CMD ["python3", "-m", "binderhub"]
+ENV PYTHONUNBUFFERED=1
 EXPOSE 8585

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -62,10 +62,6 @@ def get_value(key, default=None):
             value = value[level]
     return value
 
-# FIXME: remove debug
-import pprint
-pprint.pprint(_load_values())
-
 # load config from values.yaml
 for section, sub_cfg in get_value('config', {}).items():
     c[section].update(sub_cfg)

--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -9,12 +9,15 @@ resources:
 cors: &cors
   allowOrigin: '*'
 
-hub:
-  url: http://192.168.99.100:30902
-
 service:
   type: NodePort
   nodePort: 30901
+
+config:
+  BinderHub:
+    hub_url: http://192.168.99.100:30902
+    use_registry: false
+    log_level: 10
 
 jupyterhub:
   custom:


### PR DESCRIPTION
This is analogous to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/941 but goes one step further, which I think is appropriate for the different audiences of BinderHub and z2jh. This completely eliminates the helm-specific structure in values.yaml for setting BinderHub configuration.

The result is that previous config structure that exclusively applied to the helm chart:

```yaml
build:
  repo2dockerImage: '...'
```

which the chart and image then mapped to `c.BinderHub.repo2docker_image`. Instead, users set the class config directly in yaml:

```yaml
config:
  BinderHub:
    repo2docker_image: '...'
```


This has the following benefits:

- documentation of BinderHub class configuration *is* documentation of the helm chart configuration. There is only one name/structure to learn. The only thing to know for applying BinderHub configuration in helm is that the traits go under `config.BinderHub`.
- defaults live in exactly one place (the class defaults), no duplication or divergence of defaults.
- adding or modifying a configurable requires no modifications to the chart whatsoever unless it should be handled as a secret.

TODO:

- [x] finish implementation
- [x] make sure registry secret still works
- [x] update config docs
- [x] ensure configurables show up in autodoc output so that we ensure all configuration options are always documented