### PR TITLE
Expend the appendix example

### DIFF
--- a/examples/appendix/run-appendix
+++ b/examples/appendix/run-appendix
@@ -8,3 +8,11 @@ cp -r "${appendix_dir}/templates" /etc/jupyter/binder_templates
 cat "${appendix_dir}/extra_notebook_config.py" >> /etc/jupyter/jupyter_notebook_config.py
 # ensure /etc/jupyter has read+listdir permissions for all
 chmod -R a+rX /etc/jupyter
+
+# add custom.js.
+# it is executed when the notebook app starts and adds binder buttons next to Quit button in the UI.
+sed -i 's|{binder_url}|'"$BINDER_URL"'|g' "${appendix_dir}/static/custom.js"
+sed -i 's|{repo_url}|'"$REPO_URL"'|g' "${appendix_dir}/static/custom.js"
+mkdir -p ~/.jupyter/custom
+cat "${appendix_dir}/static/custom.js" >> ~/.jupyter/custom/custom.js
+chown -R $NB_USER:$NB_USER $HOME/.jupyter

--- a/examples/appendix/static/custom.js
+++ b/examples/appendix/static/custom.js
@@ -1,0 +1,35 @@
+function copy_link_into_clipboard(b) {
+    var $temp = $("<input>");
+    $(b).parent().append($temp);
+    $temp.val($(b).data('url')).select();
+    document.execCommand("copy");
+    $temp.remove();
+}
+
+function add_binder_buttons() {
+    var copy_button = '<button id="copy-{name}-link" ' +
+            '                 title="Copy {name} link to clipboard" ' +
+            '                 class="btn btn-default btn-sm navbar-btn" ' +
+            '                 style="margin-right: 4px; margin-left: 2px;" ' +
+            '                 data-url="{url}" ' +
+            '                 onclick="copy_link_into_clipboard(this);">' +
+            '         Copy {name} link</button>';
+
+    var link_button = '<a id="copy-{name}-link" ' +
+        '                 href="{url}" ' +
+        '                 class="btn btn-default btn-sm navbar-btn" ' +
+        '                 style="margin-right: 4px; margin-left: 2px;" ' +
+        '                 target="_blank">' +
+        '              Go to {name}</a>';
+
+    var s = $("<span id='binder-buttons'></span>");
+    s.append(link_button.replace(/{name}/g, 'repo').replace('{url}', '{repo_url}'));
+    s.append(copy_button.replace(/{name}/g, 'binder').replace('{url}', '{binder_url}'));
+    if ($("#ipython_notebook").length && $("#ipython_notebook>a").length) {
+        s.append(copy_button.replace(/{name}/g, 'session').replace('{url}', window.location.origin.concat($("#ipython_notebook>a").attr('href'))));
+    }
+    // add buttons after span.flex-spacer
+    s.insertAfter($("#header-container>.flex-spacer"));
+}
+
+add_binder_buttons();

--- a/examples/appendix/templates/login.html
+++ b/examples/appendix/templates/login.html
@@ -2,7 +2,7 @@
 {% block site %}
 
 <div id="ipython-main-app" class="container">
-  <h1>You can't access this Binder</h1>
+  <h1>Binder inaccessible</h1>
   <h2>
     You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
   </h2>
@@ -12,8 +12,8 @@
 
   <h4>Is this a Binder that you created?</h4>
   <p>
-    If so, your authentication cookie used has been deleted or expired.
-    You can get a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
+    If so, your authentication cookie for this Binder has been deleted or expired.
+    You can launch a new Binder for this repo by clicking <a href="{{binder_url}}">here</a>.
   </p>
 
   <h4>Did someone give you this Binder link?</h4>

--- a/examples/appendix/templates/page.html
+++ b/examples/appendix/templates/page.html
@@ -1,0 +1,2 @@
+{% extends "templates/page.html" %}
+{% block login_widget %}{% endblock %}


### PR DESCRIPTION
This PR:

- updates the login template from https://github.com/jupyterhub/mybinder.org-deploy/blob/master/appendix/templates/login.html
- adds page.html which extends the base page template and removes logout button. I think logout button is confusing and there is already Quit button to stop binder session
- adds new buttons next to Quit button:
  - `Go to repo`: opens the source repo url in new tab
  - `Copy binder link`: copies the binder launch link into clipboard
  - `Copy session link`: copies the binder session link into clipboard. when this link is shared with another user, that user will reach to the same binder session. it will not start a new launch.