### PR TITLE
track launches in progress if image already exists

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -274,7 +274,8 @@ class BuildHandler(BaseHandler):
                 'imageName': image_name,
                 'message': 'Found built image, launching...\n'
             })
-            await self.launch(kube)
+            with LAUNCHES_INPROGRESS.track_inprogress():
+                await self.launch(kube)
             self.event_log.emit_launch(
                 provider=provider.name,
                 spec=spec,


### PR DESCRIPTION
Now only launches after successful builds are tracked with `LAUNCHES_INPROGRESS`. This PR makes launches without build (if image already exists) to be tracked too and so they are also written into prometheus database.