### PR TITLE
Update minikube configuration to new pass-through setup

### DIFF
--- a/helm-chart/minikube-binder.yaml
+++ b/helm-chart/minikube-binder.yaml
@@ -17,6 +17,8 @@ service:
   nodePort: 30901
 
 jupyterhub:
+  custom:
+    cors: *cors
   rbac:
     enabled: true
   hub:
@@ -30,8 +32,6 @@ jupyterhub:
     services:
       binder:
         apiToken: 0c18e3dcb7c55b8c7740f1d7ee6977510ce3cb22221669278ee03f3c2259ab6b
-    extraConfigMap:
-      cors: *cors
 
   proxy:
     secretToken: f89ddee5ba10f2268fcefcd4e353235c255493095cd65addf29ebebf8df86255


### PR DESCRIPTION
The minikube config needed updating to the new `values.yaml` pass-through.