### PR TITLE
reorganizing front page of docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      - image: circleci/python:3.6-stretch
+    steps:
+      # Get our data and merge with upstream
+      - run: sudo apt-get update
+      - checkout
+      # Python env
+      - run: echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV
+
+      - restore_cache:
+          keys:
+            - cache-pip
+      # Install packages needed for sphinx build
+      - run: pip install --user alabaster traitlets tornado sphinx recommonmark sphinx_copybutton escapism kubernetes prometheus_client jupyterhub docker python-json-logger
+      - save_cache:
+          key: cache-pip
+          paths:
+            - ~/.cache/pip
+
+      # Build the docs
+      - run:
+          name: Build docs to store
+          command: |
+            cd doc
+            make html
+
+      - store_artifacts:
+          path: doc/_build/html/
+          destination: html
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           keys:
             - cache-pip
       # Install packages needed for sphinx build
-      - run: pip install --user alabaster traitlets tornado sphinx recommonmark sphinx_copybutton escapism kubernetes prometheus_client jupyterhub docker python-json-logger
+      - run: pip install --user -r doc/doc-requirements.txt
       - save_cache:
           key: cache-pip
           paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,16 @@ branches:
 before_install:
   - nvm install 8; nvm use 8
 install:
-- export PATH=$PWD/bin:$PATH
-- ./ci/install.sh
-- pip install -r dev-requirements.txt
-- npm install
-- npm run webpack
-- pip install .
+  - export PATH=$PWD/bin:$PATH
+  - ./ci/install.sh
+  - pip install -r dev-requirements.txt
+  - npm install
+  - npm run webpack
+  - pip install .
 
 script:
-- export BINDER_TEST_NAMESPACE=binder-test-$TEST
-- travis_wait ./ci/test-$TEST
+  - export BINDER_TEST_NAMESPACE=binder-test-$TEST
+  - travis_wait ./ci/test-$TEST
 
 after_failure:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,17 @@ branches:
 before_install:
   - nvm install 8; nvm use 8
 install:
-  - export PATH=$PWD/bin:$PATH
-  - ./ci/install.sh
-  - pip install -r dev-requirements.txt
-  - npm install
-  - npm run webpack
-  - pip install .
-  # sphinx requirements
-  - pip install -r doc/doc-requirements.txt
+- export PATH=$PWD/bin:$PATH
+- ./ci/install.sh
+- pip install -r dev-requirements.txt
+- npm install
+- npm run webpack
+- pip install .
+
 script:
-  - export BINDER_TEST_NAMESPACE=binder-test-$TEST
-  - travis_wait ./ci/test-$TEST
-  - pushd doc && make html && popd
+- export BINDER_TEST_NAMESPACE=binder-test-$TEST
+- travis_wait ./ci/test-$TEST
+
 after_failure:
   - |
     # get pod logs

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,3 +209,8 @@ with open('./helm.txt', 'w') as ff:
         if ln.startswith('---'):
             lines[ii] = ln.replace('-', '~')
     ff.write('\n'.join(lines))
+
+# -- Add custom CSS ----------------------------------------------
+def setup(app):
+    app.add_stylesheet('https://gitcdn.link/repo/jupyterhub/binder/master/doc/_static/custom.css')
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,7 +107,9 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+import alabaster_jupyterhub
+html_theme = 'alabaster_jupyterhub'
+html_theme_path = [alabaster_jupyterhub.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/create-cloud-resources.rst
+++ b/doc/create-cloud-resources.rst
@@ -12,6 +12,12 @@ configured Kubernetes Cluster on the cloud, and then configure the
 various components correctly. The following instructions will assist you
 in doing so.
 
+.. note::
+   
+   BinderHub uses a JupyterHub running on Kubernetes for much of its functionality.
+   For information on setting up and customizing your JupyterHub, we recommend reading
+   the `Zero to JupyterHub Guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/index.html#customization-guide>`_.
+
 Setting up Kubernetes on `Google Cloud <https://cloud.google.com/>`_
 --------------------------------------------------------------------
 

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,10 +1,14 @@
 sphinx>=1.4, !=1.5.4
 traitlets>=4.1
-recommonmark
+recommonmark==0.4.0
 prometheus_client
 docker
-kubernetes
+kubernetes==3.*
 escapism
 requests
 sphinx-copybutton
 jupyterhub
+tornado>=4.1
+python-json-logger
+alabaster
+alabaster_jupyterhub

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - prometheus_client
   - sphinx_copybutton
   - escapism
+  - jupyterhub

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -7,10 +7,4 @@ dependencies:
 - tornado>=4.1
 - sphinx>=1.4, !=1.5.4
 - pip:
-  - recommonmark==0.4.0
-  - docker
-  - kubernetes==3.*
-  - prometheus_client
-  - sphinx_copybutton
-  - escapism
-  - jupyterhub
+  - -r doc-requirements.txt

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,4 @@
+=========
 BinderHub
 =========
 
@@ -6,7 +7,7 @@ BinderHub
    BinderHub is under active development and subject to breaking changes.
 
 Getting started
----------------
+===============
 
 The primary goal of BinderHub is creating custom computing environments that
 can be used by many remote users. BinderHub enables an end user to easily
@@ -19,14 +20,15 @@ your BinderHub deployment.
 
 To get started creating your own BinderHub, start with :doc:`create-cloud-resources`.
 
-Extending JupyterHub
---------------------
+.. note::
+   
+   BinderHub uses a JupyterHub running on Kubernetes for much of its functionality.
+   For information on setting up and customizing your JupyterHub, we recommend reading
+   the `Zero to JupyterHub Guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/index.html#customization-guide>`_.
 
-If you’d like to extend your JupyterHub setup, see
-`Zero to JupyterHub <https://zero-to-jupyterhub.readthedocs.io/en/latest/index.html#customization-guide>`_.
 
 BinderHub Deployments
----------------------
+=====================
 
 Our directory of BinderHubs is published at :doc:`known-deployments`.
 
@@ -35,30 +37,44 @@ If your BinderHub deployment is not listed, please
 to discuss adding it.
 
 Zero to BinderHub
------------------
+=================
 
 A guide to help you create your own BinderHub from scratch.
 
 .. toctree::
    :maxdepth: 2
    :numbered:
+   :caption: Zero to BinderHub
 
    create-cloud-resources
    setup-registry
    setup-binderhub
    turn-off
 
-Customization and more information
-----------------------------------
+Customization and deployment information
+========================================
+
+Information on how to customize your BinderHub as well as explore what others
+in the community have done.
 
 .. toctree::
    :maxdepth: 2
-   :numbered:
-
-   overview
+   :caption: Customization and deployment
+   
    debug
    customizing
-   api
    known-deployments
+
+BinderHub Developer and Architecture Documentation
+==================================================
+
+A more detailed overview of the BinderHub design, architecture, and functionality.
+
+.. toctree::
+   :maxdepth: 2
+   :caption:  Developer and architecture docs
+
+   overview
    eventlogging
+   api
    reference/ref-index.rst


### PR DESCRIPTION
This reorganizes the front page of the documentation similar to what we've done with the other JupyterHub projects. It also loads the CSS from teh `binder` repository as a CDN to show how this could work for other projects as well.

Finally, it sets up circleci so that we can demo the documentation before merging.