### PR TITLE
Add google-cloud-logging package to binderhub image

### DIFF
--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -2,3 +2,5 @@ pycurl==7.43.0.1
 tornado==5.0.*
 kubernetes==7.0.*
 jupyterhub==0.9.4
+# Logging sinks to send eventlogging events to
+google-cloud-logging==1.8.*


### PR DESCRIPTION
We need to send events from EventLogging to some sink. Ideally,
this would be a cloud provider managed sink that we will not
have to administer. Almost all cloud providers provide this in
some form or other. This commit adds the python package to send
events to StackDriver on Google Cloud Platform. No additional
code is needed here for now - it can all be managed via
extra config. https://cloud.google.com/logging/docs/setup/python
has more information.

Ref #679 