### PR TITLE
Say Git repository (not GitHub) in home page

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -13,7 +13,7 @@
     <div class="col-lg-10 col-lg-offset-1">
       {% block header %}
       <div id="header" class="text-center">
-        <h3>Turn a GitHub repo into a collection of interactive notebooks</h3>
+        <h3>Turn a Git repo into a collection of interactive notebooks</h3>
         <div id="explanation">
           Have a repository full of Jupyter notebooks? With Binder, open those notebooks in an executable environment, making your code immediately reproducible by anyone, anywhere.
         </div>


### PR DESCRIPTION
We support Gist, GitLab, etc now.