### PR TITLE
Attempt to fix chartpress failure

### DIFF
--- a/ci/test-helm
+++ b/ci/test-helm
@@ -25,6 +25,8 @@ fi
 
 echo "building helm chart"
 cd helm-chart
+helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
+helm dependency update helm-chart/binderhub
 chartpress --commit-range ${TRAVIS_COMMIT_RANGE} ${PUSH} --extra-message "${TRAVIS_REPO_SLUG}$(git log -1 --pretty=%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/')"
 cd ..
 # git diff will show us the result of the chartpress render.
@@ -35,8 +37,6 @@ docker images | sort
 # smoke test helm install
 echo "installing binderhub helm chart"
 
-helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
-helm dependency update helm-chart/binderhub
 cat helm-chart/travis-binder.yaml
 
 helm install \


### PR DESCRIPTION
Currently failing with:

```
Error: found in requirements.yaml, but missing in charts/ directory: jupyterhub
Skipping image-cleaner, not touched in 86a9b7aff6b9...61e7e63ef6d8
Updating binderhub/values.yaml: imageCleaner.image: {'repository': 'jupyterhub/k8s-image-cleaner', 'tag': 'b6a1660'}
Updating binderhub/values.yaml: image: {'repository': 'jupyterhub/k8s-binderhub', 'tag': '562b847'}
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.6.3/bin/chartpress", line 11, in <module>
    load_entry_point('chartpress==0.3.0.dev0', 'console_scripts', 'chartpress')()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/chartpress.py", line 316, in main
    extra_message=args.extra_message,
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/chartpress.py", line 244, in publish_pages
    '--destination', td + '/',
  File "/opt/python/3.6.3/lib/python3.6/subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['helm', 'package', 'binderhub', '--destination', '/tmp/tmps6t2mwcr/']' returned non-zero exit status 1.
/home/travis/.travis/job_stages: line 415:  5628 Terminated              travis_jigger "${!}" "${timeout}" "${cmd[@]}"
```

from https://travis-ci.org/jupyterhub/binderhub/jobs/444760391.

This prevents a binderhub chart from being pushed.