### PR TITLE
Allow setting multiple extraConfig entries

### DIFF
--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -74,9 +74,9 @@ data:
   dind.host-socket-dir: {{ .Values.dind.hostSocketDir | quote }}
   {{ end }}
 
-  {{ if .Values.extraConfig }}
-  {{ range $key, $value := .Values.extraConfig -}}
+  {{ if .Values.extraConfig -}}
+  {{ range $key, $value := .Values.extraConfig }}
   extra-config.{{ $key }}.py: |
-{{ $value | indent 4 }}
+    {{- $value | nindent 4 }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Without this, they all get smooshed together. Without this patch:

```
  extra-config.01-test.py: |
    print('01', flush=True)
    extra-config.02-test.py: |
    print('02', flush=True)
```

With:

```
  extra-config.01-test.py: |
    print('01', flush=True)

  extra-config.02-test.py: |
    print('02', flush=True)
```