### PR TITLE
Upgrade version of google-cloud-logging

### DIFF
--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -3,4 +3,4 @@ tornado==5.0.*
 kubernetes==7.0.*
 jupyterhub==0.9.4
 # Logging sinks to send eventlogging events to
-google-cloud-logging==1.8.*
+git+https://github.com/googleapis/google-cloud-python@d72f443#subdirectory=logging


### PR DESCRIPTION
Includes https://github.com/googleapis/google-cloud-python/pull/6293.
Lets us push structured logs to stackdriver, rather than textual
logs.

Ref https://github.com/jupyterhub/mybinder.org-deploy/issues/97

