### PR TITLE
Validate & flatten analytics events

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 recursive-include binderhub/static *
 recursive-include binderhub/templates *
+recursive-include binderhub/event-schemas *
 graft testing
 graft doc
 include LICENSE

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -34,6 +34,9 @@ from .utils import ByteSpecification, url_path_join
 from .events import EventLog
 
 
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
 class BinderHub(Application):
     """An Application for starting a builder."""
 
@@ -396,7 +399,7 @@ class BinderHub(Application):
 
     @default('template_path')
     def _template_path_default(self):
-        return os.path.join(os.path.dirname(__file__), 'templates')
+        return os.path.join(HERE, 'templates')
 
     extra_static_path = Unicode(
         help='Path to search for extra static files.',
@@ -510,7 +513,7 @@ class BinderHub(Application):
             'build_memory_limit': self.build_memory_limit,
             'build_docker_host': self.build_docker_host,
             'base_url': self.base_url,
-            "static_path": os.path.join(os.path.dirname(__file__), "static"),
+            "static_path": os.path.join(HERE, "static"),
             'static_url_prefix': url_path_join(self.base_url, 'static/'),
             'template_variables': self.template_variables,
             'executor': self.executor,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -6,6 +6,8 @@ from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
 import re
+import json
+from glob import glob
 from urllib.parse import urlparse
 
 import kubernetes.client
@@ -489,6 +491,10 @@ class BinderHub(Application):
         )
 
         self.event_log = EventLog(parent=self)
+
+        for schema_file in glob(os.path.join(HERE, 'event-schemas','*.json')):
+            with open(schema_file) as f:
+                self.event_log.register_schema(json.load(f))
 
         self.tornado_settings.update({
             "docker_push_secret": self.docker_push_secret,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -295,11 +295,11 @@ class BuildHandler(BaseHandler):
             })
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube)
-            self.event_log.emit_launch(
-                provider=provider.name,
-                spec=spec,
-                status='success'
-            )
+            self.event_log.emit('binderhub.jupyter.org/launch', 1, {
+                'provider': provider.name,
+                'spec': spec,
+                'status': 'success'
+            })
             return
 
         # Prepare to build
@@ -403,11 +403,11 @@ class BuildHandler(BaseHandler):
             BUILD_COUNT.labels(status='success', **self.repo_metric_labels).inc()
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube)
-            self.event_log.emit_launch(
-                provider=provider.name,
-                spec=spec,
-                status='success'
-            )
+            self.event_log.emit('binderhub.jupyter.org/launch', 1, {
+                'provider': provider.name,
+                'spec': spec,
+                'status': 'success'
+            })
 
         # Don't close the eventstream immediately.
         # (javascript) eventstream clients reconnect automatically on dropped connections,

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -1,0 +1,25 @@
+{
+    "$id": "binderhub.jupyter.org/launch",
+    "version": 1,
+    "title": "BinderHub Launch Events",
+    "description": "BinderHub emits this event whenever a new repo is launched",
+    "type": "object",
+    "properties": {
+        "provider": {
+            "enum": [
+                "GitHub",
+                "GitLab",
+                "Git"
+            ],
+            "description": "Provider for the repository being launched"
+        },
+        "spec": {
+            "type": "string",
+            "description": "Provider specification for the repo being launched. Usually, <reponame>/<commit-specification>"
+        },
+        "status": {
+            "enum": ["success", "failure"],
+            "description": "Success/Failure of the launch"
+        }
+    }
+}

--- a/binderhub/events.py
+++ b/binderhub/events.py
@@ -5,6 +5,7 @@ from traitlets.config import Configurable
 
 import logging
 from datetime import datetime
+import jsonschema
 from pythonjsonlogger import jsonlogger
 from traitlets import TraitType
 import json
@@ -66,31 +67,53 @@ class EventLog(Configurable):
                 handler.setFormatter(formatter)
                 self.log.addHandler(handler)
 
-    def _emit(self, schema, version, event):
+        self.schemas = {}
+
+    def register_schema(self, schema):
+        """
+        Register a given JSON Schema with this event emitter
+
+        'version' and '$id' are required fields.
+        """
+        # Check if our schema itself is valid
+        # This throws an exception if it isn't valid
+        jsonschema.validators.validator_for(schema).check_schema(schema)
+
+        # Check that the properties we require are present
+        required_schema_fields = {'$id', 'version'}
+        for rsf in required_schema_fields:
+            if rsf not in schema:
+                raise ValueError(
+                    f'{rsf} is required in schema specification'
+                )
+
+        # Make sure reserved, auto-added fields are not in schema
+        reserved_fields = {'timestamp', 'schema', 'version'}
+        for rf in reserved_fields:
+            if rf in schema['properties']:
+                raise ValueError(
+                    f'{rf} field is reserved by event emitter & can not be explicitly set in schema'
+                )
+
+        self.schemas[(schema['$id'], schema['version'])] = schema
+
+    def emit(self, schema_name, version, event):
         """
         Emit event with given schema / version in a capsule.
         """
         if not self.handlers_maker:
             # If we don't have a handler setup, ignore everything
             return
+
+        if (schema_name, version) not in self.schemas:
+            raise ValueError(f'Schema {schema_name} version {version} not registered')
+        schema = self.schemas[(schema_name, version)]
+        jsonschema.validate(event, schema)
+
         capsule = {
             'timestamp': datetime.utcnow().isoformat() + 'Z',
-            # FIXME: Validate the schema!
-            'schema': schema,
+            'schema': schema_name,
             'version': version
         }
-        capsule['event'] = event
+        capsule.update(event)
         self.log.info(capsule)
-
-    def emit_launch(self, provider, spec, status):
-        """
-        Helper function for emitting a launch event.
-
-        This helps with validation too. Will eventually be
-        deprecated in favor of schema validation in _emit.
-        """
-        self._emit('binderhub.jupyter.org/launch', 1, {
-            'provider': provider,
-            'spec': spec,
-            'status': status
-        })

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -4,6 +4,8 @@ Classes for Repo providers
 Subclass the base class, ``RepoProvider``, to support different version
 control services and providers.
 
+Note: When adding a new repo provider, add it to the allowed values for
+      repo providers in event-schemas/launch.json.
 """
 from datetime import timedelta
 import json

--- a/binderhub/tests/test_eventlog.py
+++ b/binderhub/tests/test_eventlog.py
@@ -3,17 +3,60 @@ import json
 from contextlib import redirect_stderr
 import logging
 from binderhub.events import EventLog
+import pytest
+import jsonschema
 
 
-def test_emit_launch():
+def test_register_invalid():
+    """
+    Test registering invalid schemas fails
+    """
+    el = EventLog()
+    with pytest.raises(jsonschema.SchemaError):
+        el.register_schema({
+            # Totally invalid
+            'properties': True
+        })
+
+    with pytest.raises(ValueError):
+        el.register_schema({
+            'properties': {}
+        })
+
+    with pytest.raises(ValueError):
+        el.register_schema({
+            '$id': 'something',
+            '$version': 1,
+            'properties': {
+                'timestamp': {
+                    'type': 'string'
+                }
+            }
+        })
+
+
+
+def test_emit_event():
     """
     Test emitting launch events works
     """
+    schema = {
+        '$id': 'test/test',
+        'version': 1,
+        'properties': {
+            'something': {
+                'type': 'string'
+            },
+        },
+    }
     with tempfile.NamedTemporaryFile() as f:
         handler = logging.FileHandler(f.name)
         el = EventLog(handlers_maker=lambda el: [handler])
+        el.register_schema(schema)
 
-        el.emit_launch('GitHub', 'test/test/master', 'success')
+        el.emit('test/test', 1, {
+            'something': 'blah',
+        })
         handler.flush()
 
         f.seek(0)
@@ -23,7 +66,35 @@ def test_emit_launch():
         # Remove timestamp from capsule when checking equality, since it is gonna vary
         del event_capsule['timestamp']
         assert event_capsule == {
-            'schema': 'binderhub.jupyter.org/launch',
+            'schema': 'test/test',
             'version': 1,
-            'event': {'provider': 'GitHub', 'spec': 'test/test/master', 'status': 'success'}
+            'something': 'blah'
         }
+
+
+def test_emit_event_badschema():
+    """
+    Test failure when event doesn't match schema
+    """
+    schema = {
+        '$id': 'test/test',
+        'version': 1,
+        'properties': {
+            'something': {
+                'type': 'string'
+            },
+            'status': {
+                'enum': ['success', 'failure']
+            }
+        }
+    }
+    with tempfile.NamedTemporaryFile() as f:
+        handler = logging.FileHandler(f.name)
+        el = EventLog(handlers_maker=lambda el: [handler])
+        el.register_schema(schema)
+
+        with pytest.raises(jsonschema.ValidationError):
+            el.emit('test/test', 1, {
+                'something': 'blah',
+                'status': 'not-in-enum'
+            })

--- a/binderhub/tests/test_eventlog.py
+++ b/binderhub/tests/test_eventlog.py
@@ -5,6 +5,7 @@ import logging
 from binderhub.events import EventLog
 import pytest
 import jsonschema
+import os
 
 
 def test_register_invalid():
@@ -98,3 +99,19 @@ def test_emit_event_badschema():
                 'something': 'blah',
                 'status': 'not-in-enum'
             })
+
+
+def test_provider_completeness(app):
+    """
+    Test we add an entry in the launch schema for all providers
+    """
+    repo_providers = {
+        rp.name.default_value for rp in app.repo_providers.values()
+    }
+
+    launch_schema_path = os.path.join(os.path.dirname(__file__), '..', 'event-schemas', 'launch.json')
+
+    with open(launch_schema_path) as f:
+        launch_schema = json.load(f)
+
+    assert repo_providers == set(launch_schema['properties']['provider']['enum'])

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -2,5 +2,6 @@ pycurl==7.43.0.1
 tornado==5.0.*
 kubernetes==7.0.*
 jupyterhub==0.9.4
+jsonschema==2.6.0
 # Logging sinks to send eventlogging events to
 git+https://github.com/googleapis/google-cloud-python@d72f443#subdirectory=logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ jinja2
 prometheus_client
 python-json-logger
 jupyterhub
+jsonschema


### PR DESCRIPTION
- Use JSONSchema to validate events before emitting them.
  The schema also acts as documentation for the events.
- Flatten the capsule. This makes analytics much easier,
  since you can more easily use dataframe tools like pandas.
  We prevent capsule added fields from being redefined in
  schemas

Ref https://github.com/jupyterhub/mybinder.org-deploy/issues/789
