### PR TITLE
Streamline CircleCI documentation building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Install doc dependencies
           command: |
-            sudo pip install .
+            sudo pip install -r requirements.txt
             sudo pip install -r doc/doc-requirements.txt
 
       # Build the docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,21 +4,14 @@ jobs:
     docker:
       - image: circleci/python:3.6-stretch
     steps:
-      # Get our data and merge with upstream
-      - run: sudo apt-get update
       - checkout
-      # Python env
-      - run: echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV
 
-      - restore_cache:
-          keys:
-            - cache-pip
-      # Install packages needed for sphinx build
-      - run: pip install --user -r doc/doc-requirements.txt
-      - save_cache:
-          key: cache-pip
-          paths:
-            - ~/.cache/pip
+      # Install documentation requirements
+      - run:
+          name: Install doc dependencies
+          command: |
+            sudo pip install .
+            sudo pip install -r doc/doc-requirements.txt
 
       # Build the docs
       - run:
@@ -28,13 +21,11 @@ jobs:
             make html
 
       - store_artifacts:
-          path: doc/_build/html/
+          path: doc/build/html/
           destination: html
-
 
 workflows:
   version: 2
   default:
     jobs:
       - build_docs
-

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,13 +1,5 @@
+# documentation specific extra packages
 sphinx>=1.7
-traitlets>=4.1
 recommonmark==0.4.0
-prometheus_client
-docker
-kubernetes==3.*
-escapism
-requests
 sphinx-copybutton
-jupyterhub
-tornado>=4.1
-python-json-logger
 alabaster_jupyterhub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+kubernetes>=4.*
+escapism
+tornado
+traitlets
+docker
+jinja2
+prometheus_client
+python-json-logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ docker
 jinja2
 prometheus_client
 python-json-logger
+jupyterhub

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,12 @@ here = os.path.dirname(__file__)
 with open(os.path.join(here, 'binderhub', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
+with open(os.path.join(here, 'requirements.txt')) as f:
+    requirements = [
+        l.strip() in f.readlines()
+        if not l.strip().startswith('#')
+    ]
+
 # Build our js and css files before packaging
 subprocess.check_call(['npm', 'install'])
 subprocess.check_call(['npm', 'run', 'webpack'])
@@ -22,14 +28,5 @@ setup(
     license='BSD',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        'kubernetes>=4.*',
-        'escapism',
-        'tornado',
-        'traitlets',
-        'docker',
-        'jinja2',
-        'prometheus_client',
-        'python-json-logger',
-    ]
+    install_requires=requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(here, 'binderhub', '_version.py')) as f:
 
 with open(os.path.join(here, 'requirements.txt')) as f:
     requirements = [
-        l.strip() in f.readlines()
+        l.strip() for l in f.readlines()
         if not l.strip().startswith('#')
     ]
 


### PR DESCRIPTION
- Reduce duplication in specifying dependencies. 
- Add jupyterhub as a dependency (was missing)
- Streamline .circleci/config, stealing from https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1000

Fixes doc error in https://github.com/jupyterhub/binderhub/pull/710