### PR TITLE
Remove travis_wait from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
   - export BINDER_TEST_NAMESPACE=binder-test-$TEST
-  - travis_wait ./ci/test-$TEST
+  - ./ci/test-$TEST
 
 after_failure:
   - |


### PR DESCRIPTION
travis_wait should only help when a test produces no output for ten minutes. This shouldn't happen for us when we are running tests with `-vsx`

The downside of using travis_wait is that it suppresses all output until the tests finish, so if anything causes a hang or early failure, we won't be able to see it until travis_wait times out.