### PR TITLE
Revert "Upgrade version of google-cloud-logging"

### DIFF
--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -3,4 +3,4 @@ tornado==5.0.*
 kubernetes==7.0.*
 jupyterhub==0.9.4
 # Logging sinks to send eventlogging events to
-git+https://github.com/googleapis/google-cloud-python@d72f443#subdirectory=logging
+google-cloud-logging==1.8.*


### PR DESCRIPTION
The PR I made to google-cloud-logging didn't actually
do what I thought it would do, and we have reverted it.
See https://github.com/googleapis/google-cloud-python/issues/5799#issuecomment-434373962
for more info.

This means we're emitting JSON as text to stackdriver. I'm
ok with that for now.

Reverts jupyterhub/binderhub#706