### PR TITLE
bump the chart version

### DIFF
--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A helm chart to install Binder
 name: binderhub
-version: 0.1.0
+version: 0.2.0


### PR DESCRIPTION
missed in the Python version bump

I'll remove the chart published with binderhub 0.2 and chart version 0.1.0