### PR TITLE
typos in configmap

### DIFF
--- a/helm-chart/binderhub/templates/configmap.yaml
+++ b/helm-chart/binderhub/templates/configmap.yaml
@@ -9,11 +9,12 @@ data:
 {{- $_ := set $values "config" (merge dict .Values.config) }}
 {{- $_ := set $values.config "BinderHub" (merge dict .Values.config.BinderHub) }}
 {{- /* trim secret values. Update here if new secrets are added! */ -}}
+{{- /* every 'omit' here should be matched with a corresponding 'pick' in secret.yaml */ -}}
 {{- if $values.config.GitHubRepoProvider }}
-{{- $_ := set $values.config.GitHubRepoProvider (omit .Values.config.GitHubRepoProvider "client_secret" "access_token") }}
+{{- $_ := set $values.config "GitHubRepoProvider" (omit .Values.config.GitHubRepoProvider "client_id" "client_secret" "access_token") }}
 {{- end }}
 {{- if $values.config.GitLabRepoProvider }}
-{{- $_ := set $values.config.GitLabRepoProvider (omit .Values.config.GitLabRepoProvider "private_token" "access_token") }}
+{{- $_ := set $values.config "GitLabRepoProvider" (omit .Values.config.GitLabRepoProvider "private_token" "access_token") }}
 {{- end }}
   values.yaml: |
     {{- $values | toYaml | nindent 4 }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -7,6 +7,7 @@ data:
   {{- $values :=  dict "config" dict }}
   {{- $cfg := .Values.config }}
   binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
+  {{- /* every 'pick' here should be matched with a corresponding 'omit' in secret.yaml */ -}}
   {{- if $cfg.GitHubRepoProvider }}
   {{- $_ := set $values.config "GitHubRepoProvider" (pick $cfg.GitHubRepoProvider "client_id" "client_secret" "access_token")}}
   {{- end }}


### PR DESCRIPTION
syntax was a bit wrong for GitHubRepoProvider

caught in master but not the PR because we only have github credentials on master

It would probably be worth having some unittests for the helm charts that just call `helm template` with various inputs and check the results. We do a bit of this in zero-to-jupyterhub.