### PR TITLE
fix environment variables for authentication

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -91,8 +91,6 @@ spec:
         {{- if .Values.config.BinderHub.auth_enabled }}
         - name: JUPYTERHUB_API_URL
           value: {{ (print (.Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
-        - name: JUPYTERHUB_SERVICE_PREFIX
-          value: {{ .Values.config.BinderHub.base_url | quote }}
         - name: JUPYTERHUB_BASE_URL
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
         - name: JUPYTERHUB_CLIENT_ID

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -88,10 +88,11 @@ spec:
             secretKeyRef:
               name: binder-secret
               key: "binder.hub-token"
-        {{- if or (ne .Values.jupyterhub.auth.type "custom") (ne .Values.jupyterhub.auth.custom.className "nullauthenticator.NullAuthenticator") }}
-        # auth is enabled
+        {{- if .Values.config.BinderHub.auth_enabled }}
+        - name: JUPYTERHUB_API_URL
+          value: {{ (print (.Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
         - name: JUPYTERHUB_SERVICE_PREFIX
-          value: {{ .Values.baseUrl | quote }}
+          value: {{ .Values.config.BinderHub.base_url | quote }}
         - name: JUPYTERHUB_BASE_URL
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
         - name: JUPYTERHUB_CLIENT_ID

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -83,7 +83,7 @@ if allow_origin:
 if os.getenv('BUILD_NAMESPACE'):
     c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
-if c.BinderHub.auth_enabled:
+if c.BinderHub.auth_enabled and 'base_url' in c.BinderHub:
     c.HubOAuth.base_url = c.BinderHub.base_url
 
 # load extra config snippets

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -83,6 +83,9 @@ if allow_origin:
 if os.getenv('BUILD_NAMESPACE'):
     c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
+if c.BinderHub.auth_enabled:
+    c.HubOAuth.base_url = c.BinderHub.base_url
+
 # load extra config snippets
 for key, snippet in sorted((get_value('extraConfig') or {}).items()):
     print("Loading extra config: {}".format(key))


### PR DESCRIPTION
fix after new helm chart configuration (https://github.com/jupyterhub/binderhub/pull/680)

re-added `JUPYTERHUB_API_URL`, it is needed to connect to hub API during authentication (https://github.com/jupyterhub/jupyterhub/blob/0.9.4/jupyterhub/services/auth.py#L158)

Btw I really like the new BinderHub configuration in helm, thanks a lot!