### PR TITLE
updating css for logo contrast

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -154,15 +154,15 @@ h4 {
     margin-bottom:40px;
 }
 
-.bluedropdown{
-    background-color:#579ACA;
+.dropdownmenu{
+    background-color:#DDDDDD;
     border-radius: 3px 3px 0px 0px;
     height:35px;
     width: 100%;
 }
 
-.bluedropdown label{
-    color:white;
+.dropdownmenu label{
+    color:black;
     padding: 6px 12px;
     margin:0px;
     width: 95%;

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -85,7 +85,7 @@
 
         <!--url section-->
         <div class="url row">
-            <div class="bluedropdown">
+            <div class="dropdownmenu">
               <label>Copy the URL below and share your Binder with others:</label>
             </div>
             <div class="url-row">
@@ -95,7 +95,7 @@
         </div>
 
         <div class="badges row">
-            <div class="bluedropdown" id="toggle-badge-snippet">
+            <div class="dropdownmenu" id="toggle-badge-snippet">
               <label>Copy the text below, then paste into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge_logo.svg")}}"></label>
               <a id="badge-link"></a>
               <a href="#" title="show badge snippets"><span id="badge-snippet-caret" class="glyphicon glyphicon-triangle-right"></span></a>


### PR DESCRIPTION
The current front-page has a fairly poor logo contrast...this updates the background for these sections to the same grey that's used in another button, so that it stands out better.

It's a stop-gap measure so that people can see the new "blue" for the logo, so we should keep the conversation going about what the "right" color is long-term!