### PR TITLE
Add about page to BinderHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             make html
 
       - store_artifacts:
-          path: doc/build/html/
+          path: doc/_build/html/
           destination: html
 
 workflows:

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -25,7 +25,7 @@ from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, defaul
 from traitlets.config import Application
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 
-from .base import Custom404
+from .base import AboutHandler, Custom404
 from .build import Build
 from .builder import BuildHandler
 from .launcher import Launcher
@@ -94,6 +94,17 @@ class BinderHub(Application):
         config=True
     )
 
+    about_message = Unicode(
+        '',
+        help="""
+        Additional message to display on the about page.
+
+        Will be directly inserted into the about page's source so you can use
+        raw HTML.
+        """,
+        config=True
+    )
+
     extra_footer_scripts = Dict(
         {},
         help="""
@@ -123,8 +134,8 @@ class BinderHub(Application):
 
     auth_enabled = Bool(
         False,
-        help="""If JupyterHub authentication enabled, 
-        require user to login (don't create temporary users during launch) and 
+        help="""If JupyterHub authentication enabled,
+        require user to login (don't create temporary users during launch) and
         start the new server for the logged in user.""",
         config=True)
 
@@ -489,6 +500,7 @@ class BinderHub(Application):
             'traitlets_config': self.config,
             'google_analytics_code': self.google_analytics_code,
             'google_analytics_domain': self.google_analytics_domain,
+            'about_message': self.about_message,
             'extra_footer_scripts': self.extra_footer_scripts,
             'jinja2_env': jinja_env,
             'build_memory_limit': self.build_memory_limit,
@@ -533,6 +545,7 @@ class BinderHub(Application):
             (r'/(favicon\_building\.ico)',
                 tornado.web.StaticFileHandler,
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
+            (r'/about', AboutHandler),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -4,6 +4,8 @@ from http.client import responses
 from tornado import web
 from jupyterhub.services.auth import HubOAuthenticated, HubOAuth
 
+from ._version import __version__ as binder_version
+
 
 class BaseHandler(HubOAuthenticated, web.RequestHandler):
     """HubAuthenticated by default allows all successfully identified users (see allow_all property)."""
@@ -87,3 +89,18 @@ class Custom404(BaseHandler):
 
     def prepare(self):
         raise web.HTTPError(404)
+
+
+class AboutHandler(BaseHandler):
+    """Serve the about page"""
+    async def get(self):
+        self.render_template(
+            "about.html",
+            base_url=self.settings['base_url'],
+            submit=False,
+            binder_version=binder_version,
+            message=self.settings['about_message'],
+            google_analytics_code=self.settings['google_analytics_code'],
+            google_analytics_domain=self.settings['google_analytics_domain'],
+            extra_footer_scripts=self.settings['extra_footer_scripts'],
+        )

--- a/binderhub/templates/about.html
+++ b/binderhub/templates/about.html
@@ -1,0 +1,27 @@
+{% extends "page.html" %}
+
+
+{% block main %}
+<div id="main" class="container">
+  <div class="row">
+    <h4 class="text-center logo-subtext">(beta)</h4>
+    <div class="col-lg-10 col-lg-offset-1">
+      {% block header %}
+      <div id="header" class="text-center">
+        <h3>BinderHub</h3>
+        <div id="explanation">
+          <p>This website is powered by <a href="https://github.com/jupyterhub/binderhub">BinderHub</a> v{{ binder_version }}.
+          </p>
+          <p>
+            {{ message | safe }}
+          </p>
+        </div>
+      </div>
+      {% endblock header %}
+    </div>
+  </div>
+</div>
+{% endblock main %}
+
+{% block footer %}
+{% endblock footer %}

--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -1,6 +1,9 @@
 Customizing your BinderHub deployment
 =====================================
 
+JupyterHub customization
+------------------------
+
 Because BinderHub uses JupyterHub to manage all user sessions, you can
 customize many aspects of the resources available to the user. This is
 primarily done by modifications to your BinderHub's Helm chart (``config.yaml``).
@@ -18,3 +21,13 @@ For example, see `this section of the mybinder.org Helm Chart
 For information on how to configure your JupyterHub deployment, see the
 `JupyterHub for Kubernetes Customization Guide
 <https://zero-to-jupyterhub.readthedocs.io/en/latest/#customization-guide>`_.
+
+
+About page customization
+------------------------
+
+BinderHub serves a simple about page at ``https://BINDERHOST/about``. By default
+this shows the version of BinderHub you are running. You can add additional
+HTML to the page by setting the ``c.BinderHub.about_message`` configuration
+option to the raw HTML you would like to add. You can use this to display
+contact information or other details about your deployment.

--- a/testing/localonly/binderhub_config.py
+++ b/testing/localonly/binderhub_config.py
@@ -4,3 +4,5 @@ c.BinderHub.use_registry = False
 c.BinderHub.builder_required = False
 c.BinderHub.repo_providers = {'gh': FakeProvider}
 c.BinderHub.tornado_settings.update({'fake_build':True})
+
+c.BinderHub.about_message = "<blink>Hello world.</blink>"


### PR DESCRIPTION
This adds a simple about page to BinderHub and the possibility to extend it with a short message.

The idea is to use the space for the message to put some details about who is operating the page and how to contact them. In some jurisdictions you have to put that kind of information on a web property. For mybinder.org we can use it to insert a message about how to get hold of the team, abuse, seucrity reports, etc.

This is my idea for implementing https://github.com/jupyterhub/binder/pull/139#issuecomment-438377209