### PR TITLE
bump hub chart 676f4f3...f2d579e

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.8.0-676f4f3"
+  version: "0.8.0-f2d579e"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
changes in the hub chart:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/676f4f3...f2d579e

includes priorityClass fix needed for 1.11