### PR TITLE
Add pod priorities to image builder and cleaner

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       initContainers:
 {{ toYaml .Values.initContainers | indent 6 }}
       {{- end }}
+      {{- if .Values.jupyterhub.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       nodeSelector: {{ toJson .Values.nodeSelector }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: binderhub

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -23,6 +23,9 @@ spec:
       initContainers:
 {{ toYaml .Values.dind.initContainers | indent 10 }}
       {{- end }}
+      {{- if .Values.jupyterhub.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       containers:
       - name: dind
         image: {{ .Values.dind.daemonset.image.name }}:{{ .Values.dind.daemonset.image.tag }}

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -23,6 +23,9 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}-image-cleaner
       {{- end }}
+      {{- if .Values.jupyterhub.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       containers:
       {{- range $i, $kind := tuple "host" "dind" }}
       {{- if or (and (eq $kind "dind") $Values.dind.enabled) (and (eq $kind "host") $Values.imageCleaner.host.enabled) }}


### PR DESCRIPTION
The DIND and image cleaner pods have a priority of zero which I think means they can get evicted when there isn't enough room for pods with higher priority. This is my guess for the build up of pending build pods over night.

Is there a way to add a pod priority to all pods except certain ones? My guess is that we'd want a pod priority of 10 for everything except the placeholder pods. Right now we have to go and annotate matomo, dind, etc by hand to make sure they have a priority above zero.