### PR TITLE
Fix ingress.tls's default value

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -5,17 +5,17 @@ metadata:
   name: binderhub
   {{- if or (and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego")) .Values.ingress.annotations }}
   annotations:
-    {{- if eq .Values.ingress.https.type  "kube-lego" }}
+    {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
     kubernetes.io/tls-acme: "true"
-    {{ end -}}
+    {{- end }}
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
       http:
         paths:
           - path: /
@@ -23,12 +23,21 @@ spec:
               serviceName: binder
               servicePort: 8585
     {{- end }}
-{{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
+  {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
   tls:
     - secretName: kubelego-tls-binder-{{ .Release.Name }}
       hosts:
-        {{- range $host := .Values.ingress.hosts }}
-        - {{ $host }}
+        {{- range .Values.ingress.hosts }}
+        - {{ . | quote }}
         {{- end }}
-{{- end }}
+  {{- else if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -156,6 +156,9 @@ imageCleaner:
 
 ingress:
   enabled: false
+  https:
+    enabled: false
+    type: kube-lego
   hosts:
     - chart-example.local
   annotations: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -161,7 +161,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  tls: {}
+  tls: []
     # Secrets must be manually created in the namespace.
     # - secretName: chart-example-tls
     #   hosts:


### PR DESCRIPTION
## Post WIP update

#### Issues fixed in PR
- `ingress.tls` were ignored.
- `ingress.tls` had a default value `{}`, but should be `[]`
- `ingress.https` had no default value, and templates would fail to render without it

#### Related
If you would change a service from `LoadBalancer` to `ClusterIP`, the template rendering a Service would at the same time removing `nodePort` details but the upgrade would fail claiming `ClusterIP` service type is incompatible with `nodePort`. The solution is to delete the service and run the helm chart upgrade again.

#### Functional config for the BinderHub chart
```yaml
  config:
    BinderHub:
      hub_url: 'https://hub.neurips.mybinder.org'
      use_registry: true
      image_prefix: gcr.io/binder-prod/neurips-

  service:
    type: ClusterIP

  ingress:
    enabled: true
    annotations:
      # cert-manager provides a TLS secret
      kubernetes.io/tls-acme: "true"
      # nginx-ingress controller to be explicitly utilized instead of "gce"
      kubernetes.io/ingress.class: nginx
    hosts:
      - neurips.mybinder.org
    tls:
      - secretName: neurips-mybinder-org-tls
        hosts:
          - neurips.mybinder.org

  # Default values: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/jupyterhub/values.yaml
  jupyterhub:
    proxy:
      service:
        type: ClusterIP
    ingress:
      enabled: true
      annotations:
        kubernetes.io/tls-acme: "true"
        kubernetes.io/ingress.class: nginx
      hosts:
        - hub.neurips.mybinder.org
      tls:
        - secretName: hub-neurips-mybinder-org-tls
          hosts:
            - hub.neurips.mybinder.org
```

---

## Ignore this original post

`.Values.ingress.tls` should default to a `[]` instead of `{}` to avoid:
```
2018/11/25 21:56:36 warning: cannot overwrite table with non table for tls (map[])
```

... when the following valid configuration is provided:

```yaml
ingress:
  tls:
    - secretName: hub-neurips-mybinder-org-tls
      hosts:
        - hub.neurips.mybinder.org
```