### PR TITLE
bump jupyterhub chart 151be76...c83896f

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.8.0-151be76"
+  version: "0.8.0-84ee483"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.8.0-84ee483"
+  version: "0.8.0-c83896f"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -96,7 +96,7 @@ jupyterhub:
               if 'image' not in self.user_options:
                 raise web.HTTPError(400, "image required")
 
-              self.image_spec = self.user_options['image']
+              self.image = self.user_options['image']
               return super().start()
 
         c.JupyterHub.spawner_class = BinderSpawner


### PR DESCRIPTION
Main relevant change:

- updates kubespawner to 0.10

which should be a very small release and shouldn't have noticeable effects

https://github.com/jupyterhub/zero-to-jupyterhub/compare/151be76...c83896f