### PR TITLE
Adding node to docs environment

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,7 @@
 name: binderhub
 type: sphinx
+build:
+  image: latest
 requirements_file: doc/doc-requirements.txt
 python:
   version: 3


### PR DESCRIPTION
This is an attempt at figuring out https://github.com/jupyterhub/binderhub/issues/728 - the error was that we don't have `npm` installed, and it seems from https://docs.readthedocs.io/en/latest/builds.html#the-build-environment that we can specify a Docker image in the build that has `npm`. I *think* this PR will do that. I'll merge this and we'll see if that fixes things because I don't know of any other way to test this out than to just give it a merge...