### PR TITLE
bootstrap 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "`BinderHub`",
   "devDependencies": {
-    "bootstrap": "^3.3.7",
+    "bootstrap": "^3.4.0",
     "clipboard": "^1.7.1",
     "css-loader": "^0.28.7",
     "event-source-polyfill": "^0.0.12",


### PR DESCRIPTION
minor release. Shouldn't affect anything, but will get rid of the vulnerability warning on GitHub (vulnerability doesn't affect BinderHub, since we don't display untrusted HTML snippets).