### PR TITLE
some fixes in documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ Getting started
 
 The primary goal of BinderHub is creating custom computing environments that
 can be used by many remote users. BinderHub enables an end user to easily
-specify a desired computing environment from a GitHub repo. BinderHub then
+specify a desired computing environment from a Git repo. BinderHub then
 serves the custom computing environment at a URL which users can access
 remotely.
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -17,9 +17,9 @@ and registry of Docker images. It utilizes the following tools:
 - **Kubernetes** to manage resources on the cloud
 - **Helm** to configure and control Kubernetes
 - **Docker** to use containers that standardize computing environments
-- A **BinderHub UI** that users can access to specify GitHub repos they want
+- A **BinderHub UI** that users can access to specify Git repos they want
   built
-- **BinderHub** to generate Docker images using the URL of a GitHub repository
+- **BinderHub** to generate Docker images using the URL of a Git repository
 - A **Docker registry** (such as gcr.io) that hosts container images
 - **JupyterHub** to deploy temporary containers for users
 

--- a/doc/turn-off.rst
+++ b/doc/turn-off.rst
@@ -10,7 +10,7 @@ Contracting the size of your cluster
 ------------------------------------
 
 If you would like to shrink the size of your cluster, refer to the
-`Expanding and contracting the size of your cluster <https://zero-to-jupyterhub.readthedocs.io/en/latest/extending-jupyterhub.html#expanding-and-contracting-the-size-of-your-cluster>`_
+`Expanding and contracting the size of your cluster <https://zero-to-jupyterhub.readthedocs.io/en/latest/user-resources.html#expanding-and-contracting-the-size-of-your-cluster>`_
 section of the `Zero to JupyterHub`_ documentation. Resizing the cluster to
 zero nodes could be used if you wish to temporarily reduce the cluster (and
 save costs) without deleting the cluster.


### PR DESCRIPTION
Hi, this PR

- fixes a link to zero-to-jupyterhub documentation
- replaces "GitHub" with "Git" in 2 docs