### PR TITLE
upgrade pip, setuptools, requirements on travis; switch to pytest-asyncio

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 omit =
     binderhub/tests/*
+parallel = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ before_install:
   - nvm install 8; nvm use 8
 install:
   - export PATH=$PWD/bin:$PATH
+  - pip install --upgrade pip setuptools
   - ./ci/install.sh
-  - pip install -r dev-requirements.txt
+  - pip install --upgrade -r dev-requirements.txt
   - npm install
   - npm run webpack
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install --upgrade -r dev-requirements.txt
   - npm install
   - npm run webpack
-  - pip install .
+  - pip install --upgrade . -r helm-chart/images/binderhub/requirements.txt
 
 script:
   - export BINDER_TEST_NAMESPACE=binder-test-$TEST

--- a/binderhub/tests/test_auth.py
+++ b/binderhub/tests/test_auth.py
@@ -21,15 +21,14 @@ def use_session():
     ],
     indirect=['app']  # send param True to app fixture, so that it loads authentication configuration
 )
-@pytest.mark.gen_test
 @pytest.mark.auth_test
-def test_auth(app, path, authenticated, use_session):
+async def test_auth(app, path, authenticated, use_session):
     service_path = app.base_url.lstrip('/')
     service_url = f'{app.hub_url}{service_path}'
     url = f'{service_url}{path}'
-    r = yield async_requests.get(url)
+    r = await async_requests.get(url)
     assert r.status_code == 200, f"{r.status_code} {url}"
-    r2 = yield async_requests.post(r.url, data={'username': 'dummy', 'password': 'dummy'})
+    r2 = await async_requests.post(r.url, data={'username': 'dummy', 'password': 'dummy'})
     if authenticated:
         assert r2.status_code == 200, f"{r2.status_code} {r.url}"
     else:

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -29,12 +29,7 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
     r = await async_requests.get(build_url, stream=True)
     r.raise_for_status()
     events = []
-    for f in async_requests.iter_lines(r):
-        # await line Future
-        try:
-            line = await f
-        except StopIteration:
-            break
+    async for line in async_requests.iter_lines(r):
         line = line.decode('utf8', 'replace')
         if line.startswith('data:'):
             event = json.loads(line.split(':', 1)[1])

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -12,7 +12,7 @@ from binderhub.build import Build
 from .utils import async_requests
 
 
-@pytest.mark.gen_test(timeout=900)
+@pytest.mark.asyncio(timeout=900)
 @pytest.mark.parametrize("slug", [
     "gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd",
     "git/{}/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd".format(
@@ -21,18 +21,18 @@ from .utils import async_requests
     "gl/minrk%2Fbinderhub-ci/0d4a217d40660efaa58761d8c6084e7cf5453cca",
 ])
 @pytest.mark.remote
-def test_build(app, needs_build, needs_launch, always_build, slug, pytestconfig):
+async def test_build(app, needs_build, needs_launch, always_build, slug, pytestconfig):
     # can't use mark.github_api since only some tests here use GitHub
     if slug.startswith('gh/') and "not github_api" in pytestconfig.getoption('markexpr'):
         pytest.skip("Skipping GitHub API test")
     build_url = f"{app.url}/build/{slug}"
-    r = yield async_requests.get(build_url, stream=True)
+    r = await async_requests.get(build_url, stream=True)
     r.raise_for_status()
     events = []
     for f in async_requests.iter_lines(r):
         # await line Future
         try:
-            line = yield f
+            line = await f
         except StopIteration:
             break
         line = line.decode('utf8', 'replace')
@@ -48,7 +48,7 @@ def test_build(app, needs_build, needs_launch, always_build, slug, pytestconfig)
     assert 'url' in final
     assert 'token' in final
     print(final['url'])
-    r = yield async_requests.get(url_concat(final['url'], {'token': final['token']}))
+    r = await async_requests.get(url_concat(final['url'], {'token': final['token']}))
     r.raise_for_status()
     assert r.url.startswith(final['url'])
 

--- a/binderhub/tests/test_eventlog.py
+++ b/binderhub/tests/test_eventlog.py
@@ -101,7 +101,7 @@ def test_emit_event_badschema():
             })
 
 
-def test_provider_completeness(app):
+async def test_provider_completeness(app):
     """
     Test we add an entry in the launch schema for all providers
     """

--- a/binderhub/tests/test_registry.py
+++ b/binderhub/tests/test_registry.py
@@ -105,7 +105,6 @@ class MockManifestHandler(RequestHandler):
         self.write(json.dumps({"image": image, "tag": tag}))
 
 
-@pytest.mark.gen_test
 async def test_get_image_manifest(tmpdir, request):
     username = "asdf"
     password = "asdf;ouyag"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,8 +2,8 @@ beautifulsoup4
 codecov
 html5lib
 pytest
+pytest-asyncio
 pytest-cov
-pytest-tornado
 requests
 ruamel.yaml>=0.15
 https://github.com/jupyterhub/chartpress/archive/2f26733f6ebf9e2b76bd9cfa3b8a8439daa0b16c.tar.gz


### PR DESCRIPTION
- upgrading pip ensures we get warnings about incompatibilities
- upgrading requirements fixes one such incompatibility with pytest-cov and pytest being too old
- switch to pytest-asyncio because upgrading pytest breaks pytest-tornado, which is ~unmaintained and has issues with recent pytest and tornado

This should fix recent travis failures