### PR TITLE
pytest-cov 2.6.0 requires pytest >= 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - npm install
   - npm run webpack
   - pip install .
+  - pip freeze
 
 script:
   - export BINDER_TEST_NAMESPACE=binder-test-$TEST

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 codecov
 html5lib
-pytest
+pytest>=3.5
 pytest-cov
 pytest-tornado
 requests

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 beautifulsoup4
 codecov
 html5lib
-pytest>=3.5
-pytest-cov
+pytest
+pytest-cov<2.6.0
 pytest-tornado
 requests
 ruamel.yaml>=0.15


### PR DESCRIPTION
Tests for last 3 PRs I made are failed with 

```
pluggy.PluginValidationError: Plugin 'pytest_cov' could not be loaded: (pytest 3.3.0 (/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages), Requirement.parse('pytest>=3.6'))!
```

Then I found out that pytest-cov 2.6.0 requires pytest >= 3.5 (https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst#260-2018-09-03) and pytest-cov 2.6.1 is installed during tests.