### PR TITLE
Update authentication tests

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -558,7 +558,7 @@ class BinderHub(Application):
             oauth_redirect_uri = os.getenv('JUPYTERHUB_OAUTH_CALLBACK_URL') or \
                                  url_path_join(self.base_url, 'oauth_callback')
             oauth_redirect_uri = urlparse(oauth_redirect_uri).path
-            handlers.insert(-1, (oauth_redirect_uri, HubOAuthCallbackHandler))
+            handlers.insert(-1, (re.escape(oauth_redirect_uri), HubOAuthCallbackHandler))
         self.tornado_app = tornado.web.Application(handlers, **self.tornado_settings)
 
     def stop(self):

--- a/binderhub/tests/test_auth.py
+++ b/binderhub/tests/test_auth.py
@@ -15,17 +15,15 @@ def use_session():
 @pytest.mark.parametrize(
     'app,path,authenticated',
     [
-        (True, '', True),  # main page
-        (True, 'v2/gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd', True),
-        (True, 'metrics', False),
+        (True, '/', True),  # main page
+        (True, '/v2/gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd', True),
+        (True, '/metrics', False),
     ],
     indirect=['app']  # send param True to app fixture, so that it loads authentication configuration
 )
 @pytest.mark.auth_test
 async def test_auth(app, path, authenticated, use_session):
-    service_path = app.base_url.lstrip('/')
-    service_url = f'{app.hub_url}{service_path}'
-    url = f'{service_url}{path}'
+    url = f'{app.url}{path}'
     r = await async_requests.get(url)
     assert r.status_code == 200, f"{r.status_code} {url}"
     r2 = await async_requests.post(r.url, data={'username': 'dummy', 'password': 'dummy'})

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -89,6 +89,8 @@ spec:
               name: binder-secret
               key: "binder.hub-token"
         {{- if .Values.config.BinderHub.auth_enabled }}
+        - name: JUPYTERHUB_HOST
+          value: {{ .Values.config.BinderHub.hub_url | trimSuffix "/" | quote }}
         - name: JUPYTERHUB_API_URL
           value: {{ (print (.Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
         - name: JUPYTERHUB_BASE_URL

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -95,10 +95,8 @@ spec:
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
         - name: JUPYTERHUB_CLIENT_ID
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_client_id | quote}}
-        {{- if .Values.jupyterhub.hub.services.binder.oauth_redirect_uri }}
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
-        {{- end }}
         {{- end }}
         ports:
           - containerPort: 8585

--- a/testing/minikube/binderhub_auth_config.py
+++ b/testing/minikube/binderhub_auth_config.py
@@ -2,14 +2,13 @@ import os
 here = os.path.abspath(os.path.dirname(__file__))
 load_subconfig(os.path.join(here, 'binderhub_config.py'))
 
-c.BinderHub.base_url = '/services/binder/'
+c.BinderHub.base_url = '/'
 c.BinderHub.auth_enabled = True
-c.BinderHub.use_named_servers = False
-
-# configuration for service authentication
+# configuration for authentication
+c.HubOAuth.hub_host = c.BinderHub.hub_url
 c.HubOAuth.api_token = c.BinderHub.hub_api_token
 c.HubOAuth.api_url = c.BinderHub.hub_url + '/hub/api/'
 c.HubOAuth.base_url = c.BinderHub.base_url
-c.HubOAuth.hub_prefix = '/hub/'
-c.HubOAuth.oauth_redirect_uri = c.BinderHub.hub_url + '/services/binder/oauth_callback'
+c.HubOAuth.hub_prefix = c.BinderHub.base_url + 'hub/'
+c.HubOAuth.oauth_redirect_uri = 'http://127.0.0.1:8585/oauth_callback'
 c.HubOAuth.oauth_client_id = 'binder-oauth-client-test'

--- a/testing/minikube/binderhub_auth_config.py
+++ b/testing/minikube/binderhub_auth_config.py
@@ -11,4 +11,5 @@ c.HubOAuth.api_token = c.BinderHub.hub_api_token
 c.HubOAuth.api_url = c.BinderHub.hub_url + '/hub/api/'
 c.HubOAuth.base_url = c.BinderHub.base_url
 c.HubOAuth.hub_prefix = '/hub/'
+c.HubOAuth.oauth_redirect_uri = c.BinderHub.hub_url + '/services/binder/oauth_callback'
 c.HubOAuth.oauth_client_id = 'binder-oauth-client-test'

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -12,7 +12,6 @@ import os
 import pipes
 from subprocess import check_call, check_output
 import time
-import socket
 
 from kubernetes import client, config
 from ruamel import yaml
@@ -55,32 +54,6 @@ if auth_enabled:
     print('\nAuthentication is enabled')
     auth_conf_file = os.path.join(here, 'jupyterhub-helm-auth-config.yaml')
     args.extend(['-f', auth_conf_file])
-
-    # get host IP (https://stackoverflow.com/a/28950776/4361882)
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    try:
-        # doesn't even have to be reachable
-        s.connect(('10.255.255.255', 1))
-        IP = s.getsockname()[0]
-    except:
-        IP = '127.0.0.1'
-    finally:
-        s.close()
-    import subprocess
-
-    try:
-        minikube_ip = subprocess.check_output(['minikube', 'ip']).decode('utf-8').strip()
-    except (subprocess.SubprocessError, FileNotFoundError):
-        minikube_ip = '192.168.1.100'
-    print('Host IP: {}'.format(IP))
-    print('minikube IP: {}'.format(minikube_ip))
-    # insert host IP
-    with open(auth_conf_file, 'r') as file:
-        filedata = file.read()
-    filedata = filedata.replace('<host_ip>', IP)
-    filedata = filedata.replace('<minikube_ip>', minikube_ip)
-    with open(auth_conf_file, 'w') as file:
-        file.write(filedata)
 
 is_running = name in check_output(['helm', 'list', '-q']).decode('utf8', 'replace').split()
 if is_running:

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -66,11 +66,19 @@ if auth_enabled:
         IP = '127.0.0.1'
     finally:
         s.close()
+    import subprocess
+
+    try:
+        minikube_ip = subprocess.check_output(['minikube', 'ip']).decode('utf-8').strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        minikube_ip = '192.168.1.100'
     print('Host IP: {}'.format(IP))
+    print('minikube IP: {}'.format(minikube_ip))
     # insert host IP
     with open(auth_conf_file, 'r') as file:
         filedata = file.read()
     filedata = filedata.replace('<host_ip>', IP)
+    filedata = filedata.replace('<minikube_ip>', minikube_ip)
     with open(auth_conf_file, 'w') as file:
         file.write(filedata)
 

--- a/testing/minikube/jupyterhub-helm-auth-config.yaml
+++ b/testing/minikube/jupyterhub-helm-auth-config.yaml
@@ -4,6 +4,7 @@ hub:
   services:
     binder:
       url: http://<host_ip>:8585
+      oauth_redirect_uri: "http://<minikube_ip>:30123/services/binder/oauth_callback"
       oauth_client_id: "binder-oauth-client-test"
 
 auth:

--- a/testing/minikube/jupyterhub-helm-auth-config.yaml
+++ b/testing/minikube/jupyterhub-helm-auth-config.yaml
@@ -3,8 +3,7 @@ cull:
 hub:
   services:
     binder:
-      url: http://<host_ip>:8585
-      oauth_redirect_uri: "http://<minikube_ip>:30123/services/binder/oauth_callback"
+      oauth_redirect_uri: "http://127.0.0.1:8585/oauth_callback"
       oauth_client_id: "binder-oauth-client-test"
 
 auth:


### PR DESCRIPTION
I updated authentication tests, so now in tests binder runs  independent of jhub and uses jhub as oauth2 provider (before it was running as a service of jhub under `/services/`). I think this is the use case most of the people want to use it as, so we should test it.

There is also one fix: setting `JUPYTERHUB_HOST`, this environment variable is needed when BinderHub and JupyterHub run on different domains (as it happens in tests).