### PR TITLE
set HubOAuth.hub_host correctly

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -89,8 +89,6 @@ spec:
               name: binder-secret
               key: "binder.hub-token"
         {{- if .Values.config.BinderHub.auth_enabled }}
-        - name: JUPYTERHUB_HOST
-          value: {{ .Values.config.BinderHub.hub_url | trimSuffix "/" | quote }}
         - name: JUPYTERHUB_API_URL
           value: {{ (print (.Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
         - name: JUPYTERHUB_BASE_URL

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -1,7 +1,7 @@
 from collections import Mapping
 import os
 from functools import lru_cache
-
+from urllib.parse import urlparse
 import yaml
 
 c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
@@ -83,8 +83,11 @@ if allow_origin:
 if os.getenv('BUILD_NAMESPACE'):
     c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
-if c.BinderHub.auth_enabled and 'base_url' in c.BinderHub:
-    c.HubOAuth.base_url = c.BinderHub.base_url
+if c.BinderHub.auth_enabled:
+    hub_url = urlparse(c.BinderHub.hub_url)
+    c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)
+    if 'base_url' in c.BinderHub:
+        c.HubOAuth.base_url = c.BinderHub.base_url
 
 # load extra config snippets
 for key, snippet in sorted((get_value('extraConfig') or {}).items()):

--- a/testing/minikube/binderhub_auth_config.py
+++ b/testing/minikube/binderhub_auth_config.py
@@ -1,3 +1,4 @@
+from urllib.parse import urlparse
 import os
 here = os.path.abspath(os.path.dirname(__file__))
 load_subconfig(os.path.join(here, 'binderhub_config.py'))
@@ -5,7 +6,8 @@ load_subconfig(os.path.join(here, 'binderhub_config.py'))
 c.BinderHub.base_url = '/'
 c.BinderHub.auth_enabled = True
 # configuration for authentication
-c.HubOAuth.hub_host = c.BinderHub.hub_url
+hub_url = urlparse(c.BinderHub.hub_url)
+c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)
 c.HubOAuth.api_token = c.BinderHub.hub_api_token
 c.HubOAuth.api_url = c.BinderHub.hub_url + '/hub/api/'
 c.HubOAuth.base_url = c.BinderHub.base_url


### PR DESCRIPTION
@minrk I just realized that I made a mistake in https://github.com/jupyterhub/binderhub/pull/770: I set `JUPYTERHUB_HOST` env variable with hub url, which also contains paths (such as base url). Here I removed that env var and set `HubOAuth.hub_host` in binderhub_config.py.