### PR TITLE
Add liveness probe to binderhub helm chart

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -103,3 +103,9 @@ spec:
         ports:
           - containerPort: 8585
             name: binder
+        livenessProbe:
+          httpGet:
+            path: /about
+            port: binder
+          initialDelaySeconds: 10
+          periodSeconds: 5


### PR DESCRIPTION
Defines a liveness probe for BinderHub.

This will fail when the hub stops responding to requests for `/about`. Maybe in a follow up PR we can introduce a "alive and healthy" endpoint that can trigger a restart earlier. Might also implement the "consecutive failed launches" logic in that endpoint.

closes #772