### PR TITLE
add base_url into livenessProbe.httpGet.path

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             name: binder
         livenessProbe:
           httpGet:
-            path: /about
+            path: {{ default "/" .Values.config.BinderHub.base_url }}about
             port: binder
           initialDelaySeconds: 10
           periodSeconds: 5


### PR DESCRIPTION
Liveness probe fails with 404 when base_url is set for BinderHub. So I added base_url into `livenessProbe.httpGet.path` if base_url is set, default is "/".