### PR TITLE
Move badge and path functions out of megafile

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -17,6 +17,7 @@ import 'bootstrap';
 import 'event-source-polyfill';
 
 import BinderImage from './src/image';
+import { markdownBadge, rstBadge } from './src/badge';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';
@@ -135,20 +136,6 @@ function updateUrls(formValues) {
       el.text(el.attr('data-default'));
     })
   }
-}
-
-
-var BADGE_URL = window.location.origin + BASE_URL + 'badge_logo.svg';
-
-
-function markdownBadge(url) {
-  // return markdown badge snippet
-  return '[![Binder](' + BADGE_URL + ')](' + url + ')'
-}
-
-function rstBadge(url) {
-  // return rst badge snippet
-  return '.. image:: ' + BADGE_URL + ' :target: ' + url
 }
 
 function build(providerSpec, log, path, pathType) {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -18,6 +18,7 @@ import 'event-source-polyfill';
 
 import BinderImage from './src/image';
 import { markdownBadge, rstBadge } from './src/badge';
+import { updatePathText } from './src/path';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';
@@ -50,24 +51,6 @@ function v2url(providerPrefix, repository, ref, path, pathType) {
   }
   return url;
 }
-
-function getPathType() {
-  // return path type. 'file' or 'url'
-  return $("#url-or-file-selected").text().trim().toLowerCase();
-}
-
-function updatePathText() {
-  var pathType = getPathType();
-  var text;
-  if (pathType === "file") {
-    text = "Path to a notebook file (optional)";
-  } else {
-    text = "URL to open (optional)";
-  }
-  $("#filepath").attr('placeholder', text);
-  $("label[for=filepath]").text(text);
-}
-
 
 function updateRepoText() {
   var text;

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -18,7 +18,7 @@ import 'event-source-polyfill';
 
 import BinderImage from './src/image';
 import { markdownBadge, rstBadge } from './src/badge';
-import { updatePathText } from './src/path';
+import { getPathType, updatePathText } from './src/path';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';

--- a/binderhub/static/js/src/badge.js
+++ b/binderhub/static/js/src/badge.js
@@ -1,0 +1,11 @@
+var BADGE_URL = window.location.origin + BASE_URL + "badge_logo.svg";
+
+export function markdownBadge(url) {
+  // return markdown badge snippet
+  return "[![Binder](" + BADGE_URL + ")](" + url + ")";
+}
+
+export function rstBadge(url) {
+  // return rst badge snippet
+  return ".. image:: " + BADGE_URL + " :target: " + url;
+}

--- a/binderhub/static/js/src/badge.js
+++ b/binderhub/static/js/src/badge.js
@@ -1,3 +1,4 @@
+var BASE_URL = $("#base-url").data().url;
 var BADGE_URL = window.location.origin + BASE_URL + "badge_logo.svg";
 
 export function markdownBadge(url) {
@@ -7,5 +8,5 @@ export function markdownBadge(url) {
 
 export function rstBadge(url) {
   // return rst badge snippet
-  return ".. image:: " + BADGE_URL + " :target: " + url;
+  return ".. image:: " + BADGE_URL + "\n :target: " + url;
 }

--- a/binderhub/static/js/src/path.js
+++ b/binderhub/static/js/src/path.js
@@ -1,0 +1,22 @@
+export function getPathType() {
+  // return path type. 'file' or 'url'
+  const element = document.getElementById("url-or-file-selected");
+  return element.innerText.trim().toLowerCase();
+}
+
+export function updatePathText() {
+  var pathType = getPathType();
+  var text;
+  if (pathType === "file") {
+    text = "Path to a notebook file (optional)";
+  } else {
+    text = "URL to open (optional)";
+  }
+  const filePathElement = document.getElementById(filepath);
+  filePathElement.setAttribute("placeholder", text);
+
+  const filePathElementLabel = document.getElementsByTagName(
+    "label[for=filepath]"
+  )[0];
+  filePathElementLabel.innerText = text;
+}

--- a/binderhub/static/js/src/path.js
+++ b/binderhub/static/js/src/path.js
@@ -12,11 +12,9 @@ export function updatePathText() {
   } else {
     text = "URL to open (optional)";
   }
-  const filePathElement = document.getElementById(filepath);
+  const filePathElement = document.getElementById("filepath");
   filePathElement.setAttribute("placeholder", text);
 
-  const filePathElementLabel = document.getElementsByTagName(
-    "label[for=filepath]"
-  )[0];
+  const filePathElementLabel = document.querySelector("label[for=filepath]");
   filePathElementLabel.innerText = text;
 }


### PR DESCRIPTION
This PR works towards closing https://github.com/jupyterhub/binderhub/issues/777.

- Moves out badge and path functions to separate files
- Replaces use of jQuery with standard JS
- Closes https://github.com/jupyterhub/binderhub/issues/747