### PR TITLE
Prevent scroll to top on dropdown click

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -271,7 +271,9 @@ function indexMain() {
     // setup badge dropdown and default values.
     updateUrls();
 
-    $("#provider_prefix_sel li").click(function(){
+    $("#provider_prefix_sel li").click(function(event){
+      event.preventDefault();
+
       $("#provider_prefix-selected").text($(this).text());
       $("#provider_prefix").val($(this).attr("value"));
       updateRepoText();
@@ -279,6 +281,8 @@ function indexMain() {
     });
 
     $("#url-or-file-btn").find("a").click(function (evt) {
+      evt.preventDefault();
+
       $("#url-or-file-selected").text($(this).text());
       updatePathText();
       updateUrls();


### PR DESCRIPTION
Closes https://github.com/jupyterhub/binderhub/issues/608.

**Demo**
![no-scroll](https://user-images.githubusercontent.com/1857993/51883145-90705d80-2336-11e9-89f1-c75f749c25f7.gif)
