### PR TITLE
Docs link in building page

### DIFF
--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -14,7 +14,7 @@
 	<p>Loading your Binder...</p>
 </div>
 <div id="loader-links">
-  <p>New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information</p>
+  <p class="text-center">New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information</p>
 </div>
 
 <div id="log-container" class="panel panel-default on-build hidden row">

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -13,6 +13,9 @@
 <div id="loader-text">
 	<p>Loading your Binder...</p>
 </div>
+<div id="loader-links">
+  <p>New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information</p>
+</div>
 
 <div id="log-container" class="panel panel-default on-build hidden row">
   <div id="toggle-logs" class="panel-heading">


### PR DESCRIPTION
This PR adds a short sentence w/ a link to the Binder documentation from the loading page. Many BinderHub users (particularly new ones) will first experience Binder by clicking a link, not from going to `mybinder.org`. This makes sure that we show them a link to the docs on the loading page itself.