### PR TITLE
adding link to gcloud install

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -196,12 +196,7 @@ texinfo_documents = [
 # -- Custom scripts -------------------------------------------
 
 # Grab the latest version of the k8s and helm install instructions.
-k8s_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/create-k8s-cluster.rst"
 helm_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/setup-helm.rst"
-
-resp = requests.get(k8s_instructions)
-with open('./k8s.txt', 'w') as ff:
-    ff.write(resp.text)
 
 resp = requests.get(helm_instructions)
 with open('./helm.txt', 'w') as ff:
@@ -215,4 +210,3 @@ with open('./helm.txt', 'w') as ff:
 # -- Add custom CSS ----------------------------------------------
 def setup(app):
     app.add_stylesheet('https://gitcdn.link/repo/jupyterhub/binder/master/doc/_static/custom.css')
-

--- a/doc/create-cloud-resources.rst
+++ b/doc/create-cloud-resources.rst
@@ -13,7 +13,7 @@ various components correctly. The following instructions will assist you
 in doing so.
 
 .. note::
-   
+
    BinderHub uses a JupyterHub running on Kubernetes for much of its functionality.
    For information on setting up and customizing your JupyterHub, we recommend reading
    the `Zero to JupyterHub Guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/index.html#customization-guide>`_.
@@ -29,6 +29,9 @@ Setting up Kubernetes on `Google Cloud <https://cloud.google.com/>`_
    If you would like to help with adding instructions for other cloud
    providers, `please contact us <https://github.com/jupyterhub/binderhub/issues>`_!
 
+First, install Kubernetes by following the
+`instructions in the Zero to JupyterHub guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/google/step-zero-gcp.html>`_.
+When you're done, move on to the next section.
 
 Install Helm
 ------------


### PR DESCRIPTION
Just realized that in https://github.com/jupyterhub/binderhub/commit/a93132eed19d33fe465600241a00c2fc78d19e8b#diff-0977844fde26c8a002480f221b0c762e we removed the install instructions for GCP. This adds a link to the Z2JH guide so that it persists.