### PR TITLE
relax default liveness probe to 10s

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -107,3 +107,4 @@ spec:
             port: binder
           initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10


### PR DESCRIPTION
in case something is being bogged down, 1s may not be enough

mybinder.org failed liveness probes this morning, despite being fully responsive. Possible due to this being a too-short timeout.