### PR TITLE
bump dind image to 18.09.2

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -130,7 +130,7 @@ dind:
   daemonset:
     image:
       name: docker
-      tag: 17.11.0-ce-dind
+      tag: 18.09.2-dind
   storageDriver: overlay2
   resources: {}
   hostSocketDir: /var/run/dind


### PR DESCRIPTION
for CVE-2019-5736

users don't appear to be affected since we run them as uid 1000 and the vulnerability [appears to require pods to run as uid 0](https://kubernetes.io/blog/2019/02/11/runc-and-cve-2019-5736/)