### PR TITLE
enable registry to use oauth 2.0 as well.

### DIFF
--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -197,8 +197,13 @@ class DockerRegistry(LoggingConfigurable):
             auth_password=self.password,
         )
         auth_resp = yield client.fetch(auth_req)
-        token = json.loads(auth_resp.body.decode("utf-8", "replace"))["token"]
-
+        response_body = json.loads(auth_resp.body.decode("utf-8", "replace"))
+    
+        if "token" in response_body.keys():
+            token = response_body["token"]
+        elif "access_token" in response_body.keys(): 
+            token = response_body["access_token"]
+        
         req = httpclient.HTTPRequest(
             "{}/v2/{}/manifests/{}".format(self.url, image, tag),
             headers={"Authorization": "Bearer {}".format(token)},


### PR DESCRIPTION
Binderhub currently does not seem to support Oauth 2.0 for registry. This change should fix that. 

Explanation: 
Docker authentication supports Oauth2.0 as per their documentation: https://docs.docker.com/registry/spec/auth/token/#requesting-a-token. However it looks like binderhub has a hard dependency on "token" in the response. See https://github.com/jupyterhub/binderhub/blob/67d7d684c558e86c4dbfa8c8142e48b5747af703/binderhub/registry.py#L200

Azure Container Registry uses Oauth2.0 https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md, so as it is, binderhub cannot work with ACR. 