### PR TITLE
Use different command name in Windows setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,12 @@ with open('README.rst', encoding="utf8") as f:
     readme = f.read()
 
 # Build our js and css files before packaging
-subprocess.check_call(['npm', 'install'])
-subprocess.check_call(['npm', 'run', 'webpack'])
+if os.name == "nt":
+    subprocess.check_call(['npm.cmd', 'install'])
+    subprocess.check_call(['npm.cmd', 'run', 'webpack'])
+else:
+    subprocess.check_call(['npm', 'install'])
+    subprocess.check_call(['npm', 'run', 'webpack'])
 
 setup(
     name='binderhub',


### PR DESCRIPTION
I ran into this issue while setting up BinderHub for development on Windows.

On Windows, the `npm` command is a wrapper, not a real executable. As a result, calling `subprocess.check_call` with `"npm"` as a parameter fails as an executable with that name does not exist.

The solution is to invoke the actual executable, called `npm.cmd`, when running on Windows systems.