### PR TITLE
update gist repoprovider

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -295,7 +295,7 @@ class BuildHandler(BaseHandler):
             })
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube)
-            self.event_log.emit('binderhub.jupyter.org/launch', 1, {
+            self.event_log.emit('binderhub.jupyter.org/launch', 2, {
                 'provider': provider.name,
                 'spec': spec,
                 'status': 'success'
@@ -403,7 +403,7 @@ class BuildHandler(BaseHandler):
             BUILD_COUNT.labels(status='success', **self.repo_metric_labels).inc()
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube)
-            self.event_log.emit('binderhub.jupyter.org/launch', 1, {
+            self.event_log.emit('binderhub.jupyter.org/launch', 2, {
                 'provider': provider.name,
                 'spec': spec,
                 'status': 'success'

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -8,6 +8,7 @@
         "provider": {
             "enum": [
                 "GitHub",
+                "Gist",
                 "GitLab",
                 "Git"
             ],

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -1,6 +1,6 @@
 {
     "$id": "binderhub.jupyter.org/launch",
-    "version": 1,
+    "version": 2,
     "title": "BinderHub Launch Events",
     "description": "BinderHub emits this event whenever a new repo is launched",
     "type": "object",

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -472,7 +472,7 @@ class GistRepoProvider(GitHubRepoProvider):
 
     Users must provide a spec that matches the following form (similar to github)
 
-    <username>/<gist-id>[/<ref>]
+    [https://gist.github.com/]<username>/<gist-id>[/<ref>]
 
     The ref is optional, valid values are
         - a full sha1 of a ref in the history

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -480,6 +480,8 @@ class GistRepoProvider(GitHubRepoProvider):
     If master or no ref is specified the latest revision will be used.
     """
 
+    name = Unicode('Gist')
+
     allow_secret_gist = Bool(
         default_value=False,
         config=True,

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -497,7 +497,7 @@ class GistRepoProvider(GitHubRepoProvider):
             self.unresolved_ref = ''
 
     def get_repo_url(self):
-        return f'https://gist.github.com/{self.gist_id}.git'
+        return f'https://gist.github.com/{self.user}/{self.gist_id}.git'
 
     @gen.coroutine
     def get_resolved_ref(self):

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -62,7 +62,8 @@ function updateRepoText() {
     text = "GitLab.com repository or URL";
   }
   else if (provider === "gist") {
-    text = "Gist ID (username/gistId)";
+    text = "Gist ID (username/gistId) or URL";
+    tag_text = "Git commit SHA";
   }
   else if (provider === "git") {
     text = "Arbitrary git repository URL (http://git.example.com/repo)";
@@ -78,6 +79,7 @@ function getBuildFormValues() {
   var providerPrefix = $('#provider_prefix').val().trim();
   var repo = $('#repository').val().trim();
   if (providerPrefix !== 'git') {
+    repo = repo.replace(/^(https?:\/\/)?gist.github.com\//, '');
     repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
     repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, '');
   }

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -146,7 +146,7 @@ def test_gist_ref():
     slug = provider.get_build_slug()
     assert slug == '8a658f7f63b13768d1e75fa2464f5092'
     full_url = provider.get_repo_url()
-    assert full_url == 'https://gist.github.com/8a658f7f63b13768d1e75fa2464f5092.git'
+    assert full_url == 'https://gist.github.com/mariusvniekerk/8a658f7f63b13768d1e75fa2464f5092.git'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == '7daa381aae8409bfe28193e2ed8f767c26371237'
 

--- a/doc/eventlogging.rst
+++ b/doc/eventlogging.rst
@@ -41,3 +41,16 @@ with the lifetime length of the notebook.
 
 `Wikimedia's EventLogging Guidelines <https://www.mediawiki.org/wiki/Extension:EventLogging/Guide#Posing_a_question>`_
 contain a lot of useful info on how to approach adding more events.
+
+BinderHub Events
+================
+
+Launch event
+------------
+
+This event is emitted whenever a new repo is launched.
+
+Schemas:
+
+- `version 1 <https://github.com/jupyterhub/binderhub/blob/ba15091b0940174c1001aefd2c89b96daa8005cb/binderhub/event-schemas/launch.json>`_
+- `version 2 <https://github.com/jupyterhub/binderhub/blob/master/binderhub/event-schemas/launch.json>`_


### PR DESCRIPTION
This PR:

- adds user name into gist repo url. repo url is sent to metrics, ~~events~~ and spawner. gist url without user name works too but i think full url is more useful
- changes gist provider name from "GitHub" to "Gist"
- in UI allows giving full gist url