### PR TITLE
Docs Improvement | Setup BinderHub

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -212,9 +212,13 @@ First, get the latest helm chart for BinderHub.::
 Next, **install the Helm Chart** using the configuration files
 that you've just created. Do this by running the following command::
 
-    helm install jupyterhub/binderhub --version=0.1.0-...  --name=<choose-name> --namespace=<choose-namespace> -f secret.yaml -f config.yaml
+    helm install jupyterhub/binderhub --version=0.2.0-3b53fce  --name=<choose-name> --namespace=<choose-namespace> -f secret.yaml -f config.yaml
 
-where ``...`` is the commit hash of the binderhub chart version you wish to deploy.
+This command will install the Helm chart released on March 3rd, 2019 as
+identified by the commit hash (the random string after `0.2.0-`). If you wish to
+install a different release, you only need to provide the commit hash for your
+desired release. A list of Chart versions and their commit hashes is available
+`here <https://jupyterhub.github.io/helm-chart/#development-releases-binderhub>`__.
 
 .. note::
 

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -215,9 +215,9 @@ that you've just created. Do this by running the following command::
     helm install jupyterhub/binderhub --version=0.2.0-3b53fce  --name=<choose-name> --namespace=<choose-namespace> -f secret.yaml -f config.yaml
 
 This command will install the Helm chart released on March 3rd, 2019 as
-identified by the commit hash (the random string after `0.2.0-`). If you wish to
-install a different release, you only need to provide the commit hash for your
-desired release. A list of Chart versions and their commit hashes is available
+identified by the commit hash (the random string after `0.2.0-`), which is
+provided as a working example. You should provide the commit hash for the most
+recent release, which can be found
 `here <https://jupyterhub.github.io/helm-chart/#development-releases-binderhub>`__.
 
 .. note::

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -255,6 +255,7 @@ JupyterHub. Now, add the following lines to ``config.yaml`` file::
 Next, upgrade the helm chart to deploy this change::
 
   helm upgrade <name-from-above> jupyterhub/binderhub --version=0.2.0-3b53fce  -f secret.yaml -f config.yaml
+
 For the first deployment of your BinderHub, the commit hash parsed to the
 `--version` argument should be the same as in step 3.4. However, when it comes
 to updating your BinderHub, you can parse the commit hash of a newer chart

--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -254,7 +254,11 @@ JupyterHub. Now, add the following lines to ``config.yaml`` file::
 
 Next, upgrade the helm chart to deploy this change::
 
-  helm upgrade <name-from-above> jupyterhub/binderhub --version=v0.1.0-...  -f secret.yaml -f config.yaml
+  helm upgrade <name-from-above> jupyterhub/binderhub --version=0.2.0-3b53fce  -f secret.yaml -f config.yaml
+For the first deployment of your BinderHub, the commit hash parsed to the
+`--version` argument should be the same as in step 3.4. However, when it comes
+to updating your BinderHub, you can parse the commit hash of a newer chart
+version.
 
 Try out your BinderHub Deployment
 ---------------------------------


### PR DESCRIPTION
This PR proposes some changes to the [Set up BinderHub](https://binderhub.readthedocs.io/en/latest/setup-binderhub.html) page of the Zero-to-BinderHub documentation and partially addresses issue #803 

Changes include:
* In step [3.4 Install BinderHub](https://binderhub.readthedocs.io/en/latest/setup-binderhub.html#install-binderhub):
  * Pass a specific commit hash to the `helm install` command via `--version` flag
  * Explain this is a working example and that users should find the commit hash for the most recent version when building their own BinderHub
* In step [3.5 Connect BinderHub and JupyterHub](https://binderhub.readthedocs.io/en/latest/setup-binderhub.html#connect-binderhub-and-jupyterhub):
  * For first deployment of a BinderHub, the commit hash parsed to the `helm upgrade` command via `--version` flag should match the one used in step 3.4
  * Explain that when updating the BinderHub, the commit hash for a newer chart version can be parsed