### PR TITLE
 pass allowed query parameters to spawner via user options

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -21,7 +21,7 @@ import tornado.options
 import tornado.log
 from tornado.log import app_log
 import tornado.web
-from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, default
+from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, default, Set
 from traitlets.config import Application
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 
@@ -402,6 +402,16 @@ class BinderHub(Application):
         config=True,
     )
 
+    query_parameter_names = Set(
+        trait=Unicode(),
+        default_value=set(),
+        help="""
+        List of allowed names. Before launch, BinderHub checks if they exist in the query and 
+        pass found ones with their value to spawner's user_options.
+        """,
+        config=True
+    )
+
     @staticmethod
     def add_url_prefix(prefix, handlers):
         """add a url prefix to handlers"""
@@ -512,7 +522,8 @@ class BinderHub(Application):
             'executor': self.executor,
             'auth_enabled': self.auth_enabled,
             'use_named_servers': self.use_named_servers,
-            'event_log': self.event_log
+            'event_log': self.event_log,
+            'query_parameter_names': self.query_parameter_names
         })
         if self.auth_enabled:
             self.tornado_settings['cookie_secret'] = os.urandom(32)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -470,6 +470,13 @@ class BuildHandler(BaseHandler):
         log("Launching pod for %s: %s other pods running this repo (%s total)",
             self.repo_url, matching_pods, total_pods)
 
+        # get query parameters
+        user_options = {}
+        for name in self.settings['query_parameter_names']:
+            value = self.get_query_argument(name, None)
+            if value is not None:
+                user_options[name] = value
+
         await self.emit({
             'phase': 'launching',
             'message': 'Launching server...\n',
@@ -494,7 +501,8 @@ class BuildHandler(BaseHandler):
                 server_name = ''
             try:
                 server_info = await launcher.launch(image=self.image_name, username=username,
-                                                    server_name=server_name, repo_url=self.repo_url)
+                                                    server_name=server_name, repo_url=self.repo_url,
+                                                    user_options=user_options)
                 LAUNCH_TIME.labels(
                     status='success', retries=i,
                 ).observe(time.perf_counter() - launch_starttime)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -472,10 +472,19 @@ class BuildHandler(BaseHandler):
 
         # get query parameters
         user_options = {}
+        options_message = []
         for name in self.settings['query_parameter_names']:
             value = self.get_query_argument(name, None)
             if value is not None:
                 user_options[name] = value
+                m = f"Passing option {name} with value {value} to spawner"
+                app_log.info(m)
+                options_message.append(m)
+        if options_message:
+            await self.emit({
+                'phase': 'launching',
+                'message': '\n'.join(options_message)+'\n',
+            })
 
         await self.emit({
             'phase': 'launching',

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -76,6 +76,7 @@ function updateRepoText() {
 
 function getBuildFormValues() {
   var providerPrefix = $('#provider_prefix').val().trim();
+  var userOptions = $('#user_options').val().trim();
   var repo = $('#repository').val().trim();
   if (providerPrefix !== 'git') {
     repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
@@ -92,7 +93,8 @@ function getBuildFormValues() {
   var ref = $('#ref').val().trim() || 'master';
   var path = $('#filepath').val().trim();
   return {'providerPrefix': providerPrefix, 'repo': repo,
-          'ref': ref, 'path': path, 'pathType': getPathType()}
+          'ref': ref, 'path': path, 'pathType': getPathType(),
+          'userOptions': userOptions}
 }
 
 function updateUrls(formValues) {
@@ -121,7 +123,7 @@ function updateUrls(formValues) {
   }
 }
 
-function build(providerSpec, log, path, pathType) {
+function build(providerSpec, log, path, pathType, userOptions) {
   update_favicon(BASE_URL + "favicon_building.ico");
   // split provider prefix off of providerSpec
   var spec = providerSpec.slice(providerSpec.indexOf('/') + 1);
@@ -139,7 +141,7 @@ function build(providerSpec, log, path, pathType) {
 
   $('.on-build').removeClass('hidden');
 
-  var image = new BinderImage(providerSpec);
+  var image = new BinderImage();
 
   image.onStateChange('*', function(oldState, newState, data) {
     if (data.message !== undefined) {
@@ -195,7 +197,8 @@ function build(providerSpec, log, path, pathType) {
     image.launch(data.url, data.token, path, pathType);
   });
 
-  image.fetch();
+  var apiUrl = BASE_URL + "build/" + providerSpec + userOptions;
+  image.fetch(apiUrl);
   return image;
 }
 
@@ -288,7 +291,8 @@ function indexMain() {
           formValues.providerPrefix + '/' + formValues.repo + '/' + formValues.ref,
           log,
           formValues.path,
-          formValues.pathType
+          formValues.pathType,
+          formValues.userOptions
         );
         return false;
     });
@@ -310,7 +314,8 @@ function loadingMain(providerSpec) {
       pathType = 'file';
     }
   }
-  build(providerSpec, log, path, pathType);
+  var userOptions = window.location.search;
+  build(providerSpec, log, path, pathType, userOptions);
   return false;
 }
 

--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -1,13 +1,9 @@
-var BASE_URL = $("#base-url").data().url;
-
-export default function BinderImage(providerSpec) {
-  this.providerSpec = providerSpec;
+export default function BinderImage() {
   this.callbacks = {};
   this.state = null;
 }
 
-BinderImage.prototype.fetch = function() {
-  var apiUrl = BASE_URL + "build/" + this.providerSpec;
+BinderImage.prototype.fetch = function(apiUrl) {
   this.eventSource = new EventSource(apiUrl);
   var that = this;
   this.eventSource.onerror = function(err) {

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -24,6 +24,7 @@
       <form id="build-form" class="form jumbotron">
         <h4 id="form-header" class='row'>Build and launch a repository</h4>
         <input type="hidden" id="provider_prefix" value="gh"/>
+        <input type="hidden" id="user_options" value=""/>
         <div class="form-group row">
           <label for="repository">GitHub repo or Gist name or GitLab.com URL</label>
           <div class="input-group">


### PR DESCRIPTION
Firstly, this pull request can wait until a naming scheme for query parameters is decided (https://github.com/jupyterhub/binderhub/issues/712). I just want to propose a way to pass query parameters from launch url through `user_options` to spawner.

This PR introduces a new config `query_parameter_names` which is to be filled with list of allowed query parameter names. With this PR launch url query is appended to build url (`/build/<prefix>/<spec>`). And BinderHub uses `query_parameter_names` before launch and checks if they exist in the build url query and passes found ones with their value to spawner's `user_options` (through JupyterHub's api). 

This PR doesn't do anything with spawner, so default `BinderSpawner` doesn't know how to interpret these new user options. But one can define `c.KubeSpawner.pre_spawn_hook` similar to  https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1178#issuecomment-469813124:

```yaml
hub:
  extraConfig:
    myExtraConfig: |
      async def my_pre_spawn_hook(spawner):
          value = spawner.user_options.get(<parameter_name>)
          # set a spawner setting according to value
          c.spawner.<any KubeSpawner (or Spawner) setting> = <any value>

      c.KubeSpawner.pre_spawn_hook = my_pre_spawn_hook
```

I also added an empty hidden input `user_options` into binder form. When user launches by using form, its value is appended to build url in javascript code. This might be useful when someone has customised binder form template.

When a naming scheme is decided, I can make an update to validate `query_parameter_names` config.