### PR TITLE
Support basic (htpasswd) authentication for registry

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -177,6 +177,10 @@ Second, you will need to instruct BinderHub about the token URL::
       DockerRegistry:
         token_url: "https://myregistry.io/v2/token?service="
 
+If you setup your own local registry using
+`native basic HTTP authentication <https://docs.docker.com/registry/deploying/#native-basic-auth>`__
+(htpasswd), you can set ``token_url`` to ``None``.
+
 .. note::
 
     There is one additional URL to set in the unlikely event that docker config.json


### PR DESCRIPTION
For small, local deployments, registries can use [basic authentication](https://docs.docker.com/registry/deploying/#native-basic-auth) which doesn't support tokens. This allows using such registries by just including the user/pass directly in the registry request, rather than doing an extra token step. Tested with a local kube cluster and registry.

It's enabled by just setting token_uri to None, but could also add an explicit/separate setting for this.