### PR TITLE
[WIP] possible solution to propagate informative spawn failure messages from spawner to bhub ui

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -12,7 +12,7 @@ import escapism
 import docker
 from tornado.concurrent import chain_future, Future
 from tornado import gen
-from tornado.web import Finish, authenticated
+from tornado.web import Finish, authenticated, HTTPError
 from tornado.queues import Queue
 from tornado.iostream import StreamClosedError
 from tornado.ioloop import IOLoop
@@ -518,8 +518,8 @@ class BuildHandler(BaseHandler):
                         status=status, **self.repo_metric_labels,
                     ).inc()
 
-                if i + 1 == launcher.retries:
-                    # last attempt failed, let it raise
+                if i + 1 == launcher.retries or (isinstance(e, HTTPError) and e.status_code == 409):
+                    # last attempt failed or 409 client error, let it raise
                     raise
 
                 # not the last attempt, try again

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -62,7 +62,10 @@ jupyterhub:
   rbac:
     enabled: true
   hub:
+    consecutiveFailureLimit: 0
     extraConfig:
+      hub: |
+        c.JupyterHub.tornado_settings['slow_spawn_timeout']= 10
       binder: |
         import os
         import sys


### PR DESCRIPTION
First of all I need help here :) I don't fully understand what is happening (specially on JupyterHub side) but here is what I understand so far:

1. `slow_spawn_timeout` setting is by default 0:
 - Code: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/8ed2f8111b5575dc5df29afb114a8ee5906f9a96/images/hub/jupyterhub_config.py#L30-L32
- PR: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/884
2. This means any kind of failure during spawn is caught by jhub as `TimeoutError` and jhub always raises 500 error (even maybe spawner sends 409 error): https://github.com/jupyterhub/jupyterhub/blob/e89836c035f79a44cb5ebc1126e53c6f605464c1/jupyterhub/handlers/base.py#L887-L924
3. BinderHub catches this 500 error of API request and  retries same API request 4 more times: https://github.com/jupyterhub/binderhub/blob/1835d07222388da2a23765899cd006e6f6462827/binderhub/launcher.py#L75-L84
4. After retrying, launch fails with https://github.com/jupyterhub/binderhub/blob/1835d07222388da2a23765899cd006e6f6462827/binderhub/launcher.py#L197
5. Then BinderHub retries launch process (in total 3 times by default)
6. In total BinderHub makes 12 API requests and then user gets the standard error ("Failed to launch image ...") on the UI. During these 12 requests, hub restarts 2 times because `consecutive_failure_limit` is by default 5 (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/8ed2f8111b5575dc5df29afb114a8ee5906f9a96/jupyterhub/values.yaml#L17)

The same process happens regardless of type of error from spawner. In this PR to solve this issue,  `slow_spawn_timeout` is set to 10 seconds (default value), so BinderHub gets actual error from spawner. I also set `consecutiveFailureLimit` to 0, so hub doesn't restart after informative failures of spawner. But this is actually not good, because hub also ignores real errors that it has to restart to get rid of them.

I updated build and launch code too. So now it propagates 409 error messages from JupyterHub API to UI and doesn't retry to launch. And as I wrote before I need help here, this part can be wrong or missing. So I don't mind if we totally changed it.

related to https://github.com/jupyterhub/binderhub/issues/712 and  https://github.com/jupyterhub/binderhub/pull/805