### PR TITLE
[MRG] Generate coverage while running tests

### DIFF
--- a/ci/test-helm
+++ b/ci/test-helm
@@ -81,5 +81,5 @@ mark="remote"
 if [[ -z "$GITHUB_ACCESS_TOKEN" ]]; then
   mark="$mark and not github_api"
 fi
-pytest -vsx -m "$mark"
+pytest -vsx -m "$mark" --log-cli-level=10 --cov binderhub
 helm delete --purge binder-test


### PR DESCRIPTION
I found this inconsistency between how we run our tests while investigating why codecov doesn't show me which lines have coverage and which don't.

I was expecting https://codecov.io/gh/jupyterhub/binderhub/src/master/binderhub/build.py to show me which lines are covered. We seem to be computing some kind of coverage number because for the whole file it knows, but for some reason it doesn't show which lines are missing. If you look at code from (say) repo2docker https://codecov.io/gh/jupyter/repo2docker/src/master/repo2docker/app.py you see the green blobs in front of lines that are covered as well as background shading.