### PR TITLE
[MRG] Update the contributer guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,140 @@
-# Contributing
+# Contributing to BinderHub
 
-Welcome! As a [Jupyter](https://jupyter.org) project, we follow the [Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+Welcome! As a [Jupyter](https://jupyter.org) project, we follow the
+[Jupyter contributor guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
 
-To develop binderhub, you can use a local installation of JupyterHub on minikube,
-and run binderhub on the host system.  Note that you will quickly hit your API limit
-on GitHub if you don't have a token.
+There are several different setups for developing BinderHub, depending on which
+parts of it you want to change: the [documentation](#documentation-changes),
+the [user interface](#user-innterface-changes), or the
+[kubernetes integration](#Kubernetes-integration-changes).
 
-## Installation
+
+## Documentation changes
+
+Work on the documentation requires the least amount of setup.  You will need
+to have a modern version of [Python](https://www.python.org/).
+
+1. Clone the BinderHub repository to your local computer and ```cd``` into it.
+   ```bash
+   git clone https://github.com/jupyterhub/binderhub
+   cd binderhub
+   ```
+1. 1. Install BinderHub and the documentation tools:
+
+   ```bash
+   python3 -m pip install -r doc/doc-requirements.txt
+   ```
+
+1. The documentation is located in the `doc/` sub-directory, `cd` into it:
+
+   ```bash
+   cd ./doc
+   ```
+
+1. To build the documentation run:
+
+   ```bash
+   make html
+   ```
+
+1. Open the main documentation page in your browser, it is located at
+   `_build/html/index.html`. On a Mac you can open it directly from the
+   terminal with `open _build/html/index.html`.
+
+
+## User interface changes
+
+Work on the user interface requires a medium amount of setup. You will need
+to have a modern version of [Python](https://www.python.org/) and
+[npm](https://www.npmjs.com) installed.
+
+1. Clone the BinderHub repository to your local computer and ```cd``` into it.
+   ```bash
+   git clone https://github.com/jupyterhub/binderhub
+   cd binderhub
+   ```
+
+1. Install BinderHub:
+
+   ```bash
+   python3 -m pip install -e .
+   ```
+
+1. Install the JavaScript dependencies:
+
+   ```bash
+   npm install
+   ```
+
+1. Create the JS and CSS bundles with:
+
+   ```bash
+   npm run webpack
+   ```
+  Note: you need to run this every time you make a change to the CSS or JS
+  for it to take effect.
+
+1. Run it!
+
+   ```bash
+   python3 -m binderhub -f testing/localonly/binderhub_config.py
+   ```
+
+1. Visit http://localhost:8585 to see it in action.
+
+Building and launching repositories will not work. You can still work on the
+user interface of those parts as BinderHub is configured to fake those
+actions. You can tell you are using the fake builder and launcher from the fact
+that the build will never complete.
+
+To learn how to set yourself with a BinderHub development environment that
+lets you modify the builder and launcher refer to
+[Kubernetes integration changes](#Kubernetes-integration-changes).
+
+
+## Kubernetes integration changes
+
+Setting yourself up to make changes to the kubernetes integration of BinderHub
+requires a few one-time setup steps. These steps are described in the
+"One-time installation" section below. Follow those first then return here for
+day to day development procedures.
+
+
+### Day to day development tasks
+
+To execute our test suite you need a running minikube cluster. It does not
+need to have anything installed on it:
+
+```bash
+minikube start
+pytest -svx -m "not auth_test"
+```
+
+The tests should generate familiar pytest like output and complete in a few
+seconds.
+
+To execute all the main tests use `./ci/test-main` which will setup a
+JupyterHub on minikube for you. These tests will generate a lot of output and
+take a few minutes to run. The tests will attempt to clean up after themselves
+on your minikube cluster.
+
+To execute the tests related to authentication use `./ci/test-auth` which will
+setup a JupyterHub on minikube for you and use configuration files to configure
+your BinderHub to require authentication. These tests will generate a lot of
+output and take a few minutes to run. The tests will attempt to clean up after
+themselves on your minikube cluster.
+
+
+### One-time installation
+
+To run the full BinderHub it needs to have access to a kubernetes cluster
+with a JupyterHub installed on it. This is what we will setup in this section.
 
 Before you begin, there are a few utilities that need to be installed:
 ```bash
 sudo apt install python3 python3-pip npm curl
 ```
-You will need docker installed from https://docs.docker.com/install/ to run JupyterHub.
+
 If you a on linux, you may additionally need to install socat for port forwarding:
 
 ```bash
@@ -25,27 +147,33 @@ sudo apt install socat
    cd binderhub
    ```
 
-1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) to run Kubernetes locally.
+1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
+   to run Kubernetes locally.
 
-   For MacOS, you may find installing from https://github.com/kubernetes/minikube/releases may be
-   more stable than using Homebrew.
+   For MacOS, you may find installing from https://github.com/kubernetes/minikube/releases
+   may be more stable than using Homebrew.
 
-   To start your cluster on minikube, run the command: `minikube start`, this starts a local kubernetes cluster using VM. This command assumes that you have already installed one of the VM drivers: virtualbox/xhyve/KVM2.
+   To start your minikube cluster , run the command: `minikube start`. This
+   starts a local kubernetes cluster inside a virtual machine. This command
+   assumes that you have already installed one of the VM drivers: virtualbox,
+   xhyve or KVM2.
 
-1. Install helm to manage installing and running binderhub on your cluster,
+1. Install helm to manage installing JupyterHub and BinderHub on your cluster,
 
    ```bash
    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
    ```
 
-   [Alternative methods](https://docs.helm.sh/using_helm/#installing-the-helm-client) for helm installation
-   exist if you prefer installing without using the script.
+   [Alternative methods](https://docs.helm.sh/using_helm/#installing-the-helm-client)
+   for helm installation exist if you prefer installing without using the script.
 
-1. Initialize helm in minikube. This command initializes the local CLI and installs Tiller on your kubernetes cluster in one step:
+1. Initialize helm in minikube. This command initializes the local CLI and
+   installs Tiller on your kubernetes cluster in one step:
 
    ```bash
    helm init
    ```
+
 1. Add the JupyterHub helm charts repo:
 
    ```bash
@@ -53,13 +181,11 @@ sudo apt install socat
    helm repo update
    ```
 
-1. Install binderhub and its development requirements:
+1. Install BinderHub and its development requirements:
 
     ```bash
     python3 -m pip install -e . -r dev-requirements.txt
     ```
-
-    This list of packages is necessary to create an environment that will generate the Docker image using the Git repository. Regardless of what is in the setup.py file, the requirements file will install what the user needs to build the Docker image.
 
 1. Install JupyterHub in minikube with helm
 
@@ -67,20 +193,22 @@ sudo apt install socat
    ./testing/minikube/install-hub
    ```
 
-1. Before starting the local dev/test deployment run:
+1. Before starting your local deployment run:
 
    ```bash
    eval $(minikube docker-env)
    ```
 
-    This command sets up docker to use the same docker daemon as your minikube cluster does. This means images you build are directly available to the cluster.
-    Note: when you no longer wish to use the minikube host, you can undo this change by running:
+  This command sets up docker to use the same docker daemon as your minikube
+  cluster does. This means images you build are directly available to the
+  cluster. Note: when you no longer wish to use the minikube host, you can
+  undo this change by running:
 
    ```bash
    eval $(minikube docker-env -u)
    ```
 
-1. Start binderhub with the testing config file:
+1. Start BinderHub with the testing config file:
 
     ```bash
     python3 -m binderhub -f testing/minikube/binderhub_config.py
@@ -88,68 +216,23 @@ sudo apt install socat
 
 1. Visit [http://localhost:8585](http://localhost:8585)
 
-All features should work, including building and launching.
+All features should work, including building and launching of repositories.
 
-### Debugging tips
 
-There is an option to configure the disk size of the minikube VM on start using the flag `minikube start --disk-size string` the default value is "20g".
-
-If you get a Disk Available error you can run `minikube delete` and then reinstall binderhub following the installation guide above.
-
-## Increase your GitHub API limit
+### Tip: Increase your GitHub API limit
 
 By default, GitHub has a limit of 60 API requests per hour. We recommend
 using a GitHub API token before running tests
 in order to avoid hitting your API limit. Steps to do so are outlined in
 the [BinderHub documentation](https://binderhub.readthedocs.io/en/latest/setup-binderhub.html#increase-your-github-api-limit).
 
-## Testing
 
-To run unit tests, navigate to the root of the repository, then call:
+## Common maintainer tasks
 
-   ```bash
-   pytest
-   ```
-
-We recommend increasing your GitHub API rate limit before running tests (see above).
-
-## Building JS and CSS
-
-We use [npm](https://www.npmjs.com) for managing our JS / CSS dependencies and
-[webpack](https://webpack.js.org/) for bundling them together. You need to have
-a recent version of `npm` installed to run things locally.
-
-1. Run `npm install`. This should fetch and install all our frontend dependencies.
-2. Run `npm run webpack`. This runs webpack and creates our JS / CSS bundles. You
-   *need* to run this every time you make CSS / JS changes to see them live. Alternatively,
-   you can run `npm run webpack:watch` to automatically rebuild JS / CSS changes as
-   you make them.
-
-## Pure HTML / CSS / JS development
-
-If you do not want to set up minikube but just want to hack on the html / css / js,
-there is a simpler method!
-
-1. Install binderhub:
-
-   ```bash
-   python3 -m pip install -e .
-   ```
-
-1. Run it!
-
-   ```bash
-   python3 -m binderhub -f testing/localonly/binderhub_config.py
-   ```
-
-1. You can now access it locally at http://localhost:8585
-
-Note that building and launching will not work, but the
-`testing/localonly/binderhub_config.py` setup a fake building process which
-allows you to work on the UI experience.
+These are tasks that BinderHub maintainers perform.
 
 
-## Bumping the JupyterHub Helm Chart version
+### Bumping the JupyterHub Helm Chart version
 
 BinderHub uses the [JupyterHub Helm Chart](https://jupyterhub.github.io/helm-chart/)
 to install the proper version of JupyterHub. The version that is used is specified
@@ -170,13 +253,12 @@ structure of particular fields). Make sure that none of these changes have been
 introduced, particularly when bumping major versions of JupyterHub.
 
 
-## Releasing
+### Releasing
 
 Checklist for creating BinderHub releases. For PyPI packaging read https://packaging.python.org/guides/distributing-packages-using-setuptools/#uploading-your-project-to-pypi
 
-* remove the `dev` suffix in `binderhub/_version.py`
 * update/close the `CHANGES.rst` for this release
-* add a new section at the top of the change log for future releases
+* create a git tag for the release
 * `pip install twine`
 * `python setup.py sdist`
 * `python setup.py bdist_wheel`
@@ -184,4 +266,4 @@ Checklist for creating BinderHub releases. For PyPI packaging read https://packa
 * edit `$HOME/.pypirc` to use the binder team account
 * `twine upload dist/*`
 * create a new release on https://github.com/jupyterhub/binderhub/releases
-* bump the version in `_version.py` from `0.n.y` to `0.(n+1).0dev`
+* add a new section at the top of the change log for future releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ the [user interface](#user-innterface-changes), or the
 
 ## Documentation changes
 
-Work on the documentation requires the least amount of setup.  You will need
-to have a modern version of [Python](https://www.python.org/).
+Work on the documentation requires the least amount of setup. You will need
+to have a modern version of [Python](https://www.python.org/). The documentation
+uses the [reStructuredText markup language](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
 
 1. Clone the BinderHub repository to your local computer and ```cd``` into it.
    ```bash
@@ -138,6 +139,9 @@ themselves on your minikube cluster.
 
 To run the full BinderHub it needs to have access to a kubernetes cluster
 with a JupyterHub installed on it. This is what we will setup in this section.
+All the steps are given as command-line commands for Ubuntu systems. They are
+used as a common denominator that can be translated into the correct commands
+on your local system.
 
 Before you begin, there are a few utilities that need to be installed:
 ```bash
@@ -158,9 +162,6 @@ sudo apt install socat
 
 1. [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/)
    to run Kubernetes locally.
-
-   For MacOS, you may find installing from https://github.com/kubernetes/minikube/releases
-   may be more stable than using Homebrew.
 
    To start your minikube cluster , run the command: `minikube start`. This
    starts a local kubernetes cluster inside a virtual machine. This command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,17 @@ day to day development procedures.
 
 ### Day to day development tasks
 
-To execute our test suite you need a running minikube cluster. It does not
-need to have anything installed on it:
+After having setup minikube and helm once, these are the tasks you need for
+every day development.
+
+* Start and stop minikube with `minikube start` and `minikube stop`.
+* Install JupyterHub in minikube with helm `./testing/minikube/install-hub`
+* Setup docker to use the same docker daemon as your minikube cluster `eval $(minikube docker-env)`
+* Start BinderHub `python3 -m binderhub -f testing/minikube/binderhub_config.py`
+* Visit your BinderHub at[http://localhost:8585](http://localhost:8585)
+
+To execute most of our test suite you need a running minikube cluster.
+It does not need to have anything installed on it though:
 
 ```bash
 minikube start

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@
 What is BinderHub?
 ------------------
 
-**BinderHub** allows you to ``BUILD`` and ``REGISTER`` a Docker image using a
-GitHub repository, then ``CONNECT`` with JupyterHub, allowing you to create a
+**BinderHub** allows you to ``BUILD`` and ``REGISTER`` a Docker image from a
+Git repository, then ``CONNECT`` with JupyterHub, allowing you to create a
 public IP address that allows users to interact with the code and environment
 within a live JupyterHub instance. You can select a specific branch name,
 commit, or tag to serve.
@@ -43,8 +43,41 @@ BinderHub ties together:
 - `Repo2Docker <https://github.com/jupyter/repo2docker>`_ which generates
   a Docker image using a Git repository hosted online.
 
-BinderHub is created using Python, kubernetes, tornado, and traitlets. As such,
-it should be a familiar technical foundation for Jupyter developers.
+BinderHub is built with Python, kubernetes, tornado, npm, webpack, and sphinx.
+
+
+Documentation
+-------------
+
+For more information about the architecture, use, and setup of BinderHub, see
+`the BinderHub documentation <https://binderhub.readthedocs.io>`_.
+
+
+Contributing
+------------
+
+To contribute to the BinderHub project you can work on:
+
+* `answering questions others have <https://discourse.jupyter.org/>`_,
+* writing documentation,
+* designing the user interface, or
+* writing code.
+
+To see how to build the documentation, edit the user interface or modify the
+code see `the contribution guide <https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md>`_.
+
+
+Installation
+------------
+
+**BinderHub** is based on Python 3, it's currently only hosted on GitHub
+(pip release soon). However, it can be installed using ``pip``::
+
+    pip install git+https://github.com/jupyterhub/binderhub
+
+See `the BinderHub documentation <https://binderhub.readthedocs.io>`_ for
+a detailed guide on setting up your own BinderHub server.
+
 
 Why BinderHub?
 --------------
@@ -52,6 +85,7 @@ Why BinderHub?
 Collections of Jupyter notebooks are becoming more common in scientific research
 and data science. The ability to serve these collections on demand enhances the
 usefulness of these notebooks.
+
 
 Who is BinderHub for?
 ---------------------
@@ -62,25 +96,6 @@ Who is BinderHub for?
 * **Deployers** who want to create their own BinderHub to run on whatever
   hardware they choose.
 
-Installation
-------------
-
-**BinderHub** is based on Python 3, it's currently only hosted on GitHub (pip release soon).
-However, it can be installed using ``pip``::
-
-    pip install git+https://github.com/jupyterhub/binderhub
-    
-See `the BinderHub documentation <https://binderhub.readthedocs.io>`_ for a detailed guide on setting
-up your own BinderHub server.
-
-**Local development**: To run BinderHub locally in order to make contributions to the codebase,
-see `the contribution guide <https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md>`_.
-
-Documentation
--------------
-
-For more information about the architecture, use, and setup of BinderHub, see
-`the BinderHub documentation <https://binderhub.readthedocs.io>`_.
 
 License
 -------


### PR DESCRIPTION
This changes the contributer documentation around a bit. I was coming back to the project after a bit away wanting to use the contributor guide to quickly figure out how to run tests and got lost.

I think this way of organising them also makes it less intimidating to get started because the first thing isn't "now you need to install minikube and helm". A lot of work can be done without ever touching all that stuff.

It also gets less and less verbose as we progress down the rabbit hole. The assumption is that if you aren't scared of installing minikube and helm you have worked out how to clone a git repository (or can do so). This fixes a pet peeve of mine that a lot of guides are so verbose that you can't find anything if you are using them as a reference. Maybe the solution is to have a guide/howto as part of the documentation and a reference in `CONTRIBUTING.md`.