### PR TITLE
[MRG] Stop always pulling the repo2docker image

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -183,7 +183,6 @@ class Build:
                         image=self.build_image,
                         name="builder",
                         args=self.get_cmd(),
-                        image_pull_policy='IfNotPresent',
                         volume_mounts=volume_mounts,
                         resources=client.V1ResourceRequirements(
                             limits={'memory': self.memory_limit},

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -183,7 +183,7 @@ class Build:
                         image=self.build_image,
                         name="builder",
                         args=self.get_cmd(),
-                        image_pull_policy='Always',
+                        image_pull_policy='IfNotPresent',
                         volume_mounts=volume_mounts,
                         resources=client.V1ResourceRequirements(
                             limits={'memory': self.memory_limit},


### PR DESCRIPTION
It seems unnecessary to always pull the repo2docker image when a build starts. We never change the image for a given tag, so this ends up taking time at the start of the build with no benefit.

In a recent build it took 3minutes to pull the repo2docker image:
```
  Normal  Pulling    5m    kubelet, gke-prod-a-user-1dot11dot7-ce79d2b9-3hl2  pulling image "jupyter/repo2docker:746e4d92"
  Normal  Pulled     2m    kubelet, gke-prod-a-user-1dot11dot7-ce79d2b9-3hl2  Successfully pulled image "jupyter/repo2docker:746e4d92"
```

However maybe there is a subtle reason why we should be doing this?

From looking at the [history of the code](https://github.com/jupyterhub/binderhub/commit/a06b11c7a13d9c8514bd71e80d954fe88a19932b) I think this was done for debugging reasons. Which means we can merge this and see what happens.