### PR TITLE
Removing note about breaking changes

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,9 +10,6 @@ BinderHub
    :alt: Join our community Discourse page at https://discourse.jupyter.org
    :target: https://discourse.jupyter.org/c/binder/binderhub
 
-.. note::
-
-   BinderHub is under active development and subject to breaking changes.
 
 Getting started
 ===============


### PR DESCRIPTION
Since we've now advertised BinderHub as stable + ready for production, shall we remove this message about breaking changes etc?