### PR TITLE
Revert "Update to Docs: Clarify where in secret.yaml GitHub Personal Access Token should be added"

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -306,10 +306,9 @@ an API access token to raise your API limit to 5000 requests an hour.
 
 3. Update ``secret.yaml`` by entering the following::
 
-    jupyterhub:
-      config:
-        GitHubRepoProvider:
-          access_token: <insert_token_value_here>
+    config:
+      GitHubRepoProvider:
+        access_token: <insert_token_value_here>
 
 This value will be loaded into `GITHUB_ACCESS_TOKEN` environment variable and
 BinderHub will automatically use the token stored in this variable when making


### PR DESCRIPTION
Reverts jupyterhub/binderhub#835