### PR TITLE
add default toleration to build pods

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -192,6 +192,22 @@ class Build:
                         env=env
                     )
                 ],
+                tolerations=[
+                    client.V1Toleration(
+                        key='hub.jupyter.org/dedicated',
+                        operator='Equal',
+                        value='user',
+                        effect='NoSchedule',
+                    ),
+                    # GKE currently does not permit creating taints on a node pool
+                    # with a `/` in the key field
+                    client.V1Toleration(
+                        key='hub.jupyter.org_dedicated',
+                        operator='Equal',
+                        value='user',
+                        effect='NoSchedule',
+                    ),
+                ],
                 node_selector=self.node_selector,
                 volumes=volumes,
                 restart_policy="Never",


### PR DESCRIPTION
This implements a minimally invasive addition to the build pod spec, adding a default tolerations to build pods that match [zero2jupyterhub](https://zero-to-jupyterhub.readthedocs.io/en/latest/optimization.html?highlight=taint#using-a-dedicated-node-pool-for-users).

```
hub.jupyter.org/dedicated=user:NoSchedule
```

cc @consideRatio 

closes #851