### PR TITLE
add user tolerations to dind daemonset

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -9,6 +9,15 @@ spec:
   selector:
     matchLabels:
       name:  {{ .Release.Name }}-dind
+  tolerations:
+    - effect: NoSchedule
+      key: hub.jupyter.org/dedicated
+      operator: Equal
+      value: user
+    - effect: NoSchedule
+      key: hub.jupyter.org_dedicated
+      operator: Equal
+      value: user
   template:
     metadata:
       labels:


### PR DESCRIPTION
this is a followup to #853. We need to allow the dind daemonset to run on user pods as well.