### PR TITLE
fix tolerations in dind daemonset and add tolerations to image-cleaner

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -9,15 +9,6 @@ spec:
   selector:
     matchLabels:
       name:  {{ .Release.Name }}-dind
-  tolerations:
-    - effect: NoSchedule
-      key: hub.jupyter.org/dedicated
-      operator: Equal
-      value: user
-    - effect: NoSchedule
-      key: hub.jupyter.org_dedicated
-      operator: Equal
-      value: user
   template:
     metadata:
       labels:
@@ -27,6 +18,15 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      tolerations:
+      - effect: NoSchedule
+        key: hub.jupyter.org/dedicated
+        operator: Equal
+        value: user
+      - effect: NoSchedule
+        key: hub.jupyter.org_dedicated
+        operator: Equal
+        value: user
       nodeSelector: {{ (default (dict) .Values.config.BinderHub.build_node_selector) | toJson  }}
       {{ if .Values.dind.initContainers -}}
       initContainers:

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -19,6 +19,15 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      tolerations:
+      - effect: NoSchedule
+        key: hub.jupyter.org/dedicated
+        operator: Equal
+        value: user
+      - effect: NoSchedule
+        key: hub.jupyter.org_dedicated
+        operator: Equal
+        value: user
       nodeSelector: {{ toJson .Values.config.BinderHub.build_node_selector  }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}-image-cleaner


### PR DESCRIPTION
follow up number 2 to #853, see also #856. 

As noted in https://github.com/pangeo-data/pangeo-binder/pull/56, I think there was error in my previous PR where I put the tolerations section under the wrong spec key. Hopefully this fixes things.

This PR also adds equivalent tolerations to the image cleaner.