### PR TITLE
[MRG] Tweak loading messages

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -130,10 +130,10 @@ function build(providerSpec, log, path, pathType) {
 
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
-    $('div#loader-text p').text("Loading repository (can take 30s or more to load): " + spec);
+    $('div#loader-text p').text("Starting repository: " + spec);
     window.setTimeout(function() {
-      $('div#loader-text p').html("Repository " + spec + " is taking longer than usual to load, hang tight!")
-    }, 120000);
+      $('div#loader-text p').html("Repository " + spec + " is taking longer than usual to start, hang tight!")
+    }, 17000);
   }
 
   $('#build-progress .progress-bar').addClass('hidden');


### PR DESCRIPTION
Instead of always saying "30s or longer" I think it is better to have a "starting" and "taking longer than usual" message. The change here is to show the "longer than usual" message earlier. I chose the cutoff at 17s because the [median launch time](https://grafana.mybinder.org/d/3SpLQinmk/1-overview?refresh=1m&panelId=28&fullscreen&orgId=1) is around 15s. 90% of launches complete in under a minute and 99% in around 4minutes. Maybe we can use these stats to build a "progress bar" for launches.