### PR TITLE
[MRG] Make the URL used to generate launch badges configurable

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -123,12 +123,23 @@ class BinderHub(Application):
         '/',
         help="The base URL of the entire application",
         config=True)
-
     @validate('base_url')
     def _valid_base_url(self, proposal):
         if not proposal.value.startswith('/'):
             proposal.value = '/' + proposal.value
         if not proposal.value.endswith('/'):
+            proposal.value = proposal.value + '/'
+        return proposal.value
+
+    badge_base_url = Unicode(
+        '',
+        help="Base URL to use when generating launch badges",
+        config=True
+    )
+    @validate('badge_base_url')
+    def _valid_badge_base_url(self, proposal):
+        # add a trailing slash only when a value is set
+        if proposal.value and not proposal.value.endswith('/'):
             proposal.value = proposal.value + '/'
         return proposal.value
 
@@ -506,6 +517,7 @@ class BinderHub(Application):
             'build_memory_limit': self.build_memory_limit,
             'build_docker_host': self.build_docker_host,
             'base_url': self.base_url,
+            'badge_base_url': self.badge_base_url,
             "static_path": os.path.join(HERE, "static"),
             'static_url_prefix': url_path_join(self.base_url, 'static/'),
             'template_variables': self.template_variables,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -15,6 +15,7 @@ class MainHandler(BaseHandler):
     def get(self):
         self.render_template(
             "index.html",
+            badge_base_url=self.settings['badge_base_url'],
             base_url=self.settings['base_url'],
             submit=False,
             google_analytics_code=self.settings['google_analytics_code'],

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -29,6 +29,7 @@ import '../index.css';
 import {fit} from './vendor/xterm/addons/fit';
 
 var BASE_URL = $('#base-url').data().url;
+var BADGE_BASE_URL = $('#badge-base-url').data().url;
 
 function update_favicon(path) {
     var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
@@ -44,7 +45,12 @@ function v2url(providerPrefix, repository, ref, path, pathType) {
     // no repo, no url
     return null;
   }
-  var url = window.location.origin + BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
+  if (BADGE_BASE_URL) {
+    var url = BADGE_BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
+  }
+  else {
+    var url = window.location.origin + BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
+  }
   if (path && path.length > 0) {
     // encode the path, it will be decoded in loadingMain
     url = url + '?' + pathType + 'path=' + encodeURIComponent(path);

--- a/binderhub/static/js/src/badge.js
+++ b/binderhub/static/js/src/badge.js
@@ -1,5 +1,12 @@
 var BASE_URL = $("#base-url").data().url;
-var BADGE_URL = window.location.origin + BASE_URL + "badge_logo.svg";
+var BADGE_BASE_URL = $('#badge-base-url').data().url;
+
+if (BADGE_BASE_URL) {
+  var BADGE_URL = BADGE_BASE_URL + "badge_logo.svg";
+}
+else {
+  var BADGE_URL = window.location.origin + BASE_URL + "badge_logo.svg";
+}
 
 export function markdownBadge(url) {
   // return markdown badge snippet

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -2,6 +2,7 @@
 
 {% block head %}
 <meta id="base-url" data-url="{{base_url}}">
+<meta id="badge-base-url" data-url="{{badge_base_url}}">
 <script src="{{static_url("dist/bundle.js")}}"></script>
 {{ super() }}
 {% endblock head %}


### PR DESCRIPTION
This lets you set the base URL used for generating badges. This is useful when you have a group of hubs at different hostnames but want badges generated on all of them to point to a common hostname. I think we should use this for operating the GKE and OVH cluster as a federation so that all clusters generate https://mybinder.org/ badges and launch URLs.