### PR TITLE
[MRG] rename variable and restructure API docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,27 +8,31 @@ There's one API endpoint, which is:
 
 ::
 
-    /build/<provider>/<spec>
+    /build/<provider_prefix>/<spec>
 
 Even though it says **build** it is actually performs **launch**.
 
-Provider
---------
+**provider_prefix** identifies the provider.
+**spec** is defines the source of the computing environment to be built and 
+served using the given provider.
+See :ref:`providers-section` for supported inputs.
 
-Provider is a supported provider, and **spec** is the specification for
-the given provider.
+.. _providers-section:
 
-Currently supported providers and their specs are:
+Providers
+---------
 
-+------------+-----------+-------------------------------------------------------------+----------------------------+
-| Provider   | prefix    | spec                                                        | notes                      |
-+============+===========+=============================================================+============================+
-| GitHub     | ``gh``    | ``<user>/<repo>/<commit-sha-or-tag-or-branch>``             |                            |
-+------------+-----------+-------------------------------------------------------------+----------------------------+
-| Git        | ``git``   | ``<url-escaped-url>/<commit-sha>``                          | arbitrary HTTP git repos   |
-+------------+-----------+-------------------------------------------------------------+----------------------------+
-| GitLab     | ``gl``    | ``<url-escaped-namespace>/<commit-sha-or-tag-or-branch>``   |                            |
-+------------+-----------+-------------------------------------------------------------+----------------------------+
+Currently supported providers and their prefixes and specs are:
+
++------------+--------------------+-------------------------------------------------------------+----------------------------+
+| Provider   | provider_prefix    | spec                                                        | notes                      |
++============+====================+=============================================================+============================+
+| GitHub     | ``gh``             | ``<user>/<repo>/<commit-sha-or-tag-or-branch>``             |                            |
++------------+--------------------+-------------------------------------------------------------+----------------------------+
+| Git        | ``git``            | ``<url-escaped-url>/<commit-sha>``                          | arbitrary HTTP git repos   |
++------------+--------------------+-------------------------------------------------------------+----------------------------+
+| GitLab     | ``gl``             | ``<url-escaped-namespace>/<commit-sha-or-tag-or-branch>``   |                            |
++------------+--------------------+-------------------------------------------------------------+----------------------------+
 
 Next, construct an appropriate URL and send a request.
 
@@ -125,7 +129,7 @@ Launching
 
 When the repo has been built, and we're in the process of waiting for
 the hub to launch. This could end up succeeding and emitting a 'ready'
-event or failing and emitting a 'failure' event.
+event or failing and emitting a 'failed' event.
 
 ::
 
@@ -137,7 +141,7 @@ Ready
 When your notebook is ready! You get a endpoint URL and a token used to
 access it. You can access the notebook / API by using the token in one
 of the ways the `notebook accepts security
-tokens <http://jupyter-notebook.readthedocs.io/en/stable/security.html>`__
+tokens <http://jupyter-notebook.readthedocs.io/en/stable/security.html>`__.
 
 ::
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -32,6 +32,8 @@ Currently supported providers, their prefixes and specs are:
 | Git        | ``git``            | ``<url-escaped-url>/<commit-sha>``                          | arbitrary HTTP git repos   |
 +------------+--------------------+-------------------------------------------------------------+----------------------------+
 | GitLab     | ``gl``             | ``<url-escaped-namespace>/<commit-sha-or-tag-or-branch>``   |                            |
++------------+--------------------+-------------------------------------------------------------+----------------------------+ 
+| Gist       | ``gist``           | ``<github-username>/<gist-id><commit-sha-or-tag>``          |                            |
 +------------+--------------------+-------------------------------------------------------------+----------------------------+
 
 Next, construct an appropriate URL and send a request.

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -10,10 +10,10 @@ There's one API endpoint, which is:
 
     /build/<provider_prefix>/<spec>
 
-Even though it says **build** it is actually performs **launch**.
+Even though it says **build** it actually performs **launch**.
 
 **provider_prefix** identifies the provider.
-**spec** is defines the source of the computing environment to be built and 
+**spec** defines the source of the computing environment to be built and 
 served using the given provider.
 See :ref:`providers-section` for supported inputs.
 
@@ -22,7 +22,7 @@ See :ref:`providers-section` for supported inputs.
 Providers
 ---------
 
-Currently supported providers and their prefixes and specs are:
+Currently supported providers, their prefixes and specs are:
 
 +------------+--------------------+-------------------------------------------------------------+----------------------------+
 | Provider   | provider_prefix    | spec                                                        | notes                      |


### PR DESCRIPTION
Looking at the code and the docs at the same time, I was a bit confused by the API endpoint description. Here is a suggestion for a different structure and wording.

The name `provider_prefix` now also matches the respective parameter name in the API function in the code.

Let me know what you think!