### PR TITLE
Adding a simple age checker for a BinderHub

### DIFF
--- a/doc/age-checker.rst
+++ b/doc/age-checker.rst
@@ -1,0 +1,90 @@
+============================
+Check the age of a BinderHub
+============================
+
+There are several core pieces of technology behind a BinderHub. This page
+provides a quick interface to check how up-to-date each of them is.
+
+**Check the age of a BinderHub with the form below**
+
+.. raw:: html
+
+   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css" integrity="sha384-nn4HPE8lTHyVtfCBi5yW9d20FjT8BJwUXyWZT9InLYax14RDjBj46LmSztkmNP9w" crossorigin="anonymous">
+   <style>
+   input#checkAgeButton {
+    font-size: 1rem;
+    line-height: 1.5;
+    background-color: #477dca;
+    border-radius: 3px;
+    border: none;
+    color: white;
+    display: inline-block;
+    font-weight: 700;
+    padding: 6px 18px;
+    margin-top: 1em;
+    text-decoration: none
+   }
+
+   div.version_text {
+     font-weight: bolder;
+   }
+
+   div.version_text span.empty {
+     color: grey;
+   }
+   div.version_text span.fail {
+     color: red;
+   }
+   div.version_text span.success {
+     color: green;
+   }
+   </style>
+
+   <form id="badgeform" class="pure-form">
+      <input type="text" class="pure-input-1-4" id="binderhuburl" placeholder="BinderHub URL">
+      <input type="button" id="checkAgeButton" onclick="checkAge()" value="Check Age" />
+   </form>
+
+   <hr />
+
+   <div class="version_text" id="binderhubversiontext">BinderHub version: <span class="empty">Fill in the box then click "check age"</span></div>
+   <div class="version_text" id="repo2dockerversiontext">repo2docker version: <span class="empty">Fill in the box then click "check age"</span></div>
+
+   <script>
+   function checkAge() {
+       // Variables
+       var repo2docker_div = document.querySelectorAll('div#repo2dockerversiontext span')[0];
+       var binderhub_div = document.querySelectorAll('div#binderhubversiontext span')[0];
+
+       // Build the new badge link
+       var url = document.getElementById("binderhuburl").value;
+       if (!url.startsWith('http')) {
+          url = "https://" + url;
+       }
+
+       // Get the versions for this BinderHub
+       var url=`${url}/versions`;
+       var resp = $.get(url);
+       resp.done((versions, status) => {
+            console.log(status);
+
+            // Versions will be a JSON response
+            bhub_version = versions['binderhub'];
+            r2d_version = versions['builder'];
+            console.log(versions)
+
+            // Update the rST
+            repo2docker_div.setAttribute('class', 'success')
+            binderhub_div.setAttribute('class', 'success')
+            binderhub_div.textContent = `${bhub_version}`
+            repo2docker_div.textContent = `${r2d_version}`
+       });
+
+       resp.fail(() => {
+         binderhub_div.setAttribute('class', 'fail')
+         repo2docker_div.setAttribute('class', 'fail')
+         binderhub_div.textContent = "BinderHub URL not correct! Please check your URL."
+         repo2docker_div.textContent = "BinderHub URL not correct! Please check your URL."
+       });
+   }
+   </script>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,4 +83,5 @@ A more detailed overview of the BinderHub design, architecture, and functionalit
    overview
    eventlogging
    api
+   age-checker
    reference/ref-index.rst


### PR DESCRIPTION
This adds a page in the BinderHub documentation with a mini form that does the following (checked boxes means it is implemented in this PR, unchecked means I'd like to implement it, but not sure how to)

- [x] Takes as input the URL of a BinderHub
- [x] Press a button to grab the latest versions of software on the BinderHub
- [x] Display the versions w/ success or fail note
- [ ] List the number of **commits** of these versions relative to the latest published versions
- [ ] List the number of **days** of these versions relative to the latest published versions 

I've got the versions reading in properly (using `mybinderhub.org/versions`) but I can't figure out how to compare these versions to the "latest" versions (which I assume we should pull from here: https://jupyterhub.github.io/helm-chart/). Anybody have ideas for how this could happen?

Here's what the age checker looks like: https://302-89419368-gh.circle-artifacts.com/0/html/age-checker.html