### PR TITLE
[MRG] Make base badge URL available in the loading screen as well

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -58,6 +58,7 @@ class ParameterizedMainHandler(BaseHandler):
         self.render_template(
             "loading.html",
             base_url=self.settings['base_url'],
+            badge_base_url=self.settings['badge_base_url'],
             provider_spec=provider_spec,
             nbviewer_url=nbviewer_url,
             # urlpath=self.get_argument('urlpath', None),

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -2,6 +2,7 @@
 
 {% block head %}
 <meta id="base-url" data-url="{{base_url}}">
+<meta id="badge-base-url" data-url="{{badge_base_url}}">
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>


### PR DESCRIPTION
We also need to add the base URL data to the loading page. This was missed in #859, noticed after deploying on mybinder.org