### PR TITLE
[MRG] Add extraEnv to the BinderHub deployment

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -98,6 +98,9 @@ spec:
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
         {{- end }}
+        {{ if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 8 }}
+        {{ end }}
         ports:
           - containerPort: 8585
             name: binder

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -173,3 +173,4 @@ ingress:
 initContainers: []
 extraVolumes: []
 extraVolumeMounts: []
+extraEnv: []


### PR DESCRIPTION
This lets you set extra environment variables for the hub deployment. Useful to make secrets accessible for the events archiver.