### PR TITLE
Add 'origin' field to launch events

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -413,6 +413,12 @@ class BinderHub(Application):
         config=True,
     )
 
+    normalized_origin = Unicode(
+        '',
+        config=True,
+        help='Origin to use when emitting events. Defaults to hostname of request when empty'
+    )
+
     @staticmethod
     def add_url_prefix(prefix, handlers):
         """add a url prefix to handlers"""
@@ -524,7 +530,8 @@ class BinderHub(Application):
             'executor': self.executor,
             'auth_enabled': self.auth_enabled,
             'use_named_servers': self.use_named_servers,
-            'event_log': self.event_log
+            'event_log': self.event_log,
+            'normalized_origin': self.normalized_origin
         })
         if self.auth_enabled:
             self.tornado_settings['cookie_secret'] = os.urandom(32)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -299,7 +299,7 @@ class BuildHandler(BaseHandler):
                 'provider': provider.name,
                 'spec': spec,
                 'status': 'success',
-                'origin': self.request.host
+                'origin': self.settings['normalized_origin'] if self.settings['normalized_origin'] else self.request.host
             })
             return
 
@@ -408,7 +408,7 @@ class BuildHandler(BaseHandler):
                 'provider': provider.name,
                 'spec': spec,
                 'status': 'success',
-                'origin': self.request.host
+                'origin': self.settings['normalized_origin'] if self.settings['normalized_origin'] else self.request.host
             })
 
         # Don't close the eventstream immediately.

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -295,10 +295,11 @@ class BuildHandler(BaseHandler):
             })
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube)
-            self.event_log.emit('binderhub.jupyter.org/launch', 2, {
+            self.event_log.emit('binderhub.jupyter.org/launch', 3, {
                 'provider': provider.name,
                 'spec': spec,
-                'status': 'success'
+                'status': 'success',
+                'origin': self.request.host
             })
             return
 
@@ -403,10 +404,11 @@ class BuildHandler(BaseHandler):
             BUILD_COUNT.labels(status='success', **self.repo_metric_labels).inc()
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube)
-            self.event_log.emit('binderhub.jupyter.org/launch', 2, {
+            self.event_log.emit('binderhub.jupyter.org/launch', 3, {
                 'provider': provider.name,
                 'spec': spec,
-                'status': 'success'
+                'status': 'success',
+                'origin': self.request.host
             })
 
         # Don't close the eventstream immediately.

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -1,6 +1,6 @@
 {
     "$id": "binderhub.jupyter.org/launch",
-    "version": 2,
+    "version": 3,
     "title": "BinderHub Launch Events",
     "description": "BinderHub emits this event whenever a new repo is launched",
     "type": "object",
@@ -21,6 +21,10 @@
         "status": {
             "enum": ["success", "failure"],
             "description": "Success/Failure of the launch"
+        },
+        "origin": {
+          "type": "string",
+          "description": "BinderHub host where the event originated"
         }
     }
 }


### PR DESCRIPTION
Lets us differentiate launches from different BinderHub
installations