### PR TITLE
[MRG] Manually list BinderHub dependencies in docs requirements

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -4,7 +4,17 @@ recommonmark==0.4.0
 sphinx-copybutton
 alabaster_jupyterhub
 traitlets
-# install BinderHub from source but because `pip install` is executed in the
-# root directory (not this directory) of this repository we write '.' here
-# not '..' as you might expect when thinking relative to this file.
--e .
+# install BinderHub dependencies. We manually list them here because some
+# dependencies (like pycurl) can't be installed on ReadTheDocs and aren't
+# needed to build the docs.
+kubernetes>=4.*
+escapism
+tornado
+traitlets
+docker
+jinja2
+prometheus_client
+python-json-logger
+jupyterhub
+jsonschema
+#pycurl is not installed for docs

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -17,4 +17,4 @@ prometheus_client
 python-json-logger
 jupyterhub
 jsonschema
-#pycurl is not installed for docs
+#pycurl Do not install for docs as it breaks the RTD build. Its primary use is for mocks in testing .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# When you change this file please also update `doc/doc-requirements.txt`
+# which needs to be kept in sync manually.
 kubernetes>=4.*
 escapism
 tornado


### PR DESCRIPTION
Our docs build broken when pycurl was added as a dependency. It has some non Python package requirements that aren't fulfilled on RTD. This PR copies the requirements to the docs requirements manually. I think we change our dependencies rarely enough that we can get away having to synnc them manually.