### PR TITLE
[MRG] Add basic news header to the HTML templates

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -107,7 +107,7 @@ class BinderHub(Application):
         config=True
     )
 
-    news_message = Unicode(
+    banner_message = Unicode(
         '',
         help="""
         Message to display in a banner on all pages.
@@ -532,7 +532,7 @@ class BinderHub(Application):
             'google_analytics_code': self.google_analytics_code,
             'google_analytics_domain': self.google_analytics_domain,
             'about_message': self.about_message,
-            'news_message': self.news_message,
+            'banner_message': self.banner_message,
             'extra_footer_scripts': self.extra_footer_scripts,
             'jinja2_env': jinja_env,
             'build_memory_limit': self.build_memory_limit,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -112,8 +112,9 @@ class BinderHub(Application):
         help="""
         Message to display in a banner on all pages.
 
-        Will be directly inserted into the about page's source so you can use
-        raw HTML.
+        The value will be inserted "as is" into a HTML <div> element
+        with grey background, located at the top of the BinderHub pages. Raw
+        HTML is supported.
         """,
         config=True
     )

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -107,6 +107,17 @@ class BinderHub(Application):
         config=True
     )
 
+    news_message = Unicode(
+        '',
+        help="""
+        Message to display in a banner on all pages.
+
+        Will be directly inserted into the about page's source so you can use
+        raw HTML.
+        """,
+        config=True
+    )
+
     extra_footer_scripts = Dict(
         {},
         help="""
@@ -521,6 +532,7 @@ class BinderHub(Application):
             'google_analytics_code': self.google_analytics_code,
             'google_analytics_domain': self.google_analytics_domain,
             'about_message': self.about_message,
+            'news_message': self.news_message,
             'extra_footer_scripts': self.extra_footer_scripts,
             'jinja2_env': jinja_env,
             'build_memory_limit': self.build_memory_limit,

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -24,7 +24,9 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
 
     @property
     def template_namespace(self):
-        return dict(static_url=self.static_url, **self.settings.get('template_variables', {}))
+        return dict(static_url=self.static_url,
+                    news=self.settings['news_message'],
+                    **self.settings.get('template_variables', {}))
 
     def set_default_headers(self):
         headers = self.settings.get('headers', {})

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -25,7 +25,7 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
     @property
     def template_namespace(self):
         return dict(static_url=self.static_url,
-                    news=self.settings['news_message'],
+                    banner=self.settings['banner_message'],
                     **self.settings.get('template_variables', {}))
 
     def set_default_headers(self):

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -50,6 +50,14 @@ p > a:hover {
 }
 
 
+#msg-container {
+    text-align: left;
+    color: black;
+    padding: 16px;
+    width: 100%;
+    background-color: rgb(235, 236, 237);
+}
+
 #logo-container {
     text-align: center;
     color: black;

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -50,7 +50,7 @@ p > a:hover {
 }
 
 
-#msg-container {
+#banner-container {
     text-align: left;
     color: black;
     padding: 16px;

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -5,8 +5,10 @@
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
-<link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>
-<link rel="stylesheet" href="{{static_url("loading.css")}}">
+<link href="{{static_url("dist/styles.css")}}" rel="stylesheet">
+<link href="{{static_url("loading.css")}}" rel="stylesheet">
+
+
 {% endblock head %}
 
 {% block main %}

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -11,9 +11,9 @@
 <body>
   {% block body %}
 
-  {% if news %}
+  {% if banner %}
   <div id="msg-container">
-    {{ news | safe }}
+    {{ banner | safe }}
   </div>
   {% endif %}
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -11,6 +11,12 @@
 <body>
   {% block body %}
 
+  {% if news %}
+  <div id="msg-container">
+    {{ news | safe }}
+  </div>
+  {% endif %}
+
   {% block logo %}
   <div class="container">
     <div class="row">

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -12,7 +12,7 @@
   {% block body %}
 
   {% if banner %}
-  <div id="msg-container">
+  <div id="banner-container">
     {{ banner | safe }}
   </div>
   {% endif %}

--- a/testing/localonly/binderhub_config.py
+++ b/testing/localonly/binderhub_config.py
@@ -6,3 +6,6 @@ c.BinderHub.repo_providers = {'gh': FakeProvider}
 c.BinderHub.tornado_settings.update({'fake_build':True})
 
 c.BinderHub.about_message = "<blink>Hello world.</blink>"
+
+c.BinderHub.news_message = 'This is headline <a href="#">news.</a>'
+

--- a/testing/localonly/binderhub_config.py
+++ b/testing/localonly/binderhub_config.py
@@ -7,5 +7,4 @@ c.BinderHub.tornado_settings.update({'fake_build':True})
 
 c.BinderHub.about_message = "<blink>Hello world.</blink>"
 
-c.BinderHub.news_message = 'This is headline <a href="#">news.</a>'
-
+c.BinderHub.banner_message = 'This is headline <a href="#">news.</a>'


### PR DESCRIPTION
This PR adds the ability to have a basic "news" banner at the top of all pages. You can set the HTML to be displayed inside the banner via a config option.

Closes #877

When the message is not an empty string a banner with grey background (like the form) will appear at the top of each page (landing, loading, about, error, etc).

![Screenshot_2019-06-17 Binder](https://user-images.githubusercontent.com/1448859/59626660-bb6c1a00-913c-11e9-98bb-4dd7ef29067a.png)
