### PR TITLE
adding whitelisted specs

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -218,6 +218,20 @@ class BinderHub(Application):
         config=True,
     )
 
+    per_repo_quota_higher = Integer(
+        0,
+        help="""
+        Maximum number of concurrent users running from a higher-quota repo.
+
+        Limits the amount of Binder that can be consumed by a single repo. This
+        quota is a second limit for repos with special status. See the
+        `high_quota_specs` parameter of RepoProvider classes for usage.
+
+        0 (default) means no quotas.
+        """,
+        config=True,
+    )
+
     log_tail_lines = Integer(
         100,
         help="""
@@ -526,6 +540,7 @@ class BinderHub(Application):
             'build_pool': self.build_pool,
             'log_tail_lines': self.log_tail_lines,
             'per_repo_quota': self.per_repo_quota,
+            'per_repo_quota_higher': self.per_repo_quota_higher,
             'repo_providers': self.repo_providers,
             'use_registry': self.use_registry,
             'registry': registry,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -180,6 +180,7 @@ class BuildHandler(BaseHandler):
             hash=build_slug_hash[:hash_length],
         ).lower()
 
+
     async def fail(self, message):
         await self.emit({
             'phase': 'failed',
@@ -294,7 +295,7 @@ class BuildHandler(BaseHandler):
                 'message': 'Found built image, launching...\n'
             })
             with LAUNCHES_INPROGRESS.track_inprogress():
-                await self.launch(kube)
+                await self.launch(kube, provider)
             self.event_log.emit('binderhub.jupyter.org/launch', 3, {
                 'provider': provider.name,
                 'spec': spec,
@@ -403,7 +404,7 @@ class BuildHandler(BaseHandler):
             BUILD_TIME.labels(status='success').observe(time.perf_counter() - build_starttime)
             BUILD_COUNT.labels(status='success', **self.repo_metric_labels).inc()
             with LAUNCHES_INPROGRESS.track_inprogress():
-                await self.launch(kube)
+                await self.launch(kube, provider)
             self.event_log.emit('binderhub.jupyter.org/launch', 3, {
                 'provider': provider.name,
                 'spec': spec,
@@ -421,7 +422,7 @@ class BuildHandler(BaseHandler):
         # well-behaved clients will close connections after they receive the launch event.
         await gen.sleep(60)
 
-    async def launch(self, kube):
+    async def launch(self, kube, provider):
         """Ask JupyterHub to launch the image."""
         # check quota first
         quota = self.settings.get('per_repo_quota')
@@ -456,10 +457,9 @@ class BuildHandler(BaseHandler):
                     matching_pods += 1
                     break
 
-        # TODO: allow whitelist of repos to exceed quota
         # TODO: put busy users in a queue rather than fail?
         # That would be hard to do without in-memory state.
-        if quota and matching_pods >= quota:
+        if quota and matching_pods >= quota and not provider.is_whitelisted():
             app_log.error("%s has exceeded quota: %s/%s (%s total)",
                 self.repo_url, matching_pods, quota, total_pods)
             await self.fail("Too many users running %s! Try again soon." % self.repo_url)

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -71,6 +71,15 @@ class RepoProvider(LoggingConfigurable):
         config=True
     )
 
+    whitelisted_specs = List(
+        help="""
+        List of specs to whitelist for quota limits.
+
+        Should be a list of regexes (not regex objects) that match specs which should be whitelisted
+        """,
+        config=True
+    )
+
     unresolved_ref = Unicode()
 
     git_credentials = Unicode(
@@ -88,6 +97,17 @@ class RepoProvider(LoggingConfigurable):
             # Ignore case, because most git providers do not
             # count DS-100/textbook as different from ds-100/textbook
             if re.match(banned, self.spec, re.IGNORECASE):
+                return True
+        return False
+
+    def is_whitelisted(self):
+        """
+        Return true if the given spec is whitelisted
+        """
+        for whitelisted in self.repository_whitelist:
+            # Ignore case, because most git providers do not
+            # count DS-100/textbook as different from ds-100/textbook
+            if re.match(whitelisted, self.spec, re.IGNORECASE):
                 return True
         return False
 

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -71,11 +71,11 @@ class RepoProvider(LoggingConfigurable):
         config=True
     )
 
-    whitelisted_specs = List(
+    high_quota_specs = List(
         help="""
-        List of specs to whitelist for quota limits.
+        List of specs to assign a higher quota limit.
 
-        Should be a list of regexes (not regex objects) that match specs which should be whitelisted
+        Should be a list of regexes (not regex objects) that match specs which should have a higher quota
         """,
         config=True
     )
@@ -100,14 +100,14 @@ class RepoProvider(LoggingConfigurable):
                 return True
         return False
 
-    def is_whitelisted(self):
+    def has_higher_quota(self):
         """
-        Return true if the given spec is whitelisted
+        Return true if the given spec has a higher quota
         """
-        for whitelisted in self.repository_whitelist:
+        for higher_quota in self.high_quota_specs:
             # Ignore case, because most git providers do not
             # count DS-100/textbook as different from ds-100/textbook
-            if re.match(whitelisted, self.spec, re.IGNORECASE):
+            if re.match(higher_quota, self.spec, re.IGNORECASE):
                 return True
         return False
 

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -83,6 +83,26 @@ def test_banned():
     assert provider.is_banned()
 
 
+def test_higher_quota():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        high_quota_specs=[
+            '^yuvipanda.*'
+        ]
+    )
+    assert not provider.has_higher_quota()
+
+
+def test_not_higher_quota():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        high_quota_specs=[
+            '^jupyterhub.*'
+        ]
+    )
+    assert provider.has_higher_quota()
+
+
 @pytest.mark.parametrize('ban_spec', ['.*ddEEff.*', '.*ddEEFF.*'])
 def test_ban_is_case_insensitive(ban_spec):
     provider = GitHubRepoProvider(


### PR DESCRIPTION
This PR adds the ability to **whitelist** specifications with the GitHub repoprovider.

it closes #882 though doesn't quite follow the pattern there (which suggested a more general config architecture for specific specs).

Still not sure how to test it, but it seems to me that this would work for the whitelist usecase. @betatim what do you think? Happy to iterate on this a bit to try and get it working.