### PR TITLE
[mrg] Per spec configuration

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -426,15 +426,6 @@ class BuildHandler(BaseHandler):
         """Ask JupyterHub to launch the image."""
         # Load the spec-specific configuration if it has been overridden
         repo_config = provider.repo_config(self.settings)
-        spec_config = provider.spec_configuration_override
-
-        # check quota first
-        if provider.has_higher_quota():
-            quota = self.settings.get('per_repo_quota_higher')
-        elif "per_repo_quota" in spec_config:
-            quota = spec_config.get('per_repo_quota')
-        else:
-            quota = self.settings.get('per_repo_quota')
 
         # the image name (without tag) is unique per repo
         # use this to count the number of pods running with a given repo
@@ -468,6 +459,7 @@ class BuildHandler(BaseHandler):
 
         # TODO: put busy users in a queue rather than fail?
         # That would be hard to do without in-memory state.
+        quota = repo_config.get('quota')
         if quota and matching_pods >= quota:
             app_log.error("%s has exceeded quota: %s/%s (%s total)",
                 self.repo_url, matching_pods, quota, total_pods)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -425,6 +425,7 @@ class BuildHandler(BaseHandler):
     async def launch(self, kube, provider):
         """Ask JupyterHub to launch the image."""
         # Load the spec-specific configuration if it has been overridden
+        repo_config = provider.repo_config(self.settings)
         spec_config = provider.spec_configuration_override
 
         # check quota first

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -424,9 +424,14 @@ class BuildHandler(BaseHandler):
 
     async def launch(self, kube, provider):
         """Ask JupyterHub to launch the image."""
+        # Load the spec-specific configuration if it has been overridden
+        spec_config = provider.spec_configuration_override
+
         # check quota first
         if provider.has_higher_quota():
             quota = self.settings.get('per_repo_quota_higher')
+        elif "per_repo_quota" in spec_config:
+            quota = spec_config.get('per_repo_quota')
         else:
             quota = self.settings.get('per_repo_quota')
 

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -140,8 +140,8 @@ class RepoProvider(LoggingConfigurable):
 
         # Spec regex-based configuration
         for item in self.spec_config:
-            pattern = item.pop('pattern', None)
-            config = item.pop('config', None)
+            pattern = item.get('pattern', None)
+            config = item.get('config', None)
             if not isinstance(pattern, str):
                 raise ValueError(
                     "Spec-pattern configuration expected "

--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -141,6 +141,12 @@ a list of dictionaries that allow you to provide a pattern to match against
 each repository's specification, and override configuration values for any
 repositories that match this pattern.
 
+.. note::
+
+   If you provide **multiple patterns that match a single repository** in your
+   spec-specific configuration, then **later values in the list will override
+   earlier values**.
+
 To define this list of patterns and configuration overrides, use the
 following pattern in your Helm Chart (here we show an example using
 ``GitHubRepoProvider``, but this works for other RepoProviders as well):

--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -125,3 +125,51 @@ To do that update your ``config.yaml`` by the following::
     to hold the value of ``extra_static_url_prefix`` is also defined,
     which was used in custom ``page.html``.
     This is good to do specially if you have many custom templates and static files.
+
+.. _repo-specific-config:
+
+Custom configuration for specific repositories
+----------------------------------------------
+
+Sometimes you would like to provide a repository-specific configuration.
+For example, if you'd like certain repositories to have **higher pod quotas**
+than others, or if you'd like to provide certain resources to a subset of
+repositories.
+
+To override the configuration for a specific repository, you can provide
+a list of dictionaries that allow you to provide a pattern to match against
+each repository's specification, and override configuration values for any
+repositories that match this pattern.
+
+To define this list of patterns and configuration overrides, use the
+following pattern in your Helm Chart (here we show an example using
+``GitHubRepoProvider``, but this works for other RepoProviders as well):
+
+.. code-block:: yaml
+
+   config:
+       GitHubRepoProvider:
+         spec_config:
+           - pattern: ^ines/spacy-binder.*:
+             config:
+                key1: value1
+           - pattern: pattern2
+             config:
+                key1: othervalue1
+                key2: othervalue2
+
+For example, the following specification configuration will assign a
+pod quota of 999 to the spacy-binder repository, and a pod quota
+of 1337 to any repository in the JupyterHub organization.
+
+.. code-block:: yaml
+
+   config:
+       GitHubRepoProvider:
+         spec_config:
+           - pattern: ^ines/spacy-binder.*:
+             config:
+                quota: 999
+           - pattern: ^jupyterhub.*
+             config:
+                quota: 1337


### PR DESCRIPTION
In https://github.com/jupyterhub/binderhub/issues/887 we talked about how it'd be cool to have per-repo configuration. This is a first attempt at implementing it.

The basic idea is that we operate similar to how "banned" and "quota increase" functionality works, with one difference:

Instead of a **list** of specification regexes to match to "quota increase" or "banned", we have a **dictionary** where keys are specification regexes, and values are dictionaries of "key:value" pairs that can over-ride configuration on a repo-specific basis.

For example, you could do something like:

```
config:
    GitHubRepoProvider:
      # Add banned repositories to the list below
      # They should be strings that will match "^<org-name>/<repo-name>.*"
      spec_configuration_override:
        ^ines/spacy-binder.*:
		    quota: 1337
        ^binder-examples/requirements.*:
   			banned: true     
```

## Questions to answer

1. I agree w/ @betatim that "spec_configuration_override" isn't great, any suggestions for other names?
2. What's a clean way to document what key:value configuration pairs are meaningful in this case? We'll need to add checks for them one-by-one in the code, and for now I guess we'll just start with a `quota: <int>` key/value. In the future, should we just expose this with good documentation for what the accepted key/values are? (we could also imagine some key/values being repoprovider-specific)

## Need to add

- [x] Docs
- [x] Tests
- [x] Better naming