### PR TITLE
Launch from HTTP referrer, autodetect launch URL

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -24,7 +24,7 @@ from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, defaul
 from traitlets.config import Application
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 
-from .base import AboutHandler, Custom404, VersionHandler
+from .base import AboutHandler, AutodetectHandler, Custom404, VersionHandler
 from .build import Build
 from .builder import BuildHandler
 from .launcher import Launcher
@@ -597,6 +597,7 @@ class BinderHub(Application):
                 tornado.web.StaticFileHandler,
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
+            (r'/autodetect', AutodetectHandler),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -110,6 +110,21 @@ class AboutHandler(BaseHandler):
         )
 
 
+class AutodetectHandler(BaseHandler):
+    """Serve a just-do-the-right-thing page"""
+    async def get(self):
+        referrer = self.request.headers.get('Referer', '')
+        self.render_template(
+            "autodetect.html",
+            base_url=self.settings['base_url'],
+            submit=False,
+            referrer=referrer,
+            google_analytics_code=self.settings['google_analytics_code'],
+            google_analytics_domain=self.settings['google_analytics_domain'],
+            extra_footer_scripts=self.settings['extra_footer_scripts'],
+        )
+
+
 class VersionHandler(BaseHandler):
     """Serve information about versions running"""
     async def get(self):

--- a/binderhub/static/js/src/autodetect.js
+++ b/binderhub/static/js/src/autodetect.js
@@ -1,0 +1,46 @@
+export function autodetect(input) {
+  // Based on https://github.com/Carreau/open-with-binder/blob/0bb0a5cb7c90865fd5736c19e4aea797ce6e25be/content_scripts/binderify.js
+  var mybinderurl;
+  try {
+    var url = new URL(input.trim());
+    var parts = url.pathname.split('/');
+
+    if (url.hostname == 'github.com' && parts.length > 2) {
+      mybinderurl = 'https://mybinder.org/v2/gh/' + parts[1] + '/' + parts[2] + '/' + (parts[4] || 'master');
+      if (parts.length > 5) {
+        mybinderurl += '?filepath=' + parts.slice(5).join('%2F');
+      }
+    }
+
+    if (url.hostname == 'gist.github.com' && parts.length > 2) {
+      mybinderurl = 'https://mybinder.org/v2/gist/' + parts[1] + '/' + parts[2] + '/' + (parts[3] || 'master');
+    }
+
+    if (url.hostname == 'gitlab.com' && parts.length > 2) {
+      let repo = '';
+      let extra = '';
+      let branch_tag_hash = 'master';
+      let blob_idx = parts.indexOf('blob');
+      if (blob_idx === -1) {
+        // tree is used instead of blob when looking at a directory so try
+        // to find that instead
+        blob_idx = parts.indexOf('tree');
+      }
+      if (blob_idx > 1){
+        repo = parts.slice(1, blob_idx).join('/');
+        branch_tag_hash = parts[blob_idx + 1];
+        extra = '?filepath=' + parts.slice(blob_idx + 2).join('%2F')
+      }
+      else {
+        repo = parts.slice(1).join('/');
+      }
+      mybinderurl = 'https://mybinder.org/v2/gl/' + encodeURIComponent(repo) + '/' + branch_tag_hash + extra;
+    }
+  } catch(err) {
+    // Not a URL
+    if (/^10\.\d{4,}[\.\d]*\/.+/.exec(input)) {
+      mybinderurl = 'https://mybinder.org/v2/zenodo/' + input;
+    }
+  }
+  return mybinderurl;
+}

--- a/binderhub/templates/autodetect.html
+++ b/binderhub/templates/autodetect.html
@@ -1,0 +1,86 @@
+{% extends "page.html" %}
+
+{% block head %}
+<meta id="base-url" data-url="{{base_url}}">
+<meta id="badge-base-url" data-url="{{badge_base_url}}">
+<script src="{{static_url("dist/bundle.js")}}"></script>
+{{ super() }}
+{% endblock head %}
+
+{% block main %}
+<div id="main" class="container">
+  <div class="row">
+    <div class="col-lg-10 col-lg-offset-1">
+      {% block header %}
+      <div id="header" class="text-center">
+        <h3>Turn a Git repo into a collection of interactive notebooks</h3>
+      </div>
+      {% endblock header %}
+
+      {% block form %}
+      <form id="build-form" class="form jumbotron">
+        <h4 id="form-header" class='row'>Build and launch a repository</h4>
+
+        <div class="form-row row">
+
+        <div class="form-group col-md-10">
+          <label for="repository">Repository URL</label>
+          <input class="form-control" type="text" id="mybinder-referrer" data-lpignore="true" placeholder="Repository URL" value="" />
+        </div>
+        <div class="form-group col-md-2">
+          <div class="btn-group" id="launch-buttons">
+            <button id="submit" class="btn-submit" type="submit">launch</button>
+          </div>
+        </div>
+        </div>
+
+        <div class="url row">
+          <div class="dropdownmenu">
+            <label>Copy the URL below and share your Binder with others:</label>
+          </div>
+          <div class="url-row">
+            <pre id="mybinder-info"></pre>
+            <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}" data-clipboard-target="#mybinder-info" alt="Copy to clipboard">
+          </div>
+        </div>
+
+      <div class="badges row">
+            <div class="dropdownmenu" id="toggle-badge-snippet">
+              <label>Copy the text below, then paste into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge_logo.svg")}}"></label>
+              <a id="badge-link"></a>
+              <a href="#" title="show badge snippets"><span id="badge-snippet-caret" class="glyphicon glyphicon-triangle-right"></span></a>
+            </div>
+            <div id="badge-snippets" class="hidden">
+              <!--Markdown section-->
+              <div  class="badge-snippet-row">
+                 <pre id="markdown-badge-snippet" data-default="Fill in the fields to see the markdown badge snippet."></pre>
+                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
+                 <img class="icon clipboard"
+                    src="{{static_url("images/copy-icon-black.svg")}}"
+                    data-clipboard-target="#markdown-badge-snippet"
+                    alt="Copy markdown link to clipboard">
+              </div>
+              <!--RST section-->
+              <div  class="badge-snippet-row">
+                  <pre id="rst-badge-snippet" data-default="Fill in the fields to see the rST badge snippet."></pre>
+                  <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
+                  <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}"
+                    data-clipboard-target="#rst-badge-snippet"
+                    alt="Copy rst link to clipboard">
+              </div>
+            </div>
+        </div>
+
+      </form>
+      {% endblock form %}
+    </div>
+  </div>
+</div>
+{% endblock main %}
+
+{% block footer %}
+{{ super () }}
+<script type="text/javascript">
+autodetectMain("{{referrer}}");
+</script>
+{% endblock footer %}


### PR DESCRIPTION
Opening this for initial comments, not sure how much time I'll have to follow up in the immediate future.

Background
- https://discourse.jupyter.org/t/binderhub-button-pull-from-referrer/1572/
- This also implements some of the "awesome bar" suggestion from https://github.com/jupyterhub/binderhub/issues/844

This adds a new `/autodetect` page that takes the HTTP referrer and converts it to a mybinder URL. You can also paste a GitHub repo URL, GitHub gist URL, GitLab repo URL, or Zenodo DOI into the input box. Currently this is a separate page, mostly copied from the main index.html.

Example: In a GitHub repo create a readme with a link to `https://binder.example.org/autodetect`, if it works the referrer will be parsed and converted into a link to launch the repo you came from.An earlier example can be seen at https://github.com/manics/mybinder-referrer/tree/demo

![Screen Shot 2019-07-09 at 17 35 39-fullpage](https://user-images.githubusercontent.com/1644105/60906977-56ee3780-a270-11e9-8af9-602adbf86e32.png)

![Screen Shot 2019-07-09 at 17 35 58-fullpage](https://user-images.githubusercontent.com/1644105/60906990-5ce41880-a270-11e9-8223-602fd9b5d90b.png)

TODO:
- [ ] Tests
- [ ] Don't hard-code `https://mybinder.org/`