### PR TITLE
Bump JupyterHub chart

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.9-03215dd"
+  version: "0.9-dcde99a"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
Bump JupyterHub to latest chart. `03215dd` is from April and does not capture several improvements. I noticed the need for this with CHP version and the redirection to https port.