### PR TITLE
update documentation for "GitHub API limit"

### DIFF
--- a/doc/setup-binderhub.rst
+++ b/doc/setup-binderhub.rst
@@ -353,8 +353,7 @@ an API access token to raise your API limit to 5000 requests an hour.
       GitHubRepoProvider:
         access_token: <insert_token_value_here>
 
-This value will be loaded into `GITHUB_ACCESS_TOKEN` environment variable and
-BinderHub will automatically use the token stored in this variable when making
+BinderHub will use this token when making
 API requests to GitHub. See the `GitHub authentication documentation
 <https://developer.github.com/v3/guides/getting-started/#authentication>`_ for
 more information about API limits.


### PR DESCRIPTION
This is a small change about how `GitHubRepoProvider.access_token` is used. It is not loaded into a env variable anymore (probably since passthrough config is introduced) but passed directly to `GitHubRepoProvider`:
https://github.com/jupyterhub/binderhub/blob/137ec19b015ec84d0eb8d60b4ba2aa4ef3340ed7/helm-chart/binderhub/templates/secret.yaml#L11-L13
