### PR TITLE
absolute URL for social image

### DIFF
--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -10,6 +10,10 @@
   <meta property="og:title" content="The Binder Project">
   <meta property="og:description" content="Reproducible, sharable, interactive computing environments.">
   <meta property="og:image" content="https://mybinder.org/static/images/logo_social.png">
+  <meta property="og:image:width" content="1334">
+  <meta property="og:image:height" content="700">
+  <meta property="og:image:alt" content="The Binder Project Logo" />
+
   <meta name="twitter:card" content="summary_large_image">
   {% endblock head %}
 </head>

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -9,7 +9,7 @@
   <!-- Social media previews -->
   <meta property="og:title" content="The Binder Project">
   <meta property="og:description" content="Reproducible, sharable, interactive computing environments.">
-  <meta property="og:image" content="{{static_url("images/logo_social.png")}}">
+  <meta property="og:image" content="https://mybinder.org/static/images/logo_social.png">
   <meta name="twitter:card" content="summary_large_image">
   {% endblock head %}
 </head>


### PR DESCRIPTION
From looking at the [twitter card validator](https://cards-dev.twitter.com/validator) it seems like we *are* correctly pulling some information from the binder link, but it looks from [this SO post](https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url) that the open graph images will only work with absolute URLs.

So let's try coding an absolute URL for mybinder.org in there

https://stackoverflow.com/questions/9858577/open-graph-can-resolve-relative-url

In the future perhaps we can expose a template variable like [base_url](https://github.com/jupyterhub/binderhub/blob/a52925198dca15f69a23869a861529334391f078/helm-chart/images/binderhub/binderhub_config.py#L89) though I'm not sure how to actually set that variable