### PR TITLE
disable continuous-image-puller

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -120,6 +120,8 @@ jupyterhub:
   prePuller:
     hook:
       enabled: false
+    continuous:
+      enabled: false
 
 deployment:
   labels: {}

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -59,7 +59,10 @@ auth:
     className: "nullauthenticator.NullAuthenticator"
 
 prePuller:
-  enabled: false
+  hook:
+    enabled: false
+  continuous:
+    enabled: false
 
 proxy:
   # Another secret!


### PR DESCRIPTION
disables `continuous-image-puller`. Before it was disabled by default.

ref: https://github.com/jupyterhub/binderhub/pull/901