### PR TITLE
[MRG] Serve pod usage information in `/health` handler

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -222,14 +222,15 @@ class BinderHub(Application):
     pod_quota = Integer(
         None,
         help="""
-        The  number of concurrent pods this hub has been designed to support.
+        The number of concurrent pods this hub has been designed to support.
 
         This quota is used as an indication for how much above or below the
         design capacity a hub is running. It is not used to reject new launch
         requests when usage is above the quota.
 
-        The default corresponds to no quotas, 0 means the hub can't accept pods,
-        and any positive integer sets the quota.
+        The default corresponds to no quota, 0 means the hub can't accept pods
+        (maybe because it is in maintenance mode), and any positive integer
+        sets the quota.
         """,
         allow_none=True,
         config=True,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -34,7 +34,7 @@ from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
 from .repoproviders import (GitHubRepoProvider, GitRepoProvider,
                             GitLabRepoProvider, GistRepoProvider,
                             ZenodoProvider)
-from .metrics import MetricsHandler, PodQuotaHandler
+from .metrics import MetricsHandler
 
 from .utils import ByteSpecification, url_path_join
 from .events import EventLog
@@ -620,7 +620,6 @@ class BinderHub(Application):
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
             (r'/health', HealthHandler, {'hub_url': self.hub_url}),
-            (r'/_pod_quota', PodQuotaHandler),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -34,7 +34,7 @@ from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
 from .repoproviders import (GitHubRepoProvider, GitRepoProvider,
                             GitLabRepoProvider, GistRepoProvider,
                             ZenodoProvider)
-from .metrics import MetricsHandler
+from .metrics import MetricsHandler, UsageHandler
 
 from .utils import ByteSpecification, url_path_join
 from .events import EventLog
@@ -602,6 +602,7 @@ class BinderHub(Application):
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
             (r'/health', HealthHandler, {'hub_url': self.hub_url}),
+            (r'/_usage', UsageHandler),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -1,8 +1,10 @@
 import asyncio
+import time
 
 from functools import wraps
 
 from tornado.httpclient import AsyncHTTPClient
+from tornado.log import app_log
 
 from .base import BaseHandler
 
@@ -50,17 +52,69 @@ def false_if_raises(f):
     return wrapper
 
 
+def at_most_every(_f=None, *, interval=10):
+    """Call the wrapped function at most every `interval` seconds.
+
+    Useful when `f` is (very) expensive to compute and you are happy
+    to have results which are possibly a few seconds out of date.
+    """
+    last_time = time.monotonic() - interval - 1
+    last_result = None
+
+    def caller(f):
+        @wraps(f)
+        async def wrapper(*args, **kwargs):
+            nonlocal last_time, last_result
+            now = time.monotonic()
+            if now > last_time + interval:
+                last_result = await f(*args, **kwargs)
+                last_time = now
+            return last_result
+
+        return wrapper
+
+    if _f is None:
+        return caller
+    else:
+        return caller(_f)
+
+
 class HealthHandler(BaseHandler):
     """Serve health status"""
 
     def initialize(self, hub_url=None):
         self.hub_url = hub_url
 
+    @at_most_every
+    async def _get_pods(self):
+        """Get information about build and user pods"""
+        app_log.info("Getting pod statistics")
+        k8s = self.settings["kubernetes_client"]
+        pool = self.settings["executor"]
+
+        get_user_pods = asyncio.wrap_future(
+            pool.submit(
+                k8s.list_namespaced_pod,
+                self.settings["build_namespace"],
+                label_selector="app=jupyterhub,component=singleuser-server",
+            )
+        )
+
+        get_build_pods = asyncio.wrap_future(
+            pool.submit(
+                k8s.list_namespaced_pod,
+                self.settings["build_namespace"],
+                label_selector="component=binderhub-build",
+            )
+        )
+
+        return await asyncio.gather(get_user_pods, get_build_pods)
+
     @false_if_raises
     @retry
     async def check_jupyterhub_api(self, hub_url):
         """Check JupyterHub API health"""
-        await AsyncHTTPClient().fetch(hub_url + "hub/health", request_timeout=2)
+        await AsyncHTTPClient().fetch(hub_url + "hub/health", request_timeout=3)
 
         return True
 
@@ -81,17 +135,49 @@ class HealthHandler(BaseHandler):
         )
         return r.code in (200, 401)
 
+    async def check_pod_quota(self):
+        """Compare number of active pods to available quota"""
+        user_pods, build_pods = await self._get_pods()
+
+        n_user_pods = len(user_pods.items)
+        n_build_pods = len(build_pods.items)
+
+        quota = self.settings["pod_quota"]
+        total_pods = n_user_pods + n_build_pods
+        usage = {
+            "total_pods": total_pods,
+            "build_pods": n_build_pods,
+            "user_pods": n_user_pods,
+            "quota": quota,
+            "ok": total_pods <= quota,
+        }
+        return usage
+
     async def get(self):
         checks = []
+        check_futures = []
 
         if self.settings["use_registry"]:
-            res = await self.check_docker_registry()
-            checks.append({"service": "docker-registry", "ok": res})
+            check_futures.append(self.check_docker_registry())
+            checks.append({"service": "Docker registry", "ok": False})
 
-        res = await self.check_jupyterhub_api(self.hub_url)
-        checks.append({"service": "JupyterHub API", "ok": res})
+        check_futures.append(self.check_jupyterhub_api(self.hub_url))
+        checks.append({"service": "JupyterHub API", "ok": False})
 
-        overall = all(check["ok"] for check in checks)
+        check_futures.append(self.check_pod_quota())
+        checks.append({"service": "Pod quota", "ok": False})
+
+        for result, check in zip(await asyncio.gather(*check_futures), checks):
+            if isinstance(result, bool):
+                check["ok"] = result
+            else:
+                check.update(result)
+
+        # The pod quota is treated as a soft quota this means being above
+        # quota doesn't mean the service is unhealthy
+        overall = all(
+            check["ok"] for check in checks if check["service"] != "Pod quota"
+        )
         if not overall:
             self.set_status(503)
 

--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -149,7 +149,7 @@ class HealthHandler(BaseHandler):
             "build_pods": n_build_pods,
             "user_pods": n_user_pods,
             "quota": quota,
-            "ok": total_pods <= quota,
+            "ok": total_pods <= quota if quota is not None else True,
         }
         return usage
 

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -1,85 +1,8 @@
-import asyncio
-import time
-
-from functools import wraps
-
-from tornado.log import app_log
-
 from .base import BaseHandler
 from prometheus_client import REGISTRY, generate_latest, CONTENT_TYPE_LATEST
-
-
-def at_most_every(_f=None, *, interval=10):
-    """Call the wrapped function at most every `interval` seconds.
-
-    Useful when `f` is (very) expensive to compute and you are happy
-    to have results which are possibly a few seconds out of date.
-    """
-    last_time = time.monotonic() - interval - 1
-    last_result = None
-
-    def caller(f):
-        @wraps(f)
-        async def wrapper(*args, **kwargs):
-            nonlocal last_time, last_result
-            now = time.monotonic()
-            if now > last_time + interval:
-                last_result = await f(*args, **kwargs)
-                last_time = now
-            return last_result
-
-        return wrapper
-
-    if _f is None:
-        return caller
-    else:
-        return caller(_f)
 
 
 class MetricsHandler(BaseHandler):
     async def get(self):
         self.set_header("Content-Type", CONTENT_TYPE_LATEST)
         self.write(generate_latest(REGISTRY))
-
-
-class PodQuotaHandler(BaseHandler):
-    @at_most_every
-    async def _get_pods(self):
-        """Get information about build and user pods"""
-        app_log.info("Getting pod statistics")
-        k8s = self.settings["kubernetes_client"]
-        pool = self.settings["executor"]
-
-        get_user_pods = asyncio.wrap_future(
-            pool.submit(
-                k8s.list_namespaced_pod,
-                self.settings["build_namespace"],
-                label_selector="app=jupyterhub,component=singleuser-server",
-            )
-        )
-
-        get_build_pods = asyncio.wrap_future(
-            pool.submit(
-                k8s.list_namespaced_pod,
-                self.settings["build_namespace"],
-                label_selector="component=binderhub-build",
-            )
-        )
-
-        return await asyncio.gather(get_user_pods, get_build_pods)
-
-    async def get(self):
-        """Serve information about current usage and maximum capacity"""
-        user_pods, build_pods = await self._get_pods()
-
-        n_user_pods = len(user_pods.items)
-        n_build_pods = len(build_pods.items)
-
-        usage = {
-            "total_pods": n_user_pods + n_build_pods,
-            "build_pods": n_build_pods,
-            "user_pods": n_user_pods,
-            "quota": self.settings["pod_quota"],
-        }
-
-        self.write(usage)

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -69,7 +69,7 @@ class PodQuotaHandler(BaseHandler):
         return await asyncio.gather(get_user_pods, get_build_pods)
 
     async def get(self):
-        """Serve statistics about current usage and maximum capacity"""
+        """Serve information about current usage and maximum capacity"""
         user_pods, build_pods = await self._get_pods()
 
         n_user_pods = len(user_pods.items)

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -1,8 +1,86 @@
+import asyncio
+import time
+
+from functools import wraps
+
+from tornado.log import app_log
+
 from .base import BaseHandler
 from prometheus_client import REGISTRY, generate_latest, CONTENT_TYPE_LATEST
 
 
+def at_most_every(_f=None, *, interval=10):
+    """Call the wrapped function at most every `interval` seconds.
+
+    Useful when `f` is (very) expensive to compute and you are happy
+    to have results which are possibly a few seconds out of date.
+    """
+    last_time = time.monotonic() - interval - 1
+    last_result = None
+
+    def caller(f):
+        @wraps(f)
+        async def wrapper(*args, **kwargs):
+            nonlocal last_time, last_result
+            now = time.monotonic()
+            if now > last_time + interval:
+                last_result = await f(*args, **kwargs)
+                last_time = now
+            return last_result
+
+        return wrapper
+
+    if _f is None:
+        return caller
+    else:
+        return caller(_f)
+
+
 class MetricsHandler(BaseHandler):
     async def get(self):
-        self.set_header('Content-Type', CONTENT_TYPE_LATEST)
+        self.set_header("Content-Type", CONTENT_TYPE_LATEST)
         self.write(generate_latest(REGISTRY))
+
+
+class UsageHandler(BaseHandler):
+    @at_most_every
+    async def _get_pods(self):
+        """Get information about build and user pods"""
+        app_log.info("Getting pod statistics")
+        k8s = self.settings["kubernetes_client"]
+        pool = self.settings["executor"]
+
+        get_user_pods = asyncio.wrap_future(
+            pool.submit(
+                k8s.list_namespaced_pod,
+                self.settings["build_namespace"],
+                label_selector="app=jupyterhub,component=singleuser-server",
+            )
+        )
+
+        get_build_pods = asyncio.wrap_future(
+            pool.submit(
+                k8s.list_namespaced_pod,
+                self.settings["build_namespace"],
+                label_selector="component=binderhub-build",
+            )
+        )
+
+        return await asyncio.gather(get_user_pods, get_build_pods)
+
+    async def get(self):
+        """Serve statistics about current usage and maximum capacity"""
+        user_pods, build_pods = await self._get_pods()
+
+        n_user_pods = len(user_pods.items)
+        n_build_pods = len(build_pods.items)
+
+        usage = {
+            "total_pods": n_user_pods + n_build_pods,
+            "build_pods": n_build_pods,
+            "user_pods": n_user_pods,
+        }
+        if "max_pod_capacity" in self.settings:
+            usage["max_capacity"] = self.settings["max_capacity"]
+
+        self.write(usage)

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -42,7 +42,7 @@ class MetricsHandler(BaseHandler):
         self.write(generate_latest(REGISTRY))
 
 
-class UsageHandler(BaseHandler):
+class PodQuotaHandler(BaseHandler):
     @at_most_every
     async def _get_pods(self):
         """Get information about build and user pods"""
@@ -80,7 +80,9 @@ class UsageHandler(BaseHandler):
             "build_pods": n_build_pods,
             "user_pods": n_user_pods,
         }
-        if "max_pod_capacity" in self.settings:
-            usage["max_capacity"] = self.settings["max_capacity"]
+
+        pod_quota = self.settings.get("pod_quota", None)
+        if pod_quota is not None:
+            usage["quota"] = pod_quota
 
         self.write(usage)

--- a/binderhub/metrics.py
+++ b/binderhub/metrics.py
@@ -79,10 +79,7 @@ class PodQuotaHandler(BaseHandler):
             "total_pods": n_user_pods + n_build_pods,
             "build_pods": n_build_pods,
             "user_pods": n_user_pods,
+            "quota": self.settings["pod_quota"],
         }
-
-        pod_quota = self.settings.get("pod_quota", None)
-        if pod_quota is not None:
-            usage["quota"] = pod_quota
 
         self.write(usage)

--- a/binderhub/tests/test_health.py
+++ b/binderhub/tests/test_health.py
@@ -7,7 +7,23 @@ async def test_basic_health(app):
     r = await async_requests.get(app.url + "/health")
 
     assert r.status_code == 200
-    assert r.json() == {
-        "ok": True,
-        "checks": [{"service": "JupyterHub API", "ok": True}],
-    }
+    results = r.json()
+
+    assert results["ok"]
+    assert "checks" in results
+
+    checks = results["checks"]
+
+    assert {"service": "JupyterHub API", "ok": True} in checks
+
+    # find the result of the quota check
+    quota_check = [c for c in checks if c["service"] == "Pod quota"][0]
+    assert quota_check
+    assert quota_check["quota"] is None
+    for key in ("build_pods", "total_pods", "user_pods"):
+        assert key in quota_check
+
+    assert (
+        quota_check["total_pods"]
+        == quota_check["build_pods"] + quota_check["user_pods"]
+    )


### PR DESCRIPTION
This adds a new endpoint `/_usage` that returns information about the number of build and user pods currently running and their sum.

It introduces a new config variable called `max_pod_capacity` that will be served to indicate the maximum capacity the cluster can handle. Currently this value isn't used to enforce an upper limit during launches, so it is more indicative.

The idea is to use information from this endpoint as part of the decision to send users to a cluster from the federation redirect. We could implement a strategy that sends users to the least full cluster (`total_pods/max_pod_capacity`) or considers clusters were `total_pods > max_pod_capacity` to be unavailable for more launches.

I am not super happy with the naming. Currently it is `/_usage` and the handler is `UsageHandler` but that somehow suggests that you get historical usage information as well. So maybe "load" is a better name, but then is that the load on the system or an endpoint where you can load something?

I used the `_` prefix in `_usage` to signal that this is somehow an "internal" endpoint.

closes #874

WDYT?