### PR TITLE
Add extraArgs to dind

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -41,6 +41,9 @@ spec:
           - dockerd
           - --storage-driver={{ .Values.dind.storageDriver }}
           - -H unix://{{ .Values.dind.hostSocketDir }}/docker.sock
+          {{- if .Values.dind.daemonset.extraArgs }}
+{{ toYaml .Values.dind.daemonset.extraArgs | indent 10 }}
+          {{- end }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -131,6 +131,8 @@ dind:
     image:
       name: docker
       tag: 18.09.2-dind
+    # Additional command line arguments to pass to dockerd
+    extraArgs: []
   storageDriver: overlay2
   resources: {}
   hostSocketDir: /var/run/dind


### PR DESCRIPTION
Allows to specify extra arguments to the docker daemon for dind. The list of args will be added to the `arguments` of the container without further processing.

Fixes #914 