### PR TITLE
adding help text loop to loading page

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -341,3 +341,35 @@ window.indexMain = indexMain;
 window.onload = function() {
   new Clipboard('.clipboard');
 };
+
+
+// Cycle through helpful messages on the loading page
+const help_messages = [
+  'New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information.',
+  'If a Binder takes a long time to launch, it is usually because Binder needs to pull the environment onto a computer for the first time.',
+  'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that anybody can deploy.',
+  'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide </a> that talks about what it is like to run a BinderHub.',
+  'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>.'
+]
+var text = document.querySelector("div#loader-links p.text-center")
+
+function updateLoaderText (msg) {
+  var text = document.querySelector("div#loader-links p.text-center")
+  text.innerHTML = msg;
+};
+
+function loopHelpText () {
+  if (text !== null) {
+    // Repeat looping through the list indefinitely
+    while (true) {
+      help_messages.forEach((msg) => {
+        // Wait 5 seconds, then update the text
+        setTimeout(() => {updateLoaderText(msg);}, 5000)
+      });
+    }
+  } else {
+    // Try again after a few seconds
+    setTimeout(loopHelpText, 2000);
+  }
+}
+loopHelpText();

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -19,6 +19,7 @@ import 'event-source-polyfill';
 import BinderImage from './src/image';
 import { markdownBadge, rstBadge } from './src/badge';
 import { getPathType, updatePathText } from './src/path';
+import { nextHelpText } from './src/loading';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';
@@ -330,6 +331,10 @@ function loadingMain(providerSpec) {
     }
   }
   build(providerSpec, log, path, pathType);
+
+  // Looping through help text every few seconds
+  setInterval(nextHelpText, 4000);
+
   return false;
 }
 
@@ -341,35 +346,3 @@ window.indexMain = indexMain;
 window.onload = function() {
   new Clipboard('.clipboard');
 };
-
-
-// Cycle through helpful messages on the loading page
-const help_messages = [
-  'New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information.',
-  'If a Binder takes a long time to launch, it is usually because Binder needs to pull the environment onto a computer for the first time.',
-  'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that anybody can deploy.',
-  'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide </a> that talks about what it is like to run a BinderHub.',
-  'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>.'
-]
-var text = document.querySelector("div#loader-links p.text-center")
-
-function updateLoaderText (msg) {
-  var text = document.querySelector("div#loader-links p.text-center")
-  text.innerHTML = msg;
-};
-
-function loopHelpText () {
-  if (text !== null) {
-    // Repeat looping through the list indefinitely
-    while (true) {
-      help_messages.forEach((msg) => {
-        // Wait 5 seconds, then update the text
-        setTimeout(() => {updateLoaderText(msg);}, 5000)
-      });
-    }
-  } else {
-    // Try again after a few seconds
-    setTimeout(loopHelpText, 2000);
-  }
-}
-loopHelpText();

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -149,15 +149,6 @@ function build(providerSpec, log, path, pathType) {
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
     $('div#loader-text p.launching').text("Starting repository: " + spec)
-    $('div#loader-text p.launch_info').text("Please be patient while your environment loads.")
-    
-    window.setTimeout(function() {
-      $('div#loader-text p.launch_info').html("Launch may take longer the first few times this environment has been run.")
-    }, usual_time);
-
-    window.setTimeout(function() {
-      $('div#loader-text p.launch_info').html("Your session is taking longer than usual to start! <a href='https://gitter.im/binder' target='_blank'>Reach out in the Gitter channel to debug</a>")
-    }, usual_time * 4);
   }
 
   $('#build-progress .progress-bar').addClass('hidden');
@@ -200,7 +191,6 @@ function build(providerSpec, log, path, pathType) {
     if ($('div#loader-text').length > 0) {
       $('#loader').addClass("error");
       $('div#loader-text p.launching').html('Error loading ' + spec + '!<br /> See logs below for details.');
-      $('div#loader-text p.launch_info').html("");
     }
     image.close();
   });
@@ -338,7 +328,15 @@ function loadingMain(providerSpec) {
   build(providerSpec, log, path, pathType);
 
   // Looping through help text every few seconds
-  setInterval(nextHelpText, 6000);
+  const launchMessageInterval = 6 * 1000
+  setInterval(nextHelpText, launchMessageInterval);
+
+  // If we have a long launch, add a class so we display a long launch msg
+  const launchTimeout = 120 * 1000
+  setTimeout(() => {
+    $('div#loader-links p.text-center').addClass("longLaunch");
+    nextHelpText();
+  }, launchTimeout)
 
   return false;
 }
@@ -346,6 +344,9 @@ function loadingMain(providerSpec) {
 // export entrypoints
 window.loadingMain = loadingMain;
 window.indexMain = indexMain;
+
+// Show the logs by default
+log.show();
 
 // Load the clipboard after the page loads so it can find the buttons it needs
 window.onload = function() {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -145,7 +145,6 @@ function build(providerSpec, log, path, pathType) {
   update_favicon(BASE_URL + "favicon_building.ico");
   // split provider prefix off of providerSpec
   var spec = providerSpec.slice(providerSpec.indexOf('/') + 1);
-  var usual_time = 20000;
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
     $('div#loader-text p.launching').text("Starting repository: " + spec)
@@ -344,9 +343,6 @@ function loadingMain(providerSpec) {
 // export entrypoints
 window.loadingMain = loadingMain;
 window.indexMain = indexMain;
-
-// Show the logs by default
-log.show();
 
 // Load the clipboard after the page loads so it can find the buttons it needs
 window.onload = function() {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -145,13 +145,19 @@ function build(providerSpec, log, path, pathType) {
   update_favicon(BASE_URL + "favicon_building.ico");
   // split provider prefix off of providerSpec
   var spec = providerSpec.slice(providerSpec.indexOf('/') + 1);
-
+  var usual_time = 20000;
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
-    $('div#loader-text p').text("Starting repository: " + spec);
+    $('div#loader-text p.launching').text("Starting repository: " + spec)
+    $('div#loader-text p.launch_info').text("Please be patient while your environment loads.")
+    
     window.setTimeout(function() {
-      $('div#loader-text p').html("Repository " + spec + " is taking longer than usual to start, hang tight!")
-    }, 17000);
+      $('div#loader-text p.launch_info').html("Launch may take longer the first few times this environment has been run.")
+    }, usual_time);
+
+    window.setTimeout(function() {
+      $('div#loader-text p.launch_info').html("Your session is taking longer than usual to start! <a href='https://gitter.im/binder' target='_blank'>Reach out in the Gitter channel to debug</a>")
+    }, usual_time * 4);
   }
 
   $('#build-progress .progress-bar').addClass('hidden');
@@ -187,15 +193,14 @@ function build(providerSpec, log, path, pathType) {
     $('#phase-failed').removeClass('hidden');
 
     $("#loader").addClass("paused");
-    $('div#loader-text p').html("Repository " + spec + " has failed to load!<br />See the logs for details.");
-    update_favicon(BASE_URL + "favicon_fail.ico");
-    // If we fail for any reason, we will show logs!
-    log.show();
 
-    // Show error on loading page
+    // If we fail for any reason, show an error message and logs
+    update_favicon(BASE_URL + "favicon_fail.ico");
+    log.show();
     if ($('div#loader-text').length > 0) {
       $('#loader').addClass("error");
-      $('div#loader-text p').html('Error loading ' + spec + '!<br /> See logs below for details.');
+      $('div#loader-text p.launching').html('Error loading ' + spec + '!<br /> See logs below for details.');
+      $('div#loader-text p.launch_info').html("");
     }
     image.close();
   });
@@ -333,7 +338,7 @@ function loadingMain(providerSpec) {
   build(providerSpec, log, path, pathType);
 
   // Looping through help text every few seconds
-  setInterval(nextHelpText, 4000);
+  setInterval(nextHelpText, 6000);
 
   return false;
 }

--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -17,7 +17,7 @@ export function nextHelpText () {
             // Pick a random help message and update
             var msg = help_messages[Math.floor(Math.random() * help_messages.length)];
         } else {
-            var msg = 'Your session is taking longer than usual to start!<br /><a href="https://gitter.im/binder" target="_blank">Reach out in the Gitter channel to debug</a>';
+            var msg = 'Your session is taking longer than usual to start!<br />Check the log messages below to see what is happening.';
         }
         text.html(msg);
     }

--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -4,14 +4,21 @@ const help_messages = [
     'If a Binder takes a long time to launch, it is usually because Binder needs to pull the environment onto a computer for the first time',
     'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that anybody can deploy',
     'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide </a> that talks about what it is like to run a BinderHub',
-    'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>'
-  ]
+    'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>',
+    'Your launch may take longer the first few times that this environment has been run. This is because the machine needs to load your environment.',
+    'You can learn more about building your own Binder repositories in <a target="_blank" href="https://docs.mybinder.org">the Binder community documentation</a>.'
+]
 
+// Set a launch timeout beyond-which we'll stop cycling messages
 export function nextHelpText () {
     var text = $('div#loader-links p.text-center');
     if (text !== null) {
-        // Pick a random help message and update
-        var msg = help_messages[Math.floor(Math.random() * help_messages.length)];
+        if (!text.hasClass('longLaunch')) {
+            // Pick a random help message and update
+            var msg = help_messages[Math.floor(Math.random() * help_messages.length)];
+        } else {
+            var msg = 'Your session is taking longer than usual to start!<br /><a href="https://gitter.im/binder" target="_blank">Reach out in the Gitter channel to debug</a>';
+        }
         text.html(msg);
     }
 }

--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -1,0 +1,17 @@
+// Cycle through helpful messages on the loading page
+const help_messages = [
+    'New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information',
+    'If a Binder takes a long time to launch, it is usually because Binder needs to pull the environment onto a computer for the first time',
+    'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that anybody can deploy',
+    'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide </a> that talks about what it is like to run a BinderHub',
+    'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>'
+  ]
+
+export function nextHelpText () {
+    var text = $('div#loader-links p.text-center');
+    if (text !== null) {
+        // Pick a random help message and update
+        var msg = help_messages[Math.floor(Math.random() * help_messages.length)];
+        text.html(msg);
+    }
+}

--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -81,6 +81,10 @@ https://ihatetomatoes.net for initial code templates.*/
     text-align: center;
 }
 
+#loader-links p {
+    font-size: 1.5em;
+}
+
 div#log-container {
     width: 80%;
     margin: 0% 10%;

--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -76,7 +76,7 @@ https://ihatetomatoes.net for initial code templates.*/
 }
 
 div#loader-text {
-    min-height: 9em;
+    min-height: 3em;
 }
 
 #loader-text p {
@@ -88,11 +88,6 @@ div#loader-text {
 
 #loader-text p.launching {
     font-size: 2em;
-    font-weight: bold;
-}
-
-#loader-text p.launch_info {
-    font-size: 1.8em;
 }
 
 div#loader-links {
@@ -100,7 +95,7 @@ div#loader-links {
 }
 
 #loader-links p {
-    font-size: 1.3em;
+    font-size: 1.5em;
     text-align: center;
     max-width:700px;
     margin: 0px auto 10px auto;

--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -83,6 +83,9 @@ https://ihatetomatoes.net for initial code templates.*/
 
 #loader-links p {
     font-size: 1.5em;
+    text-align: center;
+    max-width:700px;
+    margin: 0px auto 10px auto;
 }
 
 div#log-container {

--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -75,14 +75,32 @@ https://ihatetomatoes.net for initial code templates.*/
 	padding-top: 100px;
 }
 
+div#loader-text {
+    min-height: 9em;
+}
+
 #loader-text p {
-    font-size: 2em;
     z-index: 1002;
+    max-width: 750px;
     text-align: center;
+    margin: 0px auto 10px auto;
+}
+
+#loader-text p.launching {
+    font-size: 2em;
+    font-weight: bold;
+}
+
+#loader-text p.launch_info {
+    font-size: 1.8em;
+}
+
+div#loader-links {
+    min-height: 6em;
 }
 
 #loader-links p {
-    font-size: 1.5em;
+    font-size: 1.3em;
     text-align: center;
     max-width:700px;
     margin: 0px auto 10px auto;

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -23,7 +23,8 @@
 {% block main %}
 <div id="loader"></div>
 <div id="loader-text">
-	<p>Loading your Binder...</p>
+  <p class="launching">Launching your Binder...</p>
+  <p class="launch_info"></p>
 </div>
 <div id="loader-links">
   <p class="text-center">New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information</p>

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -24,7 +24,6 @@
 <div id="loader"></div>
 <div id="loader-text">
   <p class="launching">Launching your Binder...</p>
-  <p class="launch_info"></p>
 </div>
 <div id="loader-links">
   <p class="text-center">New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information</p>


### PR DESCRIPTION
This is a first pass at adding some helpful text that loops during the loading page. The goal is both to give users some information about what's currently happening, as well as to provide some interesting information about the project in general.

I think the list should never get *too* long - not sure exactly what that means, but this starts with a handful of messages to share with users as they wait. Over time, we can add and modify this.

Here's the text that will be updated in this PR. *Note, it is sped way up just to show the messages w/o having a 60 second long gif, the actual seconds between message change is currently 4*

![hFgF7l0CmF](https://user-images.githubusercontent.com/1839645/62645380-f13dab80-b900-11e9-9b1d-1ca67bb6658e.gif)

What do people think about this pattern for sharing information?