### PR TITLE
Fixes and tests for git unresolved ref support

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -206,7 +206,7 @@ class GitRepoProvider(RepoProvider):
         except ValueError:
             # The ref is a head/tag and we resolve it using `git ls-remote`
             command = ["git", "ls-remote", self.repo, self.unresolved_ref]
-            result = subprocess.run(command, text=True, stdout=subprocess.PIPE)
+            result = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE)
             if result.returncode:
                 raise RuntimeError("Unable to run git ls-remote to get the `resolved_ref`")
             if not result.stdout:

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -206,9 +206,9 @@ class GitRepoProvider(RepoProvider):
         except ValueError:
             # The ref is a head/tag and we resolve it using `git ls-remote`
             command = ["git", "ls-remote", self.repo, self.unresolved_ref]
-            result = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE)
+            result = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if result.returncode:
-                raise RuntimeError("Unable to run git ls-remote to get the `resolved_ref`")
+                raise RuntimeError("Unable to run git ls-remote to get the `resolved_ref`: {}".format(result.stderr))
             if not result.stdout:
                 raise ValueError("The specified branch, tag or commit SHA ('{}') was not found on the remote repository."
                                 .format(self.unresolved_ref))

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -18,6 +18,9 @@ from .utils import async_requests
     "git/{}/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd".format(
         quote("https://github.com/binderhub-ci-repos/requirements", safe='')
     ),
+    "git/{}/master".format(
+        quote("https://github.com/binderhub-ci-repos/requirements", safe='')
+    ),
     "gl/minrk%2Fbinderhub-ci/0d4a217d40660efaa58761d8c6084e7cf5453cca",
 ])
 @pytest.mark.remote

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -145,19 +145,27 @@ class TestSpecErrorHandling(TestCase):
             user, repo, unresolved_ref = tokenize_spec(spec)
 
 
-def test_git_ref():
+@pytest.mark.parametrize('url,unresolved_ref,resolved_ref', [
+    ['https://github.com/jupyterhub/zero-to-jupyterhub-k8s', 
+     'f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603',
+     'f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603'],
+    ['https://github.com/jupyterhub/zero-to-jupyterhub-k8s', 
+     '0.8.0',
+     'ada2170a2181ae1760d85eab74e5264d0c6bb67f']
+])
+def test_git_ref(url, unresolved_ref, resolved_ref):
     spec = '{}/{}'.format(
-        quote('https://github.com/jupyterhub/zero-to-jupyterhub-k8s', safe=''),
-        quote('f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603')
+        quote(url, safe=''),
+        quote(unresolved_ref)
     )
 
     provider = GitRepoProvider(spec=spec)
     slug = provider.get_build_slug()
-    assert slug == 'https://github.com/jupyterhub/zero-to-jupyterhub-k8s'
+    assert slug == slug
     full_url = provider.get_repo_url()
-    assert full_url == 'https://github.com/jupyterhub/zero-to-jupyterhub-k8s'
+    assert full_url == slug
     ref = IOLoop().run_sync(provider.get_resolved_ref)
-    assert ref == 'f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603'
+    assert ref == resolved_ref
 
 
 def test_gitlab_ref():

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -161,9 +161,9 @@ def test_git_ref(url, unresolved_ref, resolved_ref):
 
     provider = GitRepoProvider(spec=spec)
     slug = provider.get_build_slug()
-    assert slug == slug
+    assert slug == url
     full_url = provider.get_repo_url()
-    assert full_url == slug
+    assert full_url == url
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == resolved_ref
 


### PR DESCRIPTION
This MR is a follow-up of #895.
- It adds support for Python versions before 3.7 (fixes the issue currently on mybinder.org)
- Suppresses any errors of `git ls-remote` in the terminal
- Instead appends this error output to the Python error
- Adds tests for the new unresolved ref