### PR TITLE
[MRG] Automatically open the log while building a repository

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -172,6 +172,7 @@ function build(providerSpec, log, path, pathType) {
 
   image.onStateChange('building', function(oldState, newState, data) {
     $('#phase-building').removeClass('hidden');
+    log.show();
   });
 
   image.onStateChange('pushing', function(oldState, newState, data) {


### PR DESCRIPTION
Automatically open the log if we are building a repo. The goal is to make it obvious to people visiting a Binder for the first time that stuff is happening and progress is made when they have to wait a long time.