### PR TITLE
adding jupyterlab file paths for preview

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -64,8 +64,8 @@ class ParameterizedMainHandler(BaseHandler):
            
             # Check if we have a JupyterLab + file path, if so then use it for the filepath
             urlpath = self.get_argument('urlpath', '').lstrip('/')
-            if 'lab/tree/' in urlpath:
-                filepath = urlpath.split('lab/tree/')[-1]
+            if urlpath.startswith("lab") and "/tree/" in urlpath:
+                filepath = urlpath.split('tree/', 1)[-1]
             
             blob_or_tree = 'blob' if filepath else 'tree'
             nbviewer_url = f'{nbviewer_url}/{org}/{repo_name}/{blob_or_tree}/{ref}/{filepath}'

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -61,6 +61,12 @@ class ParameterizedMainHandler(BaseHandler):
             org, repo_name, ref = spec.split('/', 2)
             # NOTE: tornado unquotes query arguments too -> notebooks%2Findex.ipynb becomes notebooks/index.ipynb
             filepath = self.get_argument('filepath', '').lstrip('/')
+           
+            # Check if we have a JupyterLab + file path, if so then use it for the filepath
+            urlpath = self.get_argument('urlpath', '').lstrip('/')
+            if 'lab/tree/' in urlpath:
+                filepath = urlpath.split('lab/tree/')[-1]
+            
             blob_or_tree = 'blob' if filepath else 'tree'
             nbviewer_url = f'{nbviewer_url}/{org}/{repo_name}/{blob_or_tree}/{ref}/{filepath}'
         self.render_template(


### PR DESCRIPTION
closes #645 

I think that this should add support for JupyterLab paths in the nbviewer preview.

It is pretty simple, basically just adds a few lines to:

* Check whether `urlpath` is provided in the URL
* If so, check whether `lab/tree/` exists in the `urlpath`
* If so, set `filepath` to whatever is on the right side of `lab/tree/`.

I think this should work for at least vanilla jupyterlab paths. It might break in unpredicted ways if people start using jupyterlab but also other kinds of URL patterns, but we can beef up this function when we get to those situations.