### PR TITLE
[MRG] Try to resolve an image name to determine registry health

### DIFF
--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -122,18 +122,12 @@ class HealthHandler(BaseHandler):
     @retry
     async def check_docker_registry(self):
         """Check docker registry health"""
-        registry = self.settings["registry"].url
-
-        if not registry.endswith("/"):
-            registry += "/"
-
-        # docker registries don't have an explicit health check endpoint.
-        # Instead the recommendation is to query the "root" endpoint which
-        # should return a 401 status when everything is well
-        r = await AsyncHTTPClient().fetch(
-            registry, request_timeout=3, raise_error=False
+        registry = self.settings["registry"]
+        # we are only interested in getting a response from the registry, we
+        # don't care if the image actually exists or not
+        await registry.get_image_manifest(
+            self.settings["image_prefix"] + "some-image-name", "12345"
         )
-        return r.code in (200, 401)
 
     async def check_pod_quota(self):
         """Compare number of active pods to available quota"""


### PR DESCRIPTION
A docker registry doesn't have an explicit health endpoint. The recommendation I could find in the docker registry repo was to use the root end point and if it returns a 200 or 401 the registry is healthy. However for the OVH registry we frequently have the problem that we think the registry is healthy but we can't resolve images.