### PR TITLE
Make git_credentials configurable

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -103,6 +103,7 @@ class RepoProvider(LoggingConfigurable):
         help="""
         Credentials (if any) to pass to git when cloning.
         """,
+        config=True
     )
 
     def is_banned(self):


### PR DESCRIPTION
FIX #918
This is not a complete solution, as it only allows one credential to be used, but it does allow an arbitrary private repo to be used.