### PR TITLE
install jupyterhub 1.0.0 in binderhub image

### DIFF
--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,7 +1,7 @@
 pycurl==7.43.0.1
 tornado==5.0.*
 kubernetes==7.0.*
-jupyterhub==0.9.4
+jupyterhub==1.0.0
 jsonschema==2.6.0
 # Logging sinks to send eventlogging events to
 google-cloud-logging==1.8.*


### PR DESCRIPTION
I think this was forgotten when upgraded to jhub chart with jhub version 1.0.0.