### PR TITLE
[MRG] add "sticky builds" functionality

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -568,6 +568,7 @@ class BinderHub(Application):
             "build_image": self.build_image,
             'build_node_selector': self.build_node_selector,
             'build_pool': self.build_pool,
+            "sticky_builds": self.sticky_builds,
             'log_tail_lines': self.log_tail_lines,
             'pod_quota': self.pod_quota,
             'per_repo_quota': self.per_repo_quota,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -196,6 +196,19 @@ class BinderHub(Application):
         config=True,
     )
 
+    sticky_builds = Bool(
+        False,
+        help="""
+        Attempt to assign builds for the same repository to the same node.
+
+        In order to speed up re-builds of a repository all its builds will
+        be assigned to the same node in the cluster.
+
+        Note: This feature only works if you also enable docker-in-docker support.
+        """,
+        config=True,
+    )
+
     use_registry = Bool(
         True,
         help="""

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -12,6 +12,8 @@ from kubernetes import client, watch
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 
+from .utils import rendezvous_rank
+
 
 class Build:
     """Represents a build of a git repository into a docker image.
@@ -36,7 +38,7 @@ class Build:
     """
     def __init__(self, q, api, name, namespace, repo_url, ref, git_credentials, build_image,
                  image_name, push_secret, memory_limit, docker_host, node_selector,
-                 appendix='', log_tail_lines=100):
+                 appendix='', log_tail_lines=100, sticky_builds=False):
         self.q = q
         self.api = api
         self.repo_url = repo_url
@@ -55,6 +57,10 @@ class Build:
 
         self.stop_event = threading.Event()
         self.git_credentials = git_credentials
+
+        self.sticky_builds = sticky_builds
+
+        self._component_label = "binderhub-build"
 
     def get_cmd(self):
         """Get the cmd to run to build the image"""
@@ -144,8 +150,59 @@ class Build:
         """Put the current action item into the queue for execution."""
         self.main_loop.add_callback(self.q.put, {'kind': kind, 'payload': obj})
 
+    def get_affinity(self):
+        """Determine the affinity term for the build pod.
+
+        There are a total of two affinity strategies, which one is used depends
+        on how the BinderHub is configured.
+
+        In the default setup the affinity of each build pod is an "anti-affinity"
+        which causes pods to prefer to schedule on separate nodes.
+
+        In a setup with docker-in-docker pods for a particular repository
+        prefer to schedule on the same node in order to reuse the build cache
+        of previous builds.
+        """
+        dind_pods = self.api.list_namespaced_pod(
+            self.namespace,
+            label_selector="component=dind,app=binder",
+        )
+        if self.sticky_builds and dind_pods:
+            nodes = dict((item.spec.node_name, item.spec)
+                         for item in dind_pods.items)
+            ranked_nodes = rendezvous_rank(list(nodes.keys), self.repo_url)
+            best_node_name = ranked_nodes[0][1]
+            # we reuse the affinity term of the DIND pod instead of
+            # constructing our own. But we want a soft preference instead of
+            # a hard preference in case that node is full or has gone away
+            # in the meantime
+            affinity = nodes[best_node_name].spec.affinity
+            affinity.node_affinity.preferred_during_scheduling_ignored_during_execution = affinity.node_affinity.required_during_scheduling_ignored_during_execution
+            affinity.node_affinity.required_during_scheduling_ignored_during_execution = None
+
+        else:
+            affinity = client.V1Affinity(
+                pod_anti_affinity=client.V1PodAntiAffinity(
+                    preferred_during_scheduling_ignored_during_execution=[
+                        client.V1WeightedPodAffinityTerm(
+                            weight=100,
+                            pod_affinity_term=client.V1PodAffinityTerm(
+                                topology_key="kubernetes.io/hostname",
+                                label_selector=client.V1LabelSelector(
+                                    match_labels=dict(
+                                        component=self._component_label
+                                    )
+                                )
+                            )
+                        )
+                    ]
+                )
+            )
+
+        return affinity
+
     def submit(self):
-        """Submit a image spec to openshift's s2i and wait for completion """
+        """Submit a build pod to create the image for the repository."""
         volume_mounts = [
             client.V1VolumeMount(mount_path="/var/run/docker.sock", name="docker-socket")
         ]
@@ -166,13 +223,12 @@ class Build:
         if self.git_credentials:
             env.append(client.V1EnvVar(name='GIT_CREDENTIAL_ENV', value=self.git_credentials))
 
-        component_label = "binderhub-build"
         self.pod = client.V1Pod(
             metadata=client.V1ObjectMeta(
                 name=self.name,
                 labels={
                     "name": self.name,
-                    "component": component_label,
+                    "component": self._component_label,
                 },
                 annotations={
                     "binder-repo": self.repo_url,
@@ -211,23 +267,7 @@ class Build:
                 node_selector=self.node_selector,
                 volumes=volumes,
                 restart_policy="Never",
-                affinity=client.V1Affinity(
-                    pod_anti_affinity=client.V1PodAntiAffinity(
-                        preferred_during_scheduling_ignored_during_execution=[
-                            client.V1WeightedPodAffinityTerm(
-                                weight=100,
-                                pod_affinity_term=client.V1PodAffinityTerm(
-                                    topology_key="kubernetes.io/hostname",
-                                    label_selector=client.V1LabelSelector(
-                                        match_labels=dict(
-                                            component=component_label
-                                        )
-                                    )
-                                )
-                            )
-                        ]
-                    )
-                )
+                affinity=self.get_affinity()
             )
         )
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -167,6 +167,7 @@ class Build:
             self.namespace,
             label_selector="component=dind,app=binder",
         )
+
         if self.sticky_builds and dind_pods:
             node_names = [pod.spec.node_name for pod in dind_pods.items]
             ranked_nodes = rendezvous_rank(node_names, self.repo_url)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -340,7 +340,8 @@ class BuildHandler(BaseHandler):
             node_selector=self.settings['build_node_selector'],
             appendix=appendix,
             log_tail_lines=self.settings['log_tail_lines'],
-            git_credentials=provider.git_credentials
+            git_credentials=provider.git_credentials,
+            sticky_builds=self.settings['sticky_builds'],
         )
 
         with BUILDS_INPROGRESS.track_inprogress():

--- a/binderhub/tests/test_utils.py
+++ b/binderhub/tests/test_utils.py
@@ -6,20 +6,18 @@ def test_rendezvous_rank():
     # other buckets are removed
     key = "k1"
     first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
-    second_round = utils.rendezvous_rank([first_round[0][1], first_round[1][1]], key)
-
-    print(first_round)
+    second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)
 
     assert first_round[0] == second_round[0], key
 
     key = "sdsdggdddddd"
     first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
-    second_round = utils.rendezvous_rank([first_round[0][1], first_round[1][1]], key)
+    second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)
 
     assert first_round[0] == second_round[0], key
 
     key = "crazy frog is a crazy key"
     first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
-    second_round = utils.rendezvous_rank([first_round[0][1], first_round[1][1]], key)
+    second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)
 
     assert first_round[0] == second_round[0], key

--- a/binderhub/tests/test_utils.py
+++ b/binderhub/tests/test_utils.py
@@ -12,12 +12,45 @@ def test_rendezvous_rank():
 
 
 def test_rendezvous_independence():
-    # check that the relative ranking of two buckets doesn't depend on the
-    # presence of a third bucket
+    # check that the relative ranking of 80 buckets doesn't depend on the
+    # presence of 20 extra buckets
     key = "k1"
-    two_buckets = utils.rendezvous_rank(["b1", "b3"], key)
-    three_buckets = utils.rendezvous_rank(["b1", "b2", "b3"], key)
-    # remove "b2" and check ranking
-    three_buckets.remove("b2")
+    eighty_buckets = utils.rendezvous_rank(["b%i" % i for i in range(80)], key)
+    hundred_buckets = utils.rendezvous_rank(["b%i" % i for i in range(100)], key)
 
-    assert two_buckets == three_buckets
+    for i in range(80, 100):
+        hundred_buckets.remove("b%i" % i)
+
+    assert eighty_buckets == hundred_buckets
+
+
+def test_rendezvous_redistribution():
+    # check that approximately a third of keys move to the new bucket
+    # when one is added
+    n_keys = 3000
+
+    # counnt how many keys were moved and which bucket were they moved from
+    n_moved = 0
+    from_b1 = 0
+    from_b2 = 0
+
+    for i in range(n_keys):
+        key = f"key-{i}"
+        two_buckets = utils.rendezvous_rank(["b1", "b2"], key)
+        three_buckets = utils.rendezvous_rank(["b1", "b2", "b3"], key)
+
+        if two_buckets[0] != three_buckets[0]:
+            n_moved += 1
+            if two_buckets[0] == "b1":
+                from_b1 += 1
+            if two_buckets[0] == "b2":
+                from_b2 += 1
+            # should always move to the newly added bucket
+            assert three_buckets[0] == "b3"
+
+    # because of statistical fluctuations we have to leave some room when
+    # making this comparison
+    assert 0.31 < n_moved / n_keys < 0.35
+    # keys should move from the two original buckets with approximately
+    # equal probability
+    assert abs(from_b1 - from_b2) < 10

--- a/binderhub/tests/test_utils.py
+++ b/binderhub/tests/test_utils.py
@@ -52,9 +52,8 @@ def test_rendezvous_redistribution():
     # making this comparison
     assert 0.31 < n_moved / n_keys < 0.35
     # keys should move from the two original buckets with approximately
-    # equal probability
-    assert abs(from_bucket["b1"] - from_bucket["b2"]) < 10
-
-    # use the standard deviation of the expected number of entries in each
-    # bucket to get an idea for a reasonable (order of magnitude) difference
-    assert abs(start_in["b1"] - start_in["b2"]) < (n_keys/2)**0.5
+    # equal probability. We pick 30 because it is "about right"
+    assert abs(from_bucket["b1"] - from_bucket["b2"]) < 30
+    # the initial distribution of keys should be roughly the same
+    # We pick 30 because it is "about right"
+    assert abs(start_in["b1"] - start_in["b2"]) < 30

--- a/binderhub/tests/test_utils.py
+++ b/binderhub/tests/test_utils.py
@@ -1,0 +1,25 @@
+from binderhub import utils
+
+
+def test_rendezvous_rank():
+    # check that a key doesn't move if its assigned bucket remains but the
+    # other buckets are removed
+    key = "k1"
+    first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
+    second_round = utils.rendezvous_rank([first_round[0][1], first_round[1][1]], key)
+
+    print(first_round)
+
+    assert first_round[0] == second_round[0], key
+
+    key = "sdsdggdddddd"
+    first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
+    second_round = utils.rendezvous_rank([first_round[0][1], first_round[1][1]], key)
+
+    assert first_round[0] == second_round[0], key
+
+    key = "crazy frog is a crazy key"
+    first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
+    second_round = utils.rendezvous_rank([first_round[0][1], first_round[1][1]], key)
+
+    assert first_round[0] == second_round[0], key

--- a/binderhub/tests/test_utils.py
+++ b/binderhub/tests/test_utils.py
@@ -4,18 +4,6 @@ from binderhub import utils
 def test_rendezvous_rank():
     # check that a key doesn't move if its assigned bucket remains but the
     # other buckets are removed
-    key = "k1"
-    first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
-    second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)
-
-    assert first_round[0] == second_round[0], key
-
-    key = "sdsdggdddddd"
-    first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
-    second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)
-
-    assert first_round[0] == second_round[0], key
-
     key = "crazy frog is a crazy key"
     first_round = utils.rendezvous_rank(["b1", "b2", "b3"], key)
     second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)

--- a/binderhub/tests/test_utils.py
+++ b/binderhub/tests/test_utils.py
@@ -21,3 +21,15 @@ def test_rendezvous_rank():
     second_round = utils.rendezvous_rank([first_round[0], first_round[1]], key)
 
     assert first_round[0] == second_round[0], key
+
+
+def test_rendezvous_independence():
+    # check that the relative ranking of two buckets doesn't depend on the
+    # presence of a third bucket
+    key = "k1"
+    two_buckets = utils.rendezvous_rank(["b1", "b3"], key)
+    three_buckets = utils.rendezvous_rank(["b1", "b2", "b3"], key)
+    # remove "b2" and check ranking
+    three_buckets.remove("b2")
+
+    assert two_buckets == three_buckets

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -1,6 +1,35 @@
 """Miscellaneous utilities"""
 from collections import OrderedDict
+from hashlib import blake2b
+from math import log
+
 from traitlets import Integer, TraitError
+
+
+def blake2b_as_float(b):
+    """Compute Blake2 digest and convert it to a float.
+
+    Use this to create a float [0, 1) based on the Blake2 hash function.
+    """
+    return (
+        int.from_bytes(blake2b(b, digest_size=8).digest(), "big") / 0xFFFFFFFFFFFFFFFF
+    )
+
+
+def rendezvous_rank(buckets, key):
+    """Rank the buckets for a given key using Rendez-vous hashing
+
+    Each bucket is scored for the key and the best match is assigned the
+    highest score. The return value is a list of tuples of (score, bucket),
+    sorted in decreasing order.
+    """
+    ranking = []
+    for bucket in buckets:
+        h = blake2b_as_float(b"%s-%s" % (str(key).encode(), str(bucket).encode()))
+        score = 1 / -log(h)
+        ranking.append((score, bucket))
+
+    return sorted(ranking, reverse=True)
 
 
 class ByteSpecification(Integer):
@@ -17,10 +46,10 @@ class ByteSpecification(Integer):
     """
 
     UNIT_SUFFIXES = {
-        'K': 1024,
-        'M': 1024 * 1024,
-        'G': 1024 * 1024 * 1024,
-        'T': 1024 * 1024 * 1024 * 1024,
+        "K": 1024,
+        "M": 1024 * 1024,
+        "G": 1024 * 1024 * 1024,
+        "T": 1024 * 1024 * 1024 * 1024,
     }
 
     # Default to allowing None as a value
@@ -40,16 +69,25 @@ class ByteSpecification(Integer):
         try:
             num = float(value[:-1])
         except ValueError:
-            raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
+            raise TraitError(
+                "{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T".format(
+                    val=value
+                )
+            )
         suffix = value[-1]
         if suffix not in self.UNIT_SUFFIXES:
-            raise TraitError('{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T'.format(val=value))
+            raise TraitError(
+                "{val} is not a valid memory specification. Must be an int or a string with suffix K, M, G, T".format(
+                    val=value
+                )
+            )
         else:
             return int(float(num) * self.UNIT_SUFFIXES[suffix])
 
 
 class Cache(OrderedDict):
     """Basic LRU Cache with get/set"""
+
     def __init__(self, max_size=1024):
         self.max_size = max_size
 
@@ -83,17 +121,17 @@ def url_path_join(*pieces):
 
     Copied from `notebook.utils.url_path_join`.
     """
-    initial = pieces[0].startswith('/')
-    final = pieces[-1].endswith('/')
-    stripped = [ s.strip('/') for s in pieces ]
-    result = '/'.join(s for s in stripped if s)
+    initial = pieces[0].startswith("/")
+    final = pieces[-1].endswith("/")
+    stripped = [s.strip("/") for s in pieces]
+    result = "/".join(s for s in stripped if s)
 
     if initial:
-        result = '/' + result
+        result = "/" + result
     if final:
-        result = result + '/'
-    if result == '//':
-        result = '/'
+        result = result + "/"
+    if result == "//":
+        result = "/"
 
     return result
 

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -5,7 +5,7 @@ from hashlib import blake2b
 from traitlets import Integer, TraitError
 
 
-def blake2b_as_int(b):
+def blake2b_hash_as_int(b):
     """Compute digest of the bytes `b` using the Blake2 hash function.
 
     Returns a unsigned 64bit integer.
@@ -21,7 +21,12 @@ def rendezvous_rank(buckets, key):
     """
     ranking = []
     for bucket in buckets:
-        score = blake2b_as_int(b"%s-%s" % (str(key).encode(), str(bucket).encode()))
+        # The particular hash function doesn't matter a lot, as long as it is
+        # one that maps the key to a fixed sized value and distributes the keys
+        # uniformly across the output space
+        score = blake2b_hash_as_int(
+            b"%s-%s" % (str(key).encode(), str(bucket).encode())
+        )
         ranking.append((score, bucket))
 
     return [b for (s, b) in sorted(ranking, reverse=True)]

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -1,35 +1,30 @@
 """Miscellaneous utilities"""
 from collections import OrderedDict
 from hashlib import blake2b
-from math import log
 
 from traitlets import Integer, TraitError
 
 
-def blake2b_as_float(b):
-    """Compute Blake2 digest and convert it to a float.
+def blake2b_as_int(b):
+    """Compute digest of the bytes `b` using the Blake2 hash function.
 
-    Use this to create a float [0, 1) based on the Blake2 hash function.
+    Returns a unsigned 64bit integer.
     """
-    return (
-        int.from_bytes(blake2b(b, digest_size=8).digest(), "big") / 0xFFFFFFFFFFFFFFFF
-    )
+    return int.from_bytes(blake2b(b, digest_size=8).digest(), "big")
 
 
 def rendezvous_rank(buckets, key):
     """Rank the buckets for a given key using Rendez-vous hashing
 
-    Each bucket is scored for the key and the best match is assigned the
-    highest score. The return value is a list of tuples of (score, bucket),
-    sorted in decreasing order.
+    Each bucket is scored for the specified key. The return value is a list of
+    all buckets, sorted in decreasing order (highest ranked first).
     """
     ranking = []
     for bucket in buckets:
-        h = blake2b_as_float(b"%s-%s" % (str(key).encode(), str(bucket).encode()))
-        score = 1 / -log(h)
+        score = blake2b_as_int(b"%s-%s" % (str(key).encode(), str(bucket).encode()))
         ranking.append((score, bucket))
 
-    return sorted(ranking, reverse=True)
+    return [b for (s, b) in sorted(ranking, reverse=True)]
 
 
 class ByteSpecification(Integer):


### PR DESCRIPTION
The ranking is computed using the Rendez-vous hashing algorithm.

In the abstract this can be used for all sorts of stateless ranking, however this PR is part of https://github.com/jupyterhub/binderhub/issues/946#issuecomment-529778393 and provides a method for ranking possible nodes to schedule build pods on.

The goal is to eventually have a setup where `rendezvous_rank()` is called just before submitting the build pod spec to compute a preferred node for the pod:

```python
ranking = rendezvous_rank(['node1', 'node2', 'node3'], 'https://github.com/org/repo')
# now attach ranking[0][1] as the preferred node affinity to the build pod
```

Let me know what you think of building this in small PRs. I'd propose to review and merge this without having to build out the rest.