### PR TITLE
[MRG] Add Figshare to UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ helm-chart/travis-binder.yaml
 
 # Federation data page
 doc/federation/data-federation.txt
+.vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ every day development.
 
 * Start and stop minikube with `minikube start` and `minikube stop`.
 * Install JupyterHub in minikube with helm `./testing/minikube/install-hub`
-* Setup docker to use the same docker daemon as your minikube cluster `eval $(minikube docker-env)`
+* Setup `docker` to use the same Docker daemon as your minikube cluster `eval $(minikube docker-env)`
 * Start BinderHub `python3 -m binderhub -f testing/minikube/binderhub_config.py`
 * Visit your BinderHub at[http://localhost:8585](http://localhost:8585)
 
@@ -209,7 +209,7 @@ sudo apt install socat
    eval $(minikube docker-env)
    ```
 
-  This command sets up docker to use the same docker daemon as your minikube
+  This command sets up `docker` to use the same Docker daemon as your minikube
   cluster does. This means images you build are directly available to the
   cluster. Note: when you no longer wish to use the minikube host, you can
   undo this change by running:
@@ -228,6 +228,26 @@ sudo apt install socat
 
 All features should work, including building and launching of repositories.
 
+
+### Tip: Use local repo2docker version
+
+BinderHub runs repo2docker in a container.
+For testing the combination of an unreleased repo2docker feature with BinderHub, you can use a locally build repo2docker image.
+You can configure the image in the file `testing/minikube/binderhub_config.py` with the following line:
+
+```python
+c.BinderHub.build_image = 'jupyter-repo2docker:my_image_tag'
+```
+
+**Important**: the image must be build using the same Docker daemon as the minikube cluster, otherwise you get an error _"Failed to pull image [...]  repository does not exist or may require 'docker login'"_.
+
+### Tip: Enable debug logging
+
+In the file `testing/minikube/binderhub_config.py` add the following line:
+
+```python
+c.BinderHub.debug = True
+```
 
 ### Tip: Increase your GitHub API limit
 

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -33,7 +33,7 @@ from .registry import DockerRegistry
 from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
 from .repoproviders import (GitHubRepoProvider, GitRepoProvider,
                             GitLabRepoProvider, GistRepoProvider,
-                            ZenodoProvider)
+                            ZenodoProvider, FigshareProvider)
 from .metrics import MetricsHandler
 
 from .utils import ByteSpecification, url_path_join
@@ -379,6 +379,7 @@ class BinderHub(Application):
             'git': GitRepoProvider,
             'gl': GitLabRepoProvider,
             'zenodo': ZenodoProvider,
+            'figshare': FigshareProvider,
         },
         config=True,
         help="""

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -11,7 +11,8 @@
                 "Gist",
                 "GitLab",
                 "Git",
-                "Zenodo"
+                "Zenodo",
+                "Figshare"
             ],
             "description": "Provider for the repository being launched"
         },

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -15,7 +15,8 @@ SPEC_NAMES = {
     "gist": "Gist",
     "gl": "GitLab",
     "git": "Git repo",
-    "zenodo": "Zenodo"
+    "zenodo": "Zenodo",
+    "figshare": "Figshare"
 }
 
 

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -84,6 +84,11 @@ function updateRepoText() {
     $("#ref").prop("disabled", true);
     $("label[for=ref]").prop("disabled", true);
   }
+  else if (provider === "figshare") {
+    text = "Figshare DOI (10.6084/m9.figshare.9782777.v1)";
+    $("#ref").prop("disabled", true);
+    $("label[for=ref]").prop("disabled", true);
+  }
   $("#repository").attr('placeholder', text);
   $("label[for=repository]").text(text);
   $("#ref").attr('placeholder', tag_text);
@@ -107,7 +112,7 @@ function getBuildFormValues() {
   }
 
   var ref = $('#ref').val().trim() || 'master';
-  if (providerPrefix === 'zenodo') {
+  if (providerPrefix === 'zenodo' || providerPrefix === 'figshare') {
     ref = "";
   }
   var path = $('#filepath').val().trim();

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -55,6 +55,7 @@
                 <li class="dropdown-item" value="gl"><a href="#">GitLab.com</a></li>
                 <li class="dropdown-item" value="git"><a href="#">Git repository</a></li>
                 <li class="dropdown-item" value="zenodo"><a href="#">Zenodo DOI</a></li>
+                <li class="dropdown-item" value="figshare"><a href="#">Figshare DOI</a></li>
               </ul>
             </div>
           </div>

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -6,7 +6,7 @@ from tornado.ioloop import IOLoop
 
 from binderhub.repoproviders import (
     tokenize_spec, strip_suffix, GitHubRepoProvider, GitRepoProvider,
-    GitLabRepoProvider, GistRepoProvider, ZenodoProvider
+    GitLabRepoProvider, GistRepoProvider, ZenodoProvider, FigshareProvider
 )
 
 
@@ -48,6 +48,21 @@ async def test_zenodo():
 
     slug = provider.get_build_slug()
     assert slug == 'zenodo-3242074'
+    repo_url = provider.get_repo_url()
+    assert repo_url == spec
+
+
+async def test_figshare():
+    spec = '10.6084/m9.figshare.9782777.v1'
+
+    provider = FigshareProvider(spec=spec)
+
+    # have to resolve the ref first
+    ref = await provider.get_resolved_ref()
+    assert ref == '9782777.v1'
+
+    slug = provider.get_build_slug()
+    assert slug == 'figshare-9782777.v1'
     repo_url = provider.get_repo_url()
     assert repo_url == spec
 


### PR DESCRIPTION
! This depends on an unreleased version of repo2docker !

This closes #938.

But it's not ready yet :-) Just would like to get some feedback :-), and need help:

With the UI, I get a `/master` at the end of the URL that I don't want:

![image](https://user-images.githubusercontent.com/1325054/64779209-c24cd200-d55d-11e9-8241-75d1c1eac630.png)

`http://localhost:8585/v2/figshare/10.6084/m9.figshare.9782777.v1/master`

Where does that get added? I can't find it :-/.

OTOH, the local test URL without `/master`

http://localhost:8585/v2/figshare/10.6084/m9.figshare.9782777.v2

gives me "Waiting for build to start" and in the logs there is just 

```
[..]
[D 190912 13:05:18 build:94] 2 build pods
[D 190912 13:05:18 build:141] Build phase summary: {
     "Pending": 2
    }
```

For several minutes now... shouldn't there be more logs?

-------

### Related questions

- With
```bash
python3 -m pip install -e .
./testing/minikube/install-hub
```
I should have the latest code running in my local kube, right?
- _Is it worth writing down in the docs all the places where something has to be added for a new provider?_ Though this list might be outdated with a new UI:
  - `binderhub/main.py`
    - `SPEC_NAMES`
    - `from .repoproviders import `
  - `repo_providers = Dict(`
  - `binderhub/event-schemas/launch.json` (though unsure what that is for)
  - `binderhub/repoproviders.py` the actual `class FigshareProvider(RepoProvider):`
  - `binderhub/static/js/index.js` the example text
  - `binderhub/templates/index.html` the item in the dropdown
- Have you considered generating some bits, e.g.  build `repro_providers` at runtime by asking all the imported instances of `RepoProvidder` how they want to be added to that list ?
- Is it worth attempting to generate the UI parts from a service endpoint for the next ()?
- Is is possible to run the BinderHub outside of Kubernetes to debug the code?