### PR TITLE
added  Authorization header if access_token provided

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -435,13 +435,13 @@ class GitHubRepoProvider(RepoProvider):
     auth = Dict(
         help="""Auth parameters for the GitHub API access
 
-        Populated from client_id, client_secret, access_token.
+        Populated from client_id, client_secret.
     """
     )
     @default('auth')
     def _default_auth(self):
         auth = {}
-        for key in ('client_id', 'client_secret', 'access_token'):
+        for key in ('client_id', 'client_secret'):
             value = getattr(self, key)
             if value:
                 auth[key] = value
@@ -477,6 +477,10 @@ class GitHubRepoProvider(RepoProvider):
             api_url = url_concat(api_url, self.auth)
 
         headers = {}
+        # based on: https://developer.github.com/v3/#oauth2-token-sent-in-a-header
+        if self.access_token:
+            headers['Authorization'] = "token {token}".format(token=self.access_token)
+
         if etag:
             headers['If-None-Match'] = etag
         req = HTTPRequest(api_url, headers=headers, user_agent="BinderHub")


### PR DESCRIPTION
This fixes issue https://github.com/jupyterhub/binderhub/issues/952 by adding an `Authorization: token <access_token>` header to Github API requests from Binderhub if access_token is passed by either `binderhub_config.py` or `GithubRepoProvider` in `secret.yaml`.