### PR TITLE
Add support for storing build images in gitlab registries

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -271,7 +271,7 @@ class BuildHandler(BaseHandler):
         ).replace('_', '-').lower()
 
         if self.settings['use_registry']:
-            image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
+            image_manifest = await self.registry.get_image_manifest(*image_name.split(':', 1))
             image_found = bool(image_manifest)
         else:
             # Check if the image exists locally!


### PR DESCRIPTION
Add support for gitlab token_url requests and accept gitlab registry structures, where any number of levels in the image name is possible.

Example:
binder/images/build-<slug>:tag

Where binder is the group, images the project and the rest the image name and tag in the 'images' registry. Subgroups can be added creating additional path levels. The previous logic assumed two levels only, which matches the docker.io behavior.

This change implies the image_prefix will *only* contain the image name, not a repo dns name. So 'rochaporto/myimage' is ok, but not 'docker.io/rochaporto/myimage'. If needed i could look into some additional logic for this, but given urllib.parse expects a scheme it won't be direct.

 Fixes #965 