### PR TITLE
Zenodo, Figshare: return doi url instead of spec

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -235,9 +235,7 @@ class ZenodoProvider(RepoProvider):
         return resolved_spec
 
     def get_repo_url(self):
-        # While called repo URL, the return value of this function is passed
-        # as argument to repo2docker, hence we return the spec as is.
-        return self.spec
+        return f"https://doi.org/{self.spec}"
 
     async def get_resolved_ref_url(self):
         resolved_spec = await self.get_resolved_spec()
@@ -282,9 +280,7 @@ class FigshareProvider(RepoProvider):
         return resolved_spec
 
     def get_repo_url(self):
-        # While called repo URL, the return value of this function is passed
-        # as argument to repo2docker, hence we return the spec as is.
-        return self.spec
+        return f"https://doi.org/{self.spec}"
 
     async def get_resolved_ref_url(self):
         resolved_spec = await self.get_resolved_spec()
@@ -339,7 +335,7 @@ class GitRepoProvider(RepoProvider):
                                 .format(self.unresolved_ref))
             resolved_ref = result.stdout.split(None, 1)[0]
             self.sha1_validate(resolved_ref)
-            self.resolved_ref = resolved_ref 
+            self.resolved_ref = resolved_ref
         else:
             # The ref already was a valid SHA hash
             self.resolved_ref = self.unresolved_ref

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -37,8 +37,9 @@ def test_spec_processing(spec, raw_user, raw_repo, raw_ref):
     assert raw_ref == unresolved_ref
 
 
-@pytest.mark.parametrize('spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
+@pytest.mark.parametrize('spec,repo,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
     ['10.5281/zenodo.3242074',
+     'https://doi.org/10.5281/zenodo.3242074',
      '10.5281/zenodo.3242074',
      '3242074',
      'https://doi.org/10.5281/zenodo.3242074',
@@ -46,12 +47,13 @@ def test_spec_processing(spec, raw_user, raw_repo, raw_ref):
     # 10.5281/zenodo.3242073 -> This DOI represents all versions, and will always resolve to the latest one
     # for now it is 3242074
     ['10.5281/zenodo.3242073',
+     'https://doi.org/10.5281/zenodo.3242073',
      '10.5281/zenodo.3242074',
      '3242074',
      'https://doi.org/10.5281/zenodo.3242074',
      'zenodo-3242074'],
 ])
-async def test_zenodo(spec, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
+async def test_zenodo(spec, repo, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
     provider = ZenodoProvider(spec=spec)
 
     # have to resolve the ref first
@@ -61,27 +63,29 @@ async def test_zenodo(spec, resolved_spec, resolved_ref, resolved_ref_url, build
     slug = provider.get_build_slug()
     assert slug == build_slug
     repo_url = provider.get_repo_url()
-    assert repo_url == spec
+    assert repo_url == repo
     ref_url = await provider.get_resolved_ref_url()
     assert ref_url == resolved_ref_url
     spec = await provider.get_resolved_spec()
     assert spec == resolved_spec
 
 
-@pytest.mark.parametrize('spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
+@pytest.mark.parametrize('spec,repo,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
     ['10.6084/m9.figshare.9782777.v1',
+     'https://doi.org/10.6084/m9.figshare.9782777.v1',
      '10.6084/m9.figshare.9782777.v1',
      '9782777.v1',
      'https://doi.org/10.6084/m9.figshare.9782777.v1',
      'figshare-9782777.v1'],
     # spec without version is accepted as version 1 - check FigshareProvider.get_resolved_ref()
     ['10.6084/m9.figshare.9782777',
+     'https://doi.org/10.6084/m9.figshare.9782777',
      '10.6084/m9.figshare.9782777.v1',
      '9782777.v1',
      'https://doi.org/10.6084/m9.figshare.9782777.v1',
      'figshare-9782777.v1'],
 ])
-async def test_figshare(spec, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
+async def test_figshare(spec, repo, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
     provider = FigshareProvider(spec=spec)
 
     # have to resolve the ref first
@@ -91,7 +95,7 @@ async def test_figshare(spec, resolved_spec, resolved_ref, resolved_ref_url, bui
     slug = provider.get_build_slug()
     assert slug == build_slug
     repo_url = provider.get_repo_url()
-    assert repo_url == spec
+    assert repo_url == repo
     ref_url = await provider.get_resolved_ref_url()
     assert ref_url == resolved_ref_url
     spec = await provider.get_resolved_spec()


### PR DESCRIPTION
Zenodo and Figshare providers returns spec (DOI) when `get_repo_url` is called. As much as I understand from the comment this is done because repo url is passed to repo2docker. But this is passed not only to repo2docker but also to appendix. And when I check the repo2docker tests ([zenodo](https://github.com/jupyter/repo2docker/blob/master/tests/unit/contentproviders/test_zenodo.py) and [figshare](https://github.com/jupyter/repo2docker/blob/master/tests/unit/contentproviders/test_figshare.py)), repo2docker also works with doi.org urls. In this PR I updated `get_repo_url` methods of zenodo and figshare, so they return doi.org url which is a real url, not a spec.