### PR TITLE
ref_url and resolved_spec methods for repo providers

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -313,16 +313,18 @@ class BuildHandler(BaseHandler):
             push_secret = None
 
         BuildClass = FakeBuild if self.settings.get('fake_build') else Build
-        binder_url = '{proto}://{host}{base_url}v2/{provider}/{spec}'.format(
-            proto=self.request.protocol,
-            host=self.request.host,
-            base_url=self.settings['base_url'],
-            provider=provider_prefix,
-            spec=spec,
-        )
+
+        binder_url = f"{self.request.protocol}://{self.request.host}{self.settings['base_url']}v2/" \
+                     f"{provider_prefix}/{spec}"
+        resolved_spec = await provider.get_resolved_spec()
+        persistent_binder_url = f"{self.request.protocol}://{self.request.host}{self.settings['base_url']}v2/" \
+                                f"{provider_prefix}/{resolved_spec}"
+        ref_url = await provider.get_ref_url()
         appendix = self.settings['appendix'].format(
             binder_url=binder_url,
             repo_url=repo_url,
+            persistent_binder_url=persistent_binder_url,
+            ref_url=ref_url,
         )
 
         self.build = build = BuildClass(

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -319,7 +319,7 @@ class BuildHandler(BaseHandler):
         resolved_spec = await provider.get_resolved_spec()
         persistent_binder_url = f"{self.request.protocol}://{self.request.host}{self.settings['base_url']}v2/" \
                                 f"{provider_prefix}/{resolved_spec}"
-        ref_url = await provider.get_ref_url()
+        ref_url = await provider.get_resolved_ref_url()
         appendix = self.settings['appendix'].format(
             binder_url=binder_url,
             repo_url=repo_url,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -314,11 +314,21 @@ class BuildHandler(BaseHandler):
 
         BuildClass = FakeBuild if self.settings.get('fake_build') else Build
 
-        binder_url = f"{self.request.protocol}://{self.request.host}{self.settings['base_url']}v2/" \
-                     f"{provider_prefix}/{spec}"
+        binder_url = '{proto}://{host}{base_url}v2/{provider}/{spec}'.format(
+            proto=self.request.protocol,
+            host=self.request.host,
+            base_url=self.settings['base_url'],
+            provider=provider_prefix,
+            spec=spec,
+        )
         resolved_spec = await provider.get_resolved_spec()
-        persistent_binder_url = f"{self.request.protocol}://{self.request.host}{self.settings['base_url']}v2/" \
-                                f"{provider_prefix}/{resolved_spec}"
+        persistent_binder_url = '{proto}://{host}{base_url}v2/{provider}/{spec}'.format(
+            proto=self.request.protocol,
+            host=self.request.host,
+            base_url=self.settings['base_url'],
+            provider=provider_prefix,
+            spec=resolved_spec,
+        )
         ref_url = await provider.get_resolved_ref_url()
         appendix = self.settings['appendix'].format(
             binder_url=binder_url,

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -227,9 +227,10 @@ class ZenodoProvider(RepoProvider):
     async def get_resolved_spec(self):
         if not hasattr(self, 'record_id'):
             self.record_id = await self.get_resolved_ref()
-        # zenodo registers a DOI which represents all versions.
+        # zenodo registers a DOI which represents all versions of a software package
         # and it always resolves to latest version
-        # for that case, we have to replace it with record id
+        # for that case, we have to replace the version number in DOIs with
+        # the specific (resolved) version (record_id)
         resolved_spec = self.spec.split("zenodo")[0] + "zenodo." + self.record_id
         return resolved_spec
 
@@ -275,7 +276,8 @@ class FigshareProvider(RepoProvider):
             self.record_id = await self.get_resolved_ref()
 
         # spec without version is accepted as version 1 - check get_resolved_ref method
-        # so we first strip article id and version and add it again
+        # for that case, we have to replace the version number in DOIs with
+        # the specific (resolved) version (record_id)
         resolved_spec = self.spec.split("figshare")[0] + "figshare." + self.record_id
         return resolved_spec
 

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -272,7 +272,13 @@ class FigshareProvider(RepoProvider):
         return self.spec
 
     async def get_resolved_ref_url(self):
-        return f"https://doi.org/{self.spec}"
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+
+        # spec without version is accepted as version 1 - check get_resolved_ref method
+        # so we first strip article id and version and add it again
+        spec = self.spec.rstrip(self.resolved_ref) + "." + self.resolved_ref
+        return f"https://doi.org/{spec}"
 
     def get_build_slug(self):
         return "figshare-{}".format(self.record_id)

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -225,7 +225,10 @@ class ZenodoProvider(RepoProvider):
         return self.record_id
 
     async def get_resolved_spec(self):
-        return self.spec
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        resolved_spec = self.spec.split("zenodo")[0] + "zenodo." + self.resolved_ref
+        return resolved_spec
 
     def get_repo_url(self):
         # While called repo URL, the return value of this function is passed
@@ -233,7 +236,8 @@ class ZenodoProvider(RepoProvider):
         return self.spec
 
     async def get_resolved_ref_url(self):
-        return f"https://doi.org/{self.spec}"
+        resolved_spec = await self.get_resolved_spec()
+        return f"https://doi.org/{resolved_spec}"
 
     def get_build_slug(self):
         return "zenodo-{}".format(self.record_id)
@@ -264,7 +268,13 @@ class FigshareProvider(RepoProvider):
         return self.record_id
 
     async def get_resolved_spec(self):
-        return self.spec
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+
+        # spec without version is accepted as version 1 - check get_resolved_ref method
+        # so we first strip article id and version and add it again
+        resolved_spec = self.spec.split("figshare")[0] + "figshare." + self.resolved_ref
+        return resolved_spec
 
     def get_repo_url(self):
         # While called repo URL, the return value of this function is passed
@@ -272,13 +282,8 @@ class FigshareProvider(RepoProvider):
         return self.spec
 
     async def get_resolved_ref_url(self):
-        if not hasattr(self, 'resolved_ref'):
-            self.resolved_ref = await self.get_resolved_ref()
-
-        # spec without version is accepted as version 1 - check get_resolved_ref method
-        # so we first strip article id and version and add it again
-        spec = self.spec.rstrip(self.resolved_ref) + "." + self.resolved_ref
-        return f"https://doi.org/{spec}"
+        resolved_spec = await self.get_resolved_spec()
+        return f"https://doi.org/{resolved_spec}"
 
     def get_build_slug(self):
         return "figshare-{}".format(self.record_id)

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -174,7 +174,7 @@ class RepoProvider(LoggingConfigurable):
         raise NotImplementedError("Must be overridden in the child class")
 
     @gen.coroutine
-    def get_ref_url(self):
+    def get_resolved_ref_url(self):
         """Return the URL of repository at this commit in history"""
         raise NotImplementedError("Must be overridden in child class")
 
@@ -201,7 +201,7 @@ class FakeProvider(RepoProvider):
     def get_repo_url(self):
         return "https://example.com/fake/repo.git"
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         return "https://example.com/fake/repo/tree/1a2b3c4d5e6f"
 
     def get_build_slug(self):
@@ -232,7 +232,7 @@ class ZenodoProvider(RepoProvider):
         # as argument to repo2docker, hence we return the spec as is.
         return self.spec
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         return f"https://doi.org/{self.spec}"
 
     def get_build_slug(self):
@@ -271,7 +271,7 @@ class FigshareProvider(RepoProvider):
         # as argument to repo2docker, hence we return the spec as is.
         return self.spec
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         return f"https://doi.org/{self.spec}"
 
     def get_build_slug(self):
@@ -338,7 +338,7 @@ class GitRepoProvider(RepoProvider):
     def get_repo_url(self):
         return self.repo
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         # not possible to construct ref url of unknown git provider
         return self.get_repo_url()
 
@@ -459,7 +459,7 @@ class GitLabRepoProvider(RepoProvider):
     def get_repo_url(self):
         return f"https://{self.hostname}/{self.namespace}.git"
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         if not hasattr(self, 'resolved_ref'):
             self.resolved_ref = await self.get_resolved_ref()
         return f"https://{self.hostname}/{self.namespace}/tree/{self.resolved_ref}"
@@ -548,7 +548,7 @@ class GitHubRepoProvider(RepoProvider):
     def get_repo_url(self):
         return f"https://{self.hostname}/{self.user}/{self.repo}"
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         if not hasattr(self, 'resolved_ref'):
             self.resolved_ref = await self.get_resolved_ref()
         return f"https://{self.hostname}/{self.user}/{self.repo}/tree/{self.resolved_ref}"
@@ -715,7 +715,7 @@ class GistRepoProvider(GitHubRepoProvider):
     def get_repo_url(self):
         return f'https://{self.hostname}/{self.user}/{self.gist_id}.git'
 
-    async def get_ref_url(self):
+    async def get_resolved_ref_url(self):
         if not hasattr(self, 'resolved_ref'):
             self.resolved_ref = await self.get_resolved_ref()
         return f'https://{self.hostname}/{self.user}/{self.gist_id}/{self.resolved_ref}'

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -164,9 +164,19 @@ class RepoProvider(LoggingConfigurable):
     def get_resolved_ref(self):
         raise NotImplementedError("Must be overridden in child class")
 
+    @gen.coroutine
+    def get_resolved_spec(self):
+        """Return the spec with resolved ref."""
+        raise NotImplementedError("Must be overridden in child class")
+
     def get_repo_url(self):
         """Return the git clone-able repo URL"""
         raise NotImplementedError("Must be overridden in the child class")
+
+    @gen.coroutine
+    def get_ref_url(self):
+        """Return the URL of repository at this commit in history"""
+        raise NotImplementedError("Must be overridden in child class")
 
     def get_build_slug(self):
         """Return a unique build slug"""
@@ -185,8 +195,14 @@ class FakeProvider(RepoProvider):
     async def get_resolved_ref(self):
         return "1a2b3c4d5e6f"
 
+    async def get_resolved_spec(self):
+        return "fake/repo/1a2b3c4d5e6f"
+
     def get_repo_url(self):
         return "https://example.com/fake/repo.git"
+
+    async def get_ref_url(self):
+        return "https://example.com/fake/repo/tree/1a2b3c4d5e6f"
 
     def get_build_slug(self):
         return '{user}-{repo}'.format(user='Rick', repo='Morty')
@@ -208,10 +224,16 @@ class ZenodoProvider(RepoProvider):
         self.record_id = r.effective_url.rsplit("/", maxsplit=1)[1]
         return self.record_id
 
+    async def get_resolved_spec(self):
+        return self.spec
+
     def get_repo_url(self):
         # While called repo URL, the return value of this function is passed
         # as argument to repo2docker, hence we return the spec as is.
         return self.spec
+
+    async def get_ref_url(self):
+        return f"https://doi.org/{self.spec}"
 
     def get_build_slug(self):
         return "zenodo-{}".format(self.record_id)
@@ -241,10 +263,16 @@ class FigshareProvider(RepoProvider):
 
         return self.record_id
 
+    async def get_resolved_spec(self):
+        return self.spec
+
     def get_repo_url(self):
         # While called repo URL, the return value of this function is passed
         # as argument to repo2docker, hence we return the spec as is.
         return self.spec
+
+    async def get_ref_url(self):
+        return f"https://doi.org/{self.spec}"
 
     def get_build_slug(self):
         return "figshare-{}".format(self.record_id)
@@ -270,8 +298,8 @@ class GitRepoProvider(RepoProvider):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        url, unresolved_ref = self.spec.split('/', 1)
-        self.repo = urllib.parse.unquote(url)
+        self.url, unresolved_ref = self.spec.split('/', 1)
+        self.repo = urllib.parse.unquote(self.url)
         self.unresolved_ref = urllib.parse.unquote(unresolved_ref)
         if not self.unresolved_ref:
             raise ValueError("`unresolved_ref` must be specified as a query parameter for the basic git provider")
@@ -302,8 +330,17 @@ class GitRepoProvider(RepoProvider):
 
         return self.resolved_ref
 
+    async def get_resolved_spec(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f"{self.url}/{self.resolved_ref}"
+
     def get_repo_url(self):
         return self.repo
+
+    async def get_ref_url(self):
+        # not possible to construct ref url of unknown git provider
+        return self.get_repo_url()
 
     def get_build_slug(self):
         return self.repo
@@ -374,8 +411,8 @@ class GitLabRepoProvider(RepoProvider):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        quoted_namespace, unresolved_ref = self.spec.split('/', 1)
-        self.namespace = urllib.parse.unquote(quoted_namespace)
+        self.quoted_namespace, unresolved_ref = self.spec.split('/', 1)
+        self.namespace = urllib.parse.unquote(self.quoted_namespace)
         self.unresolved_ref = urllib.parse.unquote(unresolved_ref)
         if not self.unresolved_ref:
             raise ValueError("An unresolved ref is required")
@@ -410,13 +447,22 @@ class GitLabRepoProvider(RepoProvider):
         self.resolved_ref = ref_info['id']
         return self.resolved_ref
 
+    async def get_resolved_spec(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f"{self.quoted_namespace}/{self.resolved_ref}"
+
     def get_build_slug(self):
         # escape the name and replace dashes with something else.
         return '-'.join(p.replace('-', '_-') for p in self.namespace.split('/'))
 
     def get_repo_url(self):
-        return "https://{hostname}/{namespace}.git".format(
-            hostname=self.hostname, namespace=self.namespace)
+        return f"https://{self.hostname}/{self.namespace}.git"
+
+    async def get_ref_url(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f"https://{self.hostname}/{self.namespace}/tree/{self.resolved_ref}"
 
 
 class GitHubRepoProvider(RepoProvider):
@@ -500,8 +546,12 @@ class GitHubRepoProvider(RepoProvider):
         self.repo = strip_suffix(self.repo, ".git")
 
     def get_repo_url(self):
-        return "https://{hostname}/{user}/{repo}".format(
-            hostname=self.hostname, user=self.user, repo=self.repo)
+        return f"https://{self.hostname}/{self.user}/{self.repo}"
+
+    async def get_ref_url(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f"https://{self.hostname}/{self.user}/{self.repo}/tree/{self.resolved_ref}"
 
     @gen.coroutine
     def github_api_request(self, api_url, etag=None):
@@ -621,6 +671,11 @@ class GitHubRepoProvider(RepoProvider):
         )
         return self.resolved_ref
 
+    async def get_resolved_spec(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f"{self.user}/{self.repo}/{self.resolved_ref}"
+
     def get_build_slug(self):
         return '{user}-{repo}'.format(user=self.user, repo=self.repo)
 
@@ -639,6 +694,7 @@ class GistRepoProvider(GitHubRepoProvider):
     """
 
     name = Unicode('Gist')
+    hostname = Unicode('gist.github.com')
 
     allow_secret_gist = Bool(
         default_value=False,
@@ -657,7 +713,12 @@ class GistRepoProvider(GitHubRepoProvider):
             self.unresolved_ref = ''
 
     def get_repo_url(self):
-        return f'https://gist.github.com/{self.user}/{self.gist_id}.git'
+        return f'https://{self.hostname}/{self.user}/{self.gist_id}.git'
+
+    async def get_ref_url(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f'https://{self.hostname}/{self.user}/{self.gist_id}/{self.resolved_ref}'
 
     @gen.coroutine
     def get_resolved_ref(self):
@@ -688,6 +749,11 @@ class GistRepoProvider(GitHubRepoProvider):
                 self.resolved_ref = self.unresolved_ref
 
         return self.resolved_ref
+
+    async def get_resolved_spec(self):
+        if not hasattr(self, 'resolved_ref'):
+            self.resolved_ref = await self.get_resolved_ref()
+        return f'{self.user}/{self.gist_id}/{self.resolved_ref}'
 
     def get_build_slug(self):
         return self.gist_id

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -225,9 +225,9 @@ class ZenodoProvider(RepoProvider):
         return self.record_id
 
     async def get_resolved_spec(self):
-        if not hasattr(self, 'resolved_ref'):
-            self.resolved_ref = await self.get_resolved_ref()
-        resolved_spec = self.spec.split("zenodo")[0] + "zenodo." + self.resolved_ref
+        if not hasattr(self, 'record_id'):
+            self.record_id = await self.get_resolved_ref()
+        resolved_spec = self.spec.split("zenodo")[0] + "zenodo." + self.record_id
         return resolved_spec
 
     def get_repo_url(self):
@@ -268,12 +268,12 @@ class FigshareProvider(RepoProvider):
         return self.record_id
 
     async def get_resolved_spec(self):
-        if not hasattr(self, 'resolved_ref'):
-            self.resolved_ref = await self.get_resolved_ref()
+        if not hasattr(self, 'record_id'):
+            self.record_id = await self.get_resolved_ref()
 
         # spec without version is accepted as version 1 - check get_resolved_ref method
         # so we first strip article id and version and add it again
-        resolved_spec = self.spec.split("figshare")[0] + "figshare." + self.resolved_ref
+        resolved_spec = self.spec.split("figshare")[0] + "figshare." + self.record_id
         return resolved_spec
 
     def get_repo_url(self):

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -227,6 +227,9 @@ class ZenodoProvider(RepoProvider):
     async def get_resolved_spec(self):
         if not hasattr(self, 'record_id'):
             self.record_id = await self.get_resolved_ref()
+        # zenodo registers a DOI which represents all versions.
+        # and it always resolves to latest version
+        # for that case, we have to replace it with record id
         resolved_spec = self.spec.split("zenodo")[0] + "zenodo." + self.record_id
         return resolved_spec
 

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -56,21 +56,29 @@ async def test_zenodo():
     assert resolved_spec == spec
 
 
-async def test_figshare():
-    spec = '10.6084/m9.figshare.9782777.v1'
-
+@pytest.mark.parametrize('spec,resolved_ref,resolved_ref_url,build_slug', [
+    ['10.6084/m9.figshare.9782777.v1',
+     '9782777.v1',
+     'https://doi.org/10.6084/m9.figshare.9782777.v1',
+     'figshare-9782777.v1'],
+    ['10.6084/m9.figshare.9782777',
+     '9782777.v1',
+     'https://doi.org/10.6084/m9.figshare.9782777.v1',
+     'figshare-9782777.v1'],
+])
+async def test_figshare(spec, resolved_ref, resolved_ref_url, build_slug):
     provider = FigshareProvider(spec=spec)
 
     # have to resolve the ref first
     ref = await provider.get_resolved_ref()
-    assert ref == '9782777.v1'
+    assert ref == resolved_ref
 
     slug = provider.get_build_slug()
-    assert slug == 'figshare-9782777.v1'
+    assert slug == build_slug
     repo_url = provider.get_repo_url()
     assert repo_url == spec
     ref_url = await provider.get_resolved_ref_url()
-    assert ref_url == f"https://doi.org/{spec}"
+    assert ref_url == resolved_ref_url
     resolved_spec = await provider.get_resolved_spec()
     assert resolved_spec == spec
 

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -50,7 +50,7 @@ async def test_zenodo():
     assert slug == 'zenodo-3242074'
     repo_url = provider.get_repo_url()
     assert repo_url == spec
-    ref_url = await provider.get_ref_url()
+    ref_url = await provider.get_resolved_ref_url()
     assert ref_url == f"https://doi.org/{spec}"
     resolved_spec = await provider.get_resolved_spec()
     assert resolved_spec == spec
@@ -69,7 +69,7 @@ async def test_figshare():
     assert slug == 'figshare-9782777.v1'
     repo_url = provider.get_repo_url()
     assert repo_url == spec
-    ref_url = await provider.get_ref_url()
+    ref_url = await provider.get_resolved_ref_url()
     assert ref_url == f"https://doi.org/{spec}"
     resolved_spec = await provider.get_resolved_spec()
     assert resolved_spec == spec
@@ -86,7 +86,7 @@ def test_github_ref():
     assert full_url == f'https://github.com/{namespace}'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == 'f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603'
-    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    ref_url = IOLoop().run_sync(provider.get_resolved_ref_url)
     assert ref_url == f'https://github.com/{namespace}/tree/{ref}'
     resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
     assert resolved_spec == f'{namespace}/{ref}'
@@ -263,7 +263,7 @@ def test_git_ref(url, unresolved_ref, resolved_ref):
     assert full_url == url
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == resolved_ref
-    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    ref_url = IOLoop().run_sync(provider.get_resolved_ref_url)
     assert ref_url == full_url
     resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
     assert resolved_spec == quote(url, safe='') + f'/{resolved_ref}'
@@ -282,7 +282,7 @@ def test_gitlab_ref():
     assert full_url == f'https://gitlab.com/{namespace}.git'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == 'b3344b7f17c335a817c5d7608c5e47fd7cabc023'
-    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    ref_url = IOLoop().run_sync(provider.get_resolved_ref_url)
     assert ref_url == f'https://gitlab.com/{namespace}/tree/{ref}'
     resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
     assert resolved_spec == quote(namespace, safe='') + f'/{ref}'
@@ -299,7 +299,7 @@ def test_gist_ref():
     assert full_url == f'https://gist.github.com/{spec}.git'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == '7daa381aae8409bfe28193e2ed8f767c26371237'
-    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    ref_url = IOLoop().run_sync(provider.get_resolved_ref_url)
     assert ref_url == f'https://gist.github.com/{spec}/{ref}'
     resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
     assert resolved_spec == f'{spec}/{ref}'

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -43,7 +43,7 @@ def test_spec_processing(spec, raw_user, raw_repo, raw_ref):
      '3242074',
      'https://doi.org/10.5281/zenodo.3242074',
      'zenodo-3242074'],
-    # 10.5281/zenodo.705645 -> This DOI represents all versions, and will always resolve to the latest one
+    # 10.5281/zenodo.3242073 -> This DOI represents all versions, and will always resolve to the latest one
     # for now it is 3242074
     ['10.5281/zenodo.3242073',
      '10.5281/zenodo.3242074',

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -74,6 +74,7 @@ async def test_zenodo(spec, resolved_spec, resolved_ref, resolved_ref_url, build
      '9782777.v1',
      'https://doi.org/10.6084/m9.figshare.9782777.v1',
      'figshare-9782777.v1'],
+    # spec without version is accepted as version 1 - check FigshareProvider.get_resolved_ref()
     ['10.6084/m9.figshare.9782777',
      '10.6084/m9.figshare.9782777.v1',
      '9782777.v1',

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -50,6 +50,10 @@ async def test_zenodo():
     assert slug == 'zenodo-3242074'
     repo_url = provider.get_repo_url()
     assert repo_url == spec
+    ref_url = await provider.get_ref_url()
+    assert ref_url == f"https://doi.org/{spec}"
+    resolved_spec = await provider.get_resolved_spec()
+    assert resolved_spec == spec
 
 
 async def test_figshare():
@@ -65,17 +69,27 @@ async def test_figshare():
     assert slug == 'figshare-9782777.v1'
     repo_url = provider.get_repo_url()
     assert repo_url == spec
+    ref_url = await provider.get_ref_url()
+    assert ref_url == f"https://doi.org/{spec}"
+    resolved_spec = await provider.get_resolved_spec()
+    assert resolved_spec == spec
 
 
 @pytest.mark.github_api
 def test_github_ref():
-    provider = GitHubRepoProvider(spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4')
+    namespace = 'jupyterhub/zero-to-jupyterhub-k8s'
+    spec = f'{namespace}/v0.4'
+    provider = GitHubRepoProvider(spec=spec)
     slug = provider.get_build_slug()
     assert slug == 'jupyterhub-zero-to-jupyterhub-k8s'
     full_url = provider.get_repo_url()
-    assert full_url == 'https://github.com/jupyterhub/zero-to-jupyterhub-k8s'
+    assert full_url == f'https://github.com/{namespace}'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == 'f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603'
+    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    assert ref_url == f'https://github.com/{namespace}/tree/{ref}'
+    resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
+    assert resolved_spec == f'{namespace}/{ref}'
 
 
 def test_not_banned():
@@ -249,20 +263,29 @@ def test_git_ref(url, unresolved_ref, resolved_ref):
     assert full_url == url
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == resolved_ref
+    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    assert ref_url == full_url
+    resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
+    assert resolved_spec == quote(url, safe='') + f'/{resolved_ref}'
 
 
 def test_gitlab_ref():
+    namespace = 'gitlab-org/gitlab-foss'
     spec = '{}/{}'.format(
-        quote('gitlab-org/gitlab-foss', safe=''),
+        quote(namespace, safe=''),
         quote('v10.0.6')
     )
     provider = GitLabRepoProvider(spec=spec)
     slug = provider.get_build_slug()
     assert slug == 'gitlab_-org-gitlab_-foss'
     full_url = provider.get_repo_url()
-    assert full_url == 'https://gitlab.com/gitlab-org/gitlab-foss.git'
+    assert full_url == f'https://gitlab.com/{namespace}.git'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == 'b3344b7f17c335a817c5d7608c5e47fd7cabc023'
+    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    assert ref_url == f'https://gitlab.com/{namespace}/tree/{ref}'
+    resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
+    assert resolved_spec == quote(namespace, safe='') + f'/{ref}'
 
 
 @pytest.mark.github_api
@@ -273,9 +296,13 @@ def test_gist_ref():
     slug = provider.get_build_slug()
     assert slug == '8a658f7f63b13768d1e75fa2464f5092'
     full_url = provider.get_repo_url()
-    assert full_url == 'https://gist.github.com/mariusvniekerk/8a658f7f63b13768d1e75fa2464f5092.git'
+    assert full_url == f'https://gist.github.com/{spec}.git'
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref == '7daa381aae8409bfe28193e2ed8f767c26371237'
+    ref_url = IOLoop().run_sync(provider.get_ref_url)
+    assert ref_url == f'https://gist.github.com/{spec}/{ref}'
+    resolved_spec = IOLoop().run_sync(provider.get_resolved_spec)
+    assert resolved_spec == f'{spec}/{ref}'
 
 
 @pytest.mark.github_api

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -37,36 +37,48 @@ def test_spec_processing(spec, raw_user, raw_repo, raw_ref):
     assert raw_ref == unresolved_ref
 
 
-async def test_zenodo():
-    spec = '10.5281/zenodo.3242074'
-
+@pytest.mark.parametrize('spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
+    ['10.5281/zenodo.3242074',
+     '10.5281/zenodo.3242074',
+     '3242074',
+     'https://doi.org/10.5281/zenodo.3242074',
+     'zenodo-3242074'],
+    ['10.5281/zenodo.3242073',
+     '10.5281/zenodo.3242074',
+     '3242074',
+     'https://doi.org/10.5281/zenodo.3242074',
+     'zenodo-3242074'],
+])
+async def test_zenodo(spec, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
     provider = ZenodoProvider(spec=spec)
 
     # have to resolve the ref first
     ref = await provider.get_resolved_ref()
-    assert ref == '3242074'
+    assert ref == resolved_ref
 
     slug = provider.get_build_slug()
-    assert slug == 'zenodo-3242074'
+    assert slug == build_slug
     repo_url = provider.get_repo_url()
     assert repo_url == spec
     ref_url = await provider.get_resolved_ref_url()
-    assert ref_url == f"https://doi.org/{spec}"
-    resolved_spec = await provider.get_resolved_spec()
-    assert resolved_spec == spec
+    assert ref_url == resolved_ref_url
+    spec = await provider.get_resolved_spec()
+    assert spec == resolved_spec
 
 
-@pytest.mark.parametrize('spec,resolved_ref,resolved_ref_url,build_slug', [
+@pytest.mark.parametrize('spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
     ['10.6084/m9.figshare.9782777.v1',
+     '10.6084/m9.figshare.9782777.v1',
      '9782777.v1',
      'https://doi.org/10.6084/m9.figshare.9782777.v1',
      'figshare-9782777.v1'],
     ['10.6084/m9.figshare.9782777',
+     '10.6084/m9.figshare.9782777.v1',
      '9782777.v1',
      'https://doi.org/10.6084/m9.figshare.9782777.v1',
      'figshare-9782777.v1'],
 ])
-async def test_figshare(spec, resolved_ref, resolved_ref_url, build_slug):
+async def test_figshare(spec, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
     provider = FigshareProvider(spec=spec)
 
     # have to resolve the ref first
@@ -79,8 +91,8 @@ async def test_figshare(spec, resolved_ref, resolved_ref_url, build_slug):
     assert repo_url == spec
     ref_url = await provider.get_resolved_ref_url()
     assert ref_url == resolved_ref_url
-    resolved_spec = await provider.get_resolved_spec()
-    assert resolved_spec == spec
+    spec = await provider.get_resolved_spec()
+    assert spec == resolved_spec
 
 
 @pytest.mark.github_api

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -43,6 +43,8 @@ def test_spec_processing(spec, raw_user, raw_repo, raw_ref):
      '3242074',
      'https://doi.org/10.5281/zenodo.3242074',
      'zenodo-3242074'],
+    # 10.5281/zenodo.705645 -> This DOI represents all versions, and will always resolve to the latest one
+    # for now it is 3242074
     ['10.5281/zenodo.3242073',
      '10.5281/zenodo.3242074',
      '3242074',


### PR DESCRIPTION
Hi, I added 2 new methods for each repo provider:

- `get_resolved_spec`: returns spec with resolved ref
- `get_ref_url`: returns repo url on specific commit in history

and by using these 2 new methods 2 new urls are added into appendix

- `persistent_binder_url`: binder url with resolved ref. e.g., instead of name of the branch `master`, that url will contain commit hash of the master branch when image is built
- `ref_url`: repo url on specific commit in history

I think these 2 urls are useful, if someone wants to use appendix. For example to create a button to copy binder link.