### PR TITLE
use chart jupyterhub-0.9-5eb48bc

### DIFF
--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -19,14 +19,12 @@ you need to add the following into ``config.yaml``:
         users: False
 
       hub:
+        redirectToServer: false
         services:
           binder:
             oauth_redirect_uri: "http://<binderhub_url>/oauth_callback"
             oauth_client_id: "binder-oauth-client-test"
         extraConfig:
-          hub_extra: |
-            c.JupyterHub.redirect_to_server = False
-
           binder: |
             from kubespawner import KubeSpawner
 
@@ -83,6 +81,9 @@ you have to enable named servers on JupyterHub:
     jupyterhub:
       hub:
         allowNamedServers: true
+        # change this value as you wish,
+        # or remove this line if you don't want to have any limit
+        namedServerLimitPerUser: 5
 
 .. note::
     BinderHub assigns a unique name to each server with max 40 characters.

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.9-2d435d6"
+  version: "0.9-5eb48bc"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
This PR upgrades jhub to chart chart jupyterhub-0.9-5eb48bc: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/2d435d6...5eb48bc. I went through the changes in z2jh and didn't find anything to change accordingly in BinderHub repo. But maybe I am wrong, it would be good that it is checked someone else.

And also update authentication documentation to use new config values in new chart.