### PR TITLE
helm chart: fix compatibility with helm >=2.15.0

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: {{ .Values.replicas }}
   strategy:
     rollingUpdate:
-        {{- if eq .Values.replicas 1.0 }}
+        {{- if eq (.Values.replicas | int) 1 }}
         maxSurge: 1
         maxUnavailable: 0
         {{- end }}


### PR DESCRIPTION
Helm 2.15.0 presents .Values.replicas as int, which is actually the correct behaviour, but this used to be float. This PR fixes compatibility with newer helm versions by always casting the replicas variable to int and then comparing it to an integer.

Closes #980