### PR TITLE
Added api_base_path option for GitHub Enterprise compatibility

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -434,6 +434,17 @@ class GitHubRepoProvider(RepoProvider):
         e.g. GitHub Enterprise.
         """)
 
+    api_base_path = Unicode('https://api.{hostname}',
+        config=True,
+        help="""The base path of the GitHub API
+        
+        Only necessary if not github.com,
+        e.g. GitHub Enterprise.
+
+        Can use {hostname} for substitution,
+        e.g. 'https://{hostname}/api/v3'
+        """)
+
     client_id = Unicode(config=True,
         help="""GitHub client id for authentication with the GitHub API
 
@@ -580,9 +591,9 @@ class GitHubRepoProvider(RepoProvider):
         if hasattr(self, 'resolved_ref'):
             return self.resolved_ref
 
-        api_url = "https://api.{hostname}/repos/{user}/{repo}/commits/{ref}".format(
-            user=self.user, repo=self.repo, ref=self.unresolved_ref,
-            hostname=self.hostname,
+        api_url = "{api_base_path}/repos/{user}/{repo}/commits/{ref}".format(
+            api_base_path=self.api_base_path.format(hostname=self.hostname), 
+            user=self.user, repo=self.repo, ref=self.unresolved_ref
         )
         self.log.debug("Fetching %s", api_url)
         cached = self.cache.get(api_url)


### PR DESCRIPTION
Resolves #972.

Inlined for convenience:
> The `GitHubRepoProvider` hard-codes the `api_url` pattern, which is incompatible with some/all (?) GitHub Enterprise API paths. See
> 
> https://github.com/jupyterhub/binderhub/blob/a168d069772012c52f9ac7056ec22d779927ae69/binderhub/repoproviders.py#L583-L586
> 
> An example of a possible API base path for GHE is `https://{hostname}/api/v3`.
> 
> My proposed solution is to add a configuration option for `api_base_path` that defaults to `https://api.{hostname}` for backwards compatibility and change the `api_url` derivation to use `api_base_path`.
> 
> PR coming soon.

