### PR TITLE
Added check for ratelimit headers for GitHub Enterprise compatib…

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -527,6 +527,7 @@ class GitHubRepoProvider(RepoProvider):
             elif (
                 e.code == 403
                 and e.response
+                and 'x-ratelimit-remaining' in e.response.headers
                 and e.response.headers.get('x-ratelimit-remaining') == '0'
             ):
                 rate_limit = e.response.headers['x-ratelimit-limit']
@@ -551,28 +552,30 @@ class GitHubRepoProvider(RepoProvider):
             else:
                 raise
 
-        # record and log github rate limit
-        remaining = int(resp.headers['x-ratelimit-remaining'])
-        rate_limit = int(resp.headers['x-ratelimit-limit'])
-        reset_timestamp = int(resp.headers['x-ratelimit-reset'])
+        if 'x-ratelimit-remaining' in resp.headers:
+            # record and log github rate limit
+            remaining = int(resp.headers['x-ratelimit-remaining'])
+            rate_limit = int(resp.headers['x-ratelimit-limit'])
+            reset_timestamp = int(resp.headers['x-ratelimit-reset'])
 
-        # record with prometheus
-        GITHUB_RATE_LIMIT.set(remaining)
+            # record with prometheus
+            GITHUB_RATE_LIMIT.set(remaining)
 
-        # log at different levels, depending on remaining fraction
-        fraction = remaining / rate_limit
-        if fraction < 0.2:
-            log = self.log.warning
-        elif fraction < 0.5:
-            log = self.log.info
-        else:
-            log = self.log.debug
+            # log at different levels, depending on remaining fraction
+            fraction = remaining / rate_limit
+            if fraction < 0.2:
+                log = self.log.warning
+            elif fraction < 0.5:
+                log = self.log.info
+            else:
+                log = self.log.debug
 
-        # str(timedelta) looks like '00:32'
-        delta = timedelta(seconds=int(reset_timestamp - time.time()))
-        log("GitHub rate limit remaining {remaining}/{limit}. Reset in {delta}.".format(
-            remaining=remaining, limit=rate_limit, delta=delta,
-        ))
+            # str(timedelta) looks like '00:32'
+            delta = timedelta(seconds=int(reset_timestamp - time.time()))
+            log("GitHub rate limit remaining {remaining}/{limit}. Reset in {delta}.".format(
+                remaining=remaining, limit=rate_limit, delta=delta,
+            ))
+        
         return resp
 
     @gen.coroutine


### PR DESCRIPTION
Resolves #984.

Inlined for convenience:
> The `GitHubRepoProvider` codes against the values of the `x-ratelimit-*` headers, which are always present in public GitHub.com, but GitHub Enterprise allows admins to disable rate limiting entirely, which violates the assumption of its presence in the code and prevents it from continuing. Ex:
> 
> https://github.com/jupyterhub/binderhub/blob/93026846db7e5ee1154ba2710843d2ce94cfa1ca/binderhub/repoproviders.py#L621-L642
> 
> I propose that we test for the existence of the headers and if they do not exist then bypassing the rate limit tracking portion.
> 
> Pull request coming soon.

