### PR TITLE
Add support for 3+-part image names (like on GitLab)

### DIFF
--- a/binderhub/tests/test_builder.py
+++ b/binderhub/tests/test_builder.py
@@ -1,0 +1,17 @@
+import pytest
+from binderhub import builder
+
+
+@pytest.mark.parametrize("fullname,basename,tag", [
+    ("jupyterhub/k8s-binderhub:0.2.0-a2079a5", "jupyterhub/k8s-binderhub", "0.2.0-a2079a5"),
+    ("jupyterhub/jupyterhub", "jupyterhub/jupyterhub", "latest"),
+    ("gcr.io/project/image:tag", "project/image", "tag"),
+    ("weirdregistry.com/image:tag", "image", "tag"),
+    ("gitlab-registry.example.com/group/project:some-tag", "group/project", "some-tag"),
+    ("gitlab-registry.example.com/group/project/image:latest", "group/project/image", "latest"),
+    ("gitlab-registry.example.com/group/project/my/image:rc1", "group/project/my/image", "rc1")
+])
+def test_image_basename_resolution(fullname, basename, tag):
+    resulting_basename, resulting_tag = builder.BuildHandler._get_image_basename_and_tag(fullname)
+    assert resulting_basename == basename
+    assert resulting_tag == tag


### PR DESCRIPTION
This PR enables the use of "longer" image names such as `gitlab.com/bdrian/binderhub/prod/<generated-image-slug>`. Only the lookup for possibly existing images has to be changed, because this is the only place we cannot use the full form (repo+image names together).

To allow both magical Docker Hub short names (like `jupyterhub/k8s-binderhub`) and regular names referring to a registry (`gcr.io/project/something`), this approach cuts off the first part unless the image name looks like it may come from Docker Hub -- those image names always have two parts and certain restrictions that are not all present in Docker itself:

> Organization name must contain a combination of alphanumeric characters of 4-30 characters in length. Letters must be lowercase.

> Your repository name must contain a combination of alphanumeric characters and may contain the special characters ., _, or -. Letters must be lowercase.

Additionally, less than two or more than 255 characters are also refused as repository names.

To be able to test this with the existing Travis setup right away, I had to single the basename derivation out; alternatively we'd have to find a publicly reachable registry that supports 3+-part image names and is not GitLab, because getting a token from GitLab's registry doesn't work yet (see #965). Local testing with "long names" in a remote registry was fine, though.

This change breaks compatibility with registries that do not operate at their domain root (something like `mycompany.com/registry`), but I'm not sure if that's actually used or even possible. Additional feedback is welcome.

Contributes to #965, but doesn't close it.