### PR TITLE
Set Binder ingress service port to 80

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
           - path: /
             backend:
               serviceName: binder
-              servicePort: 8585
+              servicePort: 80
     {{- end }}
   {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
   tls:


### PR DESCRIPTION
The targetPort in the container is default 8585, but the service port is
hard-coded in the template to 80.