### PR TITLE
fix cleaning pods up after testing

### DIFF
--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -222,9 +222,9 @@ def cleanup_pods(namespace, labels):
         print(f"deleting pod {pod.metadata.name}")
         try:
             kube.delete_namespaced_pod(
-                pod.metadata.name,
-                namespace,
-                kubernetes.client.V1DeleteOptions(grace_period_seconds=0),
+                name=pod.metadata.name,
+                namespace=namespace,
+                body=kubernetes.client.V1DeleteOptions(grace_period_seconds=0),
             )
         except kubernetes.client.rest.ApiException as e:
             # ignore 404, 409: already gone

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -9,7 +9,7 @@ ruamel.yaml
 # install BinderHub dependencies. We manually list them here because some
 # dependencies (like pycurl) can't be installed on ReadTheDocs and aren't
 # needed to build the docs.
-kubernetes==7.0.*
+kubernetes==9.0.*
 escapism
 tornado
 traitlets

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -9,7 +9,7 @@ ruamel.yaml
 # install BinderHub dependencies. We manually list them here because some
 # dependencies (like pycurl) can't be installed on ReadTheDocs and aren't
 # needed to build the docs.
-kubernetes>=4.*
+kubernetes==7.0.*
 escapism
 tornado
 traitlets

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,6 +1,6 @@
 pycurl==7.43.0.1
 tornado==5.0.*
-kubernetes==7.0.*
+kubernetes==9.0.*
 jupyterhub==1.0.0
 jsonschema==2.6.0
 # Logging sinks to send eventlogging events to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # When you change this file please also update `doc/doc-requirements.txt`
 # which needs to be kept in sync manually.
-kubernetes>=4.*
+kubernetes==7.0.*
 escapism
 tornado
 traitlets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # When you change this file please also update `doc/doc-requirements.txt`
 # which needs to be kept in sync manually.
-kubernetes==7.0.*
+kubernetes==9.0.*
 escapism
 tornado
 traitlets


### PR DESCRIPTION
I think something change in the definition of `delete_namespaced_pod` method in kubernetes package. When I run tests locally, I start to get: `TypeError: delete_namespaced_pod() takes 3 positional arguments but 4 were given`.  I think in that way because `kubernetes>=4.*` is in `requirements.txt` and it installs latest kubernetes package but in `binderhub/helm-chart/images/binderhub/requirements.txt` it is fixed to version 7 (`kubernetes==7.0.*`). So we don't see this error in travis.

So first I used keyword arguments in `delete_namespaced_pod` method call to fix that problem. And then I also updated `requirements.txt` and `doc/doc-requirements.txt`, so they install the same version of kubernetes packages as in docker image.
