### PR TITLE
Proxy Support

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -3,12 +3,13 @@ Main handler classes for requests
 """
 import urllib.parse
 
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from tornado.httpclient import HTTPRequest
 from tornado.web import HTTPError, authenticated
 from tornado.httputil import url_concat
 from tornado.log import app_log
 
 from .base import BaseHandler
+from .utils import ProxiedAsyncHTTPClient
 
 SPEC_NAMES = {
     "gh": "GitHub",
@@ -77,7 +78,7 @@ class ParameterizedMainHandler(BaseHandler):
 
             # Check if the nbviewer URL is valid and would display something
             # useful to the reader, if not we don't show it
-            client = AsyncHTTPClient()
+            client = ProxiedAsyncHTTPClient()
             # quote any unicode characters in the URL
             proto, rest = nbviewer_url.split("://")
             rest = urllib.parse.quote(rest)

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -11,6 +11,8 @@ from tornado.httputil import url_concat
 from traitlets.config import LoggingConfigurable
 from traitlets import Dict, Unicode, default
 
+from .utils import ProxiedAsyncHTTPClient
+
 DEFAULT_DOCKER_REGISTRY_URL = "https://registry.hub.docker.com"
 DEFAULT_DOCKER_AUTH_URL = "https://index.docker.io/v1"
 
@@ -187,7 +189,7 @@ class DockerRegistry(LoggingConfigurable):
 
     @gen.coroutine
     def get_image_manifest(self, image, tag):
-        client = httpclient.AsyncHTTPClient()
+        client = ProxiedAsyncHTTPClient()
         url = "{}/v2/{}/manifests/{}".format(self.url, image, tag)
         # first, get a token to perform the manifest request
         if self.token_url:

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -18,13 +18,14 @@ import subprocess
 from prometheus_client import Gauge
 
 from tornado import gen
-from tornado.httpclient import AsyncHTTPClient, HTTPError, HTTPRequest
+from tornado.httpclient import HTTPError, HTTPRequest
 from tornado.httputil import url_concat
 
 from traitlets import Dict, Unicode, Bool, default, List, observe
 from traitlets.config import LoggingConfigurable
 
 from .utils import Cache
+from .utils import ProxiedAsyncHTTPClient
 
 GITHUB_RATE_LIMIT = Gauge('binderhub_github_rate_limit_remaining', 'GitHub rate limit remaining')
 SHA1_PATTERN = re.compile(r'[0-9a-f]{40}')
@@ -217,7 +218,7 @@ class ZenodoProvider(RepoProvider):
 
     @gen.coroutine
     def get_resolved_ref(self):
-        client = AsyncHTTPClient()
+        client = ProxiedAsyncHTTPClient()
         req = HTTPRequest("https://doi.org/{}".format(self.spec),
                           user_agent="BinderHub")
         r = yield client.fetch(req)
@@ -257,7 +258,7 @@ class FigshareProvider(RepoProvider):
 
     @gen.coroutine
     def get_resolved_ref(self):
-        client = AsyncHTTPClient()
+        client = ProxiedAsyncHTTPClient()
         req = HTTPRequest("https://doi.org/{}".format(self.spec),
                           user_agent="BinderHub")
         r = yield client.fetch(req)
@@ -439,7 +440,7 @@ class GitLabRepoProvider(RepoProvider):
             return self.resolved_ref
 
         namespace = urllib.parse.quote(self.namespace, safe='')
-        client = AsyncHTTPClient()
+        client = ProxiedAsyncHTTPClient()
         api_url = "https://{hostname}/api/v4/projects/{namespace}/repository/commits/{ref}".format(
             hostname=self.hostname,
             namespace=namespace,
@@ -582,7 +583,7 @@ class GitHubRepoProvider(RepoProvider):
 
     @gen.coroutine
     def github_api_request(self, api_url, etag=None):
-        client = AsyncHTTPClient()
+        client = ProxiedAsyncHTTPClient()
         if self.auth:
             # Add auth params. After logging!
             api_url = url_concat(api_url, self.auth)


### PR DESCRIPTION
This PR adds support for running BinderHub behind a proxy, at least once complementary changes are made in repo2docker. I'm not sure if this is the prettiest way to go, feedback is welcome.

See #939 