### PR TITLE
add hub_url_local as hub_url currently represents both public and local

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -681,7 +681,7 @@ class BinderHub(Application):
                 tornado.web.StaticFileHandler,
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
-            (r'/health', HealthHandler, {'hub_url': self.hub_url}),
+            (r'/health', HealthHandler, {'hub_url': self.hub_url_local}),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -379,14 +379,21 @@ class BinderHub(Application):
         config=True,
     )
 
-    hub_url_public = Unicode(
+    hub_url_local = Unicode(
         help="""
-        The public base URL of the JupyterHub instance where users will run if different from hub_url
+        The base URL of the JupyterHub instance for local/internal traffic
+
+        If local/internal network connections from the BinderHub process should access
+        JupyterHub using a different URL than public/external traffic set this, default
+        is hub_url
         """,
         config=True,
     )
+    @default('hub_url_local')
+    def _default_hub_url_local(self):
+        return self.hub_url
 
-    @validate('hub_url', 'hub_url_public')
+    @validate('hub_url', 'hub_url_local')
     def _add_slash(self, proposal):
         """trait validator to ensure hub_url ends with a trailing slash"""
         if proposal.value is not None and not proposal.value.endswith('/'):
@@ -585,7 +592,7 @@ class BinderHub(Application):
         self.launcher = Launcher(
             parent=self,
             hub_url=self.hub_url,
-            hub_url_public=self.hub_url_public,
+            hub_url_local=self.hub_url_local,
             hub_api_token=self.hub_api_token,
             create_user=not self.auth_enabled,
         )

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -378,7 +378,15 @@ class BinderHub(Application):
         """,
         config=True,
     )
-    @validate('hub_url')
+
+    hub_url_public = Unicode(
+        help="""
+        The public base URL of the JupyterHub instance where users will run if different from hub_url
+        """,
+        config=True,
+    )
+
+    @validate('hub_url', 'hub_url_public')
     def _add_slash(self, proposal):
         """trait validator to ensure hub_url ends with a trailing slash"""
         if proposal.value is not None and not proposal.value.endswith('/'):
@@ -577,6 +585,7 @@ class BinderHub(Application):
         self.launcher = Launcher(
             parent=self,
             hub_url=self.hub_url,
+            hub_url_public=self.hub_url_public,
             hub_api_token=self.hub_api_token,
             create_user=not self.auth_enabled,
         )

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -34,7 +34,7 @@ class Launcher(LoggingConfigurable):
 
     hub_api_token = Unicode(help="The API token for the Hub")
     hub_url = Unicode(help="The URL of the Hub")
-    hub_url_public = Unicode(help="The public URL of the Hub if different")
+    hub_url_local = Unicode(help="The internal URL of the Hub if different")
     create_user = Bool(True, help="Create a new Hub user")
     allow_named_servers = Bool(
         os.getenv('JUPYTERHUB_ALLOW_NAMED_SERVERS', "false") == "true",
@@ -241,5 +241,5 @@ class Launcher(LoggingConfigurable):
                           format(_server_name, username, e, body))
             raise web.HTTPError(500, "Failed to launch image %s" % image)
 
-        data['url'] = (self.hub_url_public or self.hub_url) + 'user/%s/%s' % (username, server_name)
+        data['url'] = self.hub_url + 'user/%s/%s' % (username, server_name)
         return data

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -34,6 +34,7 @@ class Launcher(LoggingConfigurable):
 
     hub_api_token = Unicode(help="The API token for the Hub")
     hub_url = Unicode(help="The URL of the Hub")
+    hub_url_public = Unicode(help="The public URL of the Hub if different")
     create_user = Bool(True, help="Create a new Hub user")
     allow_named_servers = Bool(
         os.getenv('JUPYTERHUB_ALLOW_NAMED_SERVERS', "false") == "true",
@@ -240,5 +241,5 @@ class Launcher(LoggingConfigurable):
                           format(_server_name, username, e, body))
             raise web.HTTPError(500, "Failed to launch image %s" % image)
 
-        data['url'] = self.hub_url + 'user/%s/%s' % (username, server_name)
+        data['url'] = (self.hub_url_public or self.hub_url) + 'user/%s/%s' % (username, server_name)
         return data

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -14,7 +14,7 @@ from tornado.log import app_log
 from tornado import web, gen
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPError
 from traitlets.config import LoggingConfigurable
-from traitlets import Integer, Unicode, Bool
+from traitlets import Integer, Unicode, Bool, default
 from jupyterhub.traitlets import Callable
 from jupyterhub.utils import maybe_future
 
@@ -35,6 +35,9 @@ class Launcher(LoggingConfigurable):
     hub_api_token = Unicode(help="The API token for the Hub")
     hub_url = Unicode(help="The URL of the Hub")
     hub_url_local = Unicode(help="The internal URL of the Hub if different")
+    @default('hub_url_local')
+    def _default_hub_url_local(self):
+        return self.hub_url
     create_user = Bool(True, help="Create a new Hub user")
     allow_named_servers = Bool(
         os.getenv('JUPYTERHUB_ALLOW_NAMED_SERVERS', "false") == "true",
@@ -82,7 +85,7 @@ class Launcher(LoggingConfigurable):
         """Make an API request to JupyterHub"""
         headers = kwargs.setdefault('headers', {})
         headers.update({'Authorization': 'token %s' % self.hub_api_token})
-        hub_api_url = os.getenv('JUPYTERHUB_API_URL', '') or self.hub_url + 'hub/api/'
+        hub_api_url = os.getenv('JUPYTERHUB_API_URL', '') or self.hub_url_local + 'hub/api/'
         request_url = hub_api_url + url
         req = HTTPRequest(request_url, *args, **kwargs)
         retry_delay = self.retry_delay

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -84,8 +84,7 @@ if os.getenv('BUILD_NAMESPACE'):
     c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
 if c.BinderHub.auth_enabled:
-    hub_url = urlparse(c.BinderHub.hub_url_public if 'hub_url_public' in c.BinderHub
-                       else c.BinderHub.hub_url)
+    hub_url = urlparse(c.BinderHub.hub_url)
     c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)
     if 'base_url' in c.BinderHub:
         c.HubOAuth.base_url = c.BinderHub.base_url

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -84,7 +84,8 @@ if os.getenv('BUILD_NAMESPACE'):
     c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
 if c.BinderHub.auth_enabled:
-    hub_url = urlparse(c.BinderHub.hub_url)
+    hub_url = urlparse(c.BinderHub.hub_url_public if 'hub_url_public' in c.BinderHub
+                       else c.BinderHub.hub_url)
     c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)
     if 'base_url' in c.BinderHub:
         c.HubOAuth.base_url = c.BinderHub.base_url

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
               key: "binder.hub-token"
         {{- if .Values.config.BinderHub.auth_enabled }}
         - name: JUPYTERHUB_API_URL
-          value: {{ (print (.Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
+          value: {{ (print (.Values.config.BinderHub.hub_url_local | default .Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
         - name: JUPYTERHUB_BASE_URL
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
         - name: JUPYTERHUB_CLIENT_ID


### PR DESCRIPTION
I don't know if this is useful so opening it for comments.

I just ran Binderhub on a misconfigured test system where external ingress is limited by IP range. Unfortunately the IP range didn't include itself 😀

BinderHub uses the external JupyterHub API instead of the internal K8s service. Obviously the firewall will be fixed, but is this potentially useful anyway?