### PR TITLE
[MRG] Move dropdown to the left

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -69,7 +69,9 @@ function updateRepoText() {
     tag_text = "Git commit SHA";
   }
   $("#repository").attr('placeholder', text);
+  $("label[for=repository]").text(text);
   $("#ref").attr('placeholder', tag_text);
+  $("label[for=ref]").text(tag_text);
 }
 
 function getBuildFormValues() {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -69,9 +69,7 @@ function updateRepoText() {
     tag_text = "Git commit SHA";
   }
   $("#repository").attr('placeholder', text);
-  $("label[for=repository]").text(text);
   $("#ref").attr('placeholder', tag_text);
-  $("label[for=ref]").text(tag_text);
 }
 
 function getBuildFormValues() {

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -25,9 +25,8 @@
         <h4 id="form-header" class='row'>Build and launch a repository</h4>
         <input type="hidden" id="provider_prefix" value="gh"/>
         <div class="form-group row">
-          <label for="repository">GitHub repo or Gist name or GitLab.com URL</label>
+          <label for="repository">Git repository URL (github.com, gitlab.com or self-host)</label>
           <div class="input-group">
-            <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="GitHub repository name or link"/>
             <div class="input-group-btn" id="url-type-btn">
               <button type="button" class="btn btn-secondary dropdown-toggle"
                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
@@ -45,6 +44,7 @@
                 <li class="dropdown-item" value="git"><a href="#">Git repository</a></li>
               </ul>
             </div>
+            <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="GitHub repository name or link"/>
           </div>
         </div>
         <div class="form-row row">


### PR DESCRIPTION
Follow up to #807

This moves the drop down menu to the left to make it more prominent to help users to notice that they have a choice.

This PR adds back the JS which updates the label when a user selects a different value in the dropdown.