### PR TITLE
Bump and update for fresh chartpressing

### DIFF
--- a/ci/test-helm
+++ b/ci/test-helm
@@ -34,21 +34,39 @@ if [[ ! -z "$GITHUB_ACCESS_TOKEN" ]]; then
 EOF
 fi
 
+# FIXME: Move to a dedicated build stage in travis like in z2jh
+#
+# ref: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/.travis.yml
 if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
   openssl aes-256-cbc -K $encrypted_d8355cc3d845_key -iv $encrypted_d8355cc3d845_iv -in travis.enc -out travis -d
   chmod 0400 travis
   export GIT_SSH_COMMAND="ssh -i ${PWD}/travis"
   docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
-  PUSH="--push --publish-chart"
+
+  if [ "${TRAVIS_TAG:-}" == "" ]; then
+    # Using --long, we are ensured to get a build suffix, which ensures we don't
+    # build the same tag twice. The --extra-message influences the additional
+    # text to the commit message on the gh-pages branch of
+    # jupyterhub/helm-chart.
+    #
+    # ref: https://github.com/jupyterhub/helm-chart
+    PUSH="--push --publish-chart --long --extra-message \"${TRAVIS_REPO_SLUG}$(git log -1 --pretty=%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/')\""
+  else
+    # Setting a tag explicitly enforces a rebuild if this tag had already been
+    # built and we wanted to override it.
+    PUSH="--push --publish-chart --tag ${TRAVIS_TAG}"
+  fi
 else
   PUSH=""
 fi
+
+
 
 echo "building helm chart"
 cd helm-chart
 helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
 helm dependency update binderhub
-chartpress --commit-range ${TRAVIS_COMMIT_RANGE} ${PUSH} --extra-message "${TRAVIS_REPO_SLUG}$(git log -1 --pretty=%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/')"
+chartpress ${PUSH}
 cd ..
 # git diff will show us the result of the chartpress render.
 # This should only include the tags for chartpress images.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio
 pytest-cov
 requests
 ruamel.yaml>=0.15
-chartpress==0.3.1
+chartpress>=0.4.3,<0.5
 jupyterhub

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -1,23 +1,28 @@
+# For a reference on this configuration, see the chartpress README file.
+# ref: https://github.com/jupyterhub/chartpress
 charts:
   - name: binderhub
     imagePrefix: jupyterhub/k8s-
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart
-    paths:
-      - ..
+    resetTag: local
+    resetVersion: 0.2.0
+    # NOTE: All paths will be set relative to this file's location, which is in the
+    # helm-chart folder.
     images:
       image-cleaner:
         valuesPath: imageCleaner.image
       binderhub:
-        # Context to send to docker build for use by the Dockerfile
+        # Context to send to docker build for use by the Dockerfile. We pass the
+        # root folder in order to allow the image to access and build the python
+        # package. Since we do that, chartpress will always react to changes in
+        # documentation and other things, and always consider the chart version
+        # to change along with the image version.
         contextPath: ..
-        # Dockerfile path relative to chartpress.yaml
+        # Since we changed the contextPath, we must also change the
+        # dockerfilePath. This is because chartpress assume the Dockerfile will
+        # reside in the contextPath folder, and since we overrode the default of
+        # images/binderhub it will be the wrong folder.
         dockerfilePath: images/binderhub/Dockerfile
         valuesPath: image
-        # additional paths relevant to the image
-        # in addition to image directory itself
-        # paths are relative to chartpress.yaml
-        paths:
-          - ../setup.py
-          - ../binderhub

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -29,11 +29,12 @@ WORKDIR /
 # to the current directory within the container.
 COPY --from=build-stage /tmp/binderhub/dist/*.whl .
 
-# Copy the additional Python requirements for our Docker container. These can be
-# certain pinned versions or peer dependencies.
+# Copy the additional Python requirements for our Docker container from the
+# build context. These can be certain pinned versions or peer dependencies.
+COPY helm-chart/images/binderhub/requirements.txt .
 RUN pip install --no-cache-dir \
         *.whl \
-        -r /tmp/binderhub/helm-chart/images/binderhub/requirements.txt
+        -r requirements.txt
 
 # Copy the binderhub configuration to use.
 # FUTURE: Follow the approach taken in Z2JH:

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,22 +1,44 @@
-FROM buildpack-deps:stretch
+# Using multi-stage builds
+# ref: https://docs.docker.com/develop/develop-images/multistage-build/
+FROM buildpack-deps:stretch as build-stage
 
-RUN echo 'deb http://deb.nodesource.com/node_8.x artful main' > /etc/apt/sources.list.d/nodesource.list
+RUN echo 'deb http://deb.nodesource.com/node_8.x artful main' > /etc/apt/sources.list.d/nodesource.list \
+ && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN apt-get update && \
-    apt-get install --yes nodejs python3 python3-pip python3-wheel python3-setuptools
+    apt-get install --yes \
+        nodejs \
+        python3 \
+        python3-pip \
+        python3-wheel \
+        python3-setuptools
 
+# Copy the whole git repository to /tmp/binderhub
 COPY . /tmp/binderhub
 WORKDIR /tmp/binderhub
 
+# Build binderhub the python library
 RUN python3 setup.py bdist_wheel
 
+# The final stage
+# ---------------
 FROM python:3.6-stretch
+WORKDIR /
 
-COPY --from=0 /tmp/binderhub/dist/*.whl .
-ADD helm-chart/images/binderhub/binderhub_config.py .
-ADD helm-chart/images/binderhub/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir *.whl -r /tmp/requirements.txt
+# Copy the built binderhub python wheel from the build-stage
+# to the current directory within the container.
+COPY --from=build-stage /tmp/binderhub/dist/*.whl .
+
+# Copy the additional Python requirements for our Docker container. These can be
+# certain pinned versions or peer dependencies.
+RUN pip install --no-cache-dir \
+        *.whl \
+        -r /tmp/binderhub/helm-chart/images/binderhub/requirements.txt
+
+# Copy the binderhub configuration to use.
+# FUTURE: Follow the approach taken in Z2JH:
+#         https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1478
+COPY helm-chart/images/binderhub/binderhub_config.py .
 
 CMD ["python3", "-m", "binderhub"]
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
I bumped chartpress but also clarified various things etc in docs.

- removed use of deprecated --commit-range that is now handled
automatically.
- trimmed paths in chartpress.yaml to what mattered and documented some
reasons for that.
- added notes to the Dockerfile which I spent time understanding more in
detail while working on this PR.
- added resetTag and resetVersion to the chartpress.yaml configuration,
allowing the use of the --reset flag to reset values.yaml and Chart.yaml
to the state it was in before chartpress was run locally.

---

## Potentially breaking change
Note [the Helm chart versions for JupyterHub](https://jupyterhub.github.io/helm-chart/) with names like `jupyterhub-0.9.0-alpha.1.033.fd3e470`? With chartpress 0.4.3, this is what you will get for BinderHub as well. The pattern is `<chartname>-<version>[-<pre-release-tag>[.nnn.sha]]`, this could influence henchbot etc. perhaps.