### PR TITLE
Fix broken doc link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -196,7 +196,7 @@ texinfo_documents = [
 # -- Custom scripts -------------------------------------------
 
 # Grab the latest version of the k8s and helm install instructions.
-helm_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/setup-helm.rst"
+helm_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/setup-jupyterhub/setup-helm.rst"
 
 resp = requests.get(helm_instructions)
 with open('./helm.txt', 'w') as ff:


### PR DESCRIPTION
ping @betatim @choldgraf - solves https://github.com/jupyterhub/binderhub/pull/1004#issuecomment-555226799!

It does not fix an issue relating to installing kubernetes==11.0.0b1, which is a pre-release. Does conda do it when it is referenced from a environment file but not if using pip directly? Hm... Confused, but that is what the circle-ci error about not finding kubernetes.api.client is about.

---

I don't understand why we install binderhub stuff in doc-requirements.txt, why do we do this? https://github.com/jupyterhub/binderhub/commit/73072c94f5d6b1b3ed8fb45897bc16e1810e8f18