### PR TITLE
Bump Z2JH and fix CI tests (Running != Ready)

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.9-5eb48bc"
+  version: "0.9.0-alpha.1.033.fd3e470"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -83,17 +83,32 @@ def wait_for(f, msg, timeout=300):
         raise TimeoutError(f"{msg} did not occur in {timeout} seconds")
     print(msg)
 
-def hub_running():
-    """Return whether all pods in our test namespace are ready"""
-    pods = kube.list_namespaced_pod(namespace).items
-    # debug:
-    for pod in pods:
-        print(f"{pod.status.phase}\t{pod.metadata.name}")
-    return all(pod.status.phase == 'Running' for pod in pods)
+def pods_ready():
+    """
+    Return whether all pods in our test namespace are ready, which is a tougher
+    criteria than running.
 
-# wait until all of our pods are running
+    ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
+    ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podstatus-v1-core
+    """
+    pods = kube.list_namespaced_pod(namespace).items
+
+    # FIXME: we could perhaps delegate this waiting for readiness to kubernetes
+    # api and do like in z2jh:
+    # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/5703a8de9017d83242f8d4dd1ac00887c162629b/dev#L261-L266
+    all_pods_ready = True
+    for pod in pods:
+        if not any(
+            condition.type == "Ready" and condition.status == "True"
+            for condition in pod.status.conditions
+        ):
+            all_pods_ready = False
+            print(f"{pod.status.phase}\t{pod.metadata.name}")
+    return all_pods_ready
+
+# wait until all of our pods are running and ready
 try:
-    wait_for(hub_running, "Hub is up")
+    wait_for(pods_ready, "Hub is up")
 except TimeoutError:
     # show pods on timeout, in case there's a hint about what's wrong
     check_call(['kubectl', 'get', 'pod', '--all-namespaces'])


### PR DESCRIPTION
There was [a test failure](https://travis-ci.org/jupyterhub/binderhub/jobs/613744946?utm_medium=notification&utm_source=github_status) because the hub became running but later
crashed, these kinds of crashes can happen but the hub will not become
ready until the risk of it happening has gone away. So, if we wait for
the hub to be Ready as compared to only become Running, we are good.

For this to make a difference, Running must be distinguished from Ready,
which it will become in a Z2JH release where we introduced a Readiness
probe. What version of z2jh are we using?

The answer is we are using an too old one to benefit from those fixes...

Hmm... So then I had to bump z2jh, and that means a bump of JupyterHub to beyond 1.0.0.