### PR TITLE
[MRG] Pass BINDER_REPO_URL and other vars to spawned container at runtime

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -263,6 +263,7 @@ class BuildHandler(BaseHandler):
             host=self.request.host,
             base_url=self.settings['base_url'],
         )
+        # These are relative URLs so do not have a leading /
         self.binder_request = 'v2/{provider}/{spec}'.format(
             provider=provider_prefix,
             spec=spec,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -255,6 +255,8 @@ class BuildHandler(BaseHandler):
             await self.fail("Could not resolve ref for %s. Double check your URL." % key)
             return
 
+        ref_url = self.ref_url = await provider.get_resolved_ref_url()
+
         # generate a complete build name (for GitHub: `build-{user}-{repo}-{ref}`)
 
         image_prefix = self.settings['image_prefix']
@@ -329,7 +331,6 @@ class BuildHandler(BaseHandler):
             provider=provider_prefix,
             spec=resolved_spec,
         )
-        ref_url = await provider.get_resolved_ref_url()
         appendix = self.settings['appendix'].format(
             binder_url=binder_url,
             repo_url=repo_url,
@@ -509,8 +510,11 @@ class BuildHandler(BaseHandler):
                 username = launcher.unique_name_from_repo(self.repo_url)
                 server_name = ''
             try:
-                server_info = await launcher.launch(image=self.image_name, username=username,
-                                                    server_name=server_name, repo_url=self.repo_url)
+                server_info = await launcher.launch(image=self.image_name,
+                                                    username=username,
+                                                    server_name=server_name,
+                                                    repo_url=self.repo_url,
+                                                    ref_url=self.ref_url)
                 LAUNCH_TIME.labels(
                     status='success', retries=i,
                 ).observe(time.perf_counter() - launch_starttime)

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -258,17 +258,16 @@ class BuildHandler(BaseHandler):
         self.ref_url = await provider.get_resolved_ref_url()
         resolved_spec = await provider.get_resolved_spec()
 
-        self.binder_url = '{proto}://{host}{base_url}v2/{provider}/{spec}'.format(
+        self.binder_launch_host = self.settings['badge_base_url'] or '{proto}://{host}{base_url}'.format(
             proto=self.request.protocol,
             host=self.request.host,
             base_url=self.settings['base_url'],
+        )
+        self.binder_request = 'v2/{provider}/{spec}'.format(
             provider=provider_prefix,
             spec=spec,
         )
-        self.persistent_binder_url = '{proto}://{host}{base_url}v2/{provider}/{spec}'.format(
-            proto=self.request.protocol,
-            host=self.request.host,
-            base_url=self.settings['base_url'],
+        self.binder_persistent_request = 'v2/{provider}/{spec}'.format(
             provider=provider_prefix,
             spec=resolved_spec,
         )
@@ -333,9 +332,9 @@ class BuildHandler(BaseHandler):
         BuildClass = FakeBuild if self.settings.get('fake_build') else Build
 
         appendix = self.settings['appendix'].format(
-            binder_url=self.binder_url,
+            binder_url=self.binder_launch_host + self.binder_request,
+            persistent_binder_url=self.binder_launch_host + self.binder_persistent_request,
             repo_url=repo_url,
-            persistent_binder_url=self.persistent_binder_url,
             ref_url=self.ref_url,
         )
 
@@ -512,9 +511,10 @@ class BuildHandler(BaseHandler):
                 server_name = ''
             try:
                 extra_args = {
-                    'ref_url': self.ref_url,
-                    'binder_url': self.binder_url,
-                    'persistent_binder_url': self.persistent_binder_url,
+                    'binder_ref_url': self.ref_url,
+                    'binder_launch_host': self.binder_launch_host,
+                    'binder_request': self.binder_request,
+                    'binder_persistent_request': self.binder_persistent_request,
                 }
                 server_info = await launcher.launch(image=self.image_name,
                                                     username=username,

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -117,7 +117,7 @@ class Launcher(LoggingConfigurable):
         # add a random suffix to avoid collisions for users on the same image
         return '{}-{}'.format(prefix, ''.join(random.choices(SUFFIX_CHARS, k=SUFFIX_LENGTH)))
 
-    async def launch(self, image, username, server_name='', repo_url=''):
+    async def launch(self, image, username, server_name='', repo_url='', ref_url=''):
         """Launch a server for a given image
 
         - creates a temporary user on the Hub if authentication is not enabled
@@ -127,6 +127,7 @@ class Launcher(LoggingConfigurable):
           - `url`: the URL of the server
           - `image`: image spec
           - `repo_url`: the url of the repo
+          - `ref_url`: the url of this version of the repo
           - `token`: the token for the server
         """
         # TODO: validate the image argument?
@@ -156,6 +157,7 @@ class Launcher(LoggingConfigurable):
         # and also to be returned into 'ready' state
         data = {'image': image,
                 'repo_url': repo_url,
+                'ref_url': ref_url,
                 'token': base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=\n')}
 
         # server name to be used in logs

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -117,7 +117,7 @@ class Launcher(LoggingConfigurable):
         # add a random suffix to avoid collisions for users on the same image
         return '{}-{}'.format(prefix, ''.join(random.choices(SUFFIX_CHARS, k=SUFFIX_LENGTH)))
 
-    async def launch(self, image, username, server_name='', repo_url='', ref_url=''):
+    async def launch(self, image, username, server_name='', repo_url='', extra_args=None):
         """Launch a server for a given image
 
         - creates a temporary user on the Hub if authentication is not enabled
@@ -127,7 +127,7 @@ class Launcher(LoggingConfigurable):
           - `url`: the URL of the server
           - `image`: image spec
           - `repo_url`: the url of the repo
-          - `ref_url`: the url of this version of the repo
+          - `extra_args`: Dictionary of extra arguments passed to the server
           - `token`: the token for the server
         """
         # TODO: validate the image argument?
@@ -157,8 +157,9 @@ class Launcher(LoggingConfigurable):
         # and also to be returned into 'ready' state
         data = {'image': image,
                 'repo_url': repo_url,
-                'ref_url': ref_url,
                 'token': base64.urlsafe_b64encode(uuid.uuid4().bytes).decode('ascii').rstrip('=\n')}
+        if extra_args:
+            data.update(extra_args)
 
         # server name to be used in logs
         _server_name = " {}".format(server_name) if server_name else ''

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -34,6 +34,19 @@ you need to add the following into ``config.yaml``:
                     # binder service sets the image spec via user options
                     self.image = self.user_options['image']
                   return super().start()
+
+              def get_env(self):
+                  env = super(BinderSpawner, self).get_env()
+                  if 'repo_url' in self.user_options:
+                    env['BINDER_REPO_URL'] = self.user_options['repo_url']
+                  if 'ref_url' in self.user_options:
+                      env['BINDER_REF_URL'] = self.user_options['ref_url']
+                  if 'binder_url' in self.user_options:
+                      env['BINDER_URL'] = self.user_options['binder_url']
+                  if 'persistent_binder_url' in self.user_options:
+                      env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
+                  return env
+
             c.JupyterHub.spawner_class = BinderSpawner
 
       singleuser:

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -38,13 +38,14 @@ you need to add the following into ``config.yaml``:
               def get_env(self):
                   env = super(BinderSpawner, self).get_env()
                   if 'repo_url' in self.user_options:
-                    env['BINDER_REPO_URL'] = self.user_options['repo_url']
-                  if 'ref_url' in self.user_options:
-                      env['BINDER_REF_URL'] = self.user_options['ref_url']
-                  if 'binder_url' in self.user_options:
-                      env['BINDER_URL'] = self.user_options['binder_url']
-                  if 'persistent_binder_url' in self.user_options:
-                      env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
+                      env['BINDER_REPO_URL'] = self.user_options['repo_url']
+                  for key in (
+                          'binder_ref_url',
+                          'binder_launch_host',
+                          'binder_persistent_request',
+                          'binder_request'):
+                      if key in self.user_options:
+                          env[key.upper()] = self.user_options[key]
                   return env
 
             c.JupyterHub.spawner_class = BinderSpawner

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -100,19 +100,15 @@ jupyterhub:
               return super().start()
 
           def get_env(self):
-              if 'repo_url' not in self.user_options:
-                  raise web.HTTPError(400, "repo_url required")
-              if 'ref_url' not in self.user_options:
-                  raise web.HTTPError(400, "ref_url required")
-              if 'binder_url' not in self.user_options:
-                  raise web.HTTPError(400, "binder_url required")
-              if 'persistent_binder_url' not in self.user_options:
-                  raise web.HTTPError(400, "persistent_binder_url required")
               env = super(BinderSpawner, self).get_env()
-              env['BINDER_REPO_URL'] = self.user_options['repo_url']
-              env['BINDER_REF_URL'] = self.user_options['ref_url']
-              env['BINDER_URL'] = self.user_options['binder_url']
-              env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
+              if 'repo_url' in self.user_options:
+                env['BINDER_REPO_URL'] = self.user_options['repo_url']
+              if 'ref_url' in self.user_options:
+                  env['BINDER_REF_URL'] = self.user_options['ref_url']
+              if 'binder_url' in self.user_options:
+                  env['BINDER_URL'] = self.user_options['binder_url']
+              if 'persistent_binder_url' in self.user_options:
+                  env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
               return env
 
         c.JupyterHub.spawner_class = BinderSpawner

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -99,6 +99,13 @@ jupyterhub:
               self.image = self.user_options['image']
               return super().start()
 
+          def get_env(self):
+              if 'repo_url' not in self.user_options:
+                  raise web.HTTPError(400, "repo_url required")
+              env = super(BinderSpawner, self).get_env()
+              env['BINDER_REPO_URL'] = self.user_options['repo_url']
+              return env
+
         c.JupyterHub.spawner_class = BinderSpawner
     services:
       binder:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -102,13 +102,14 @@ jupyterhub:
           def get_env(self):
               env = super(BinderSpawner, self).get_env()
               if 'repo_url' in self.user_options:
-                env['BINDER_REPO_URL'] = self.user_options['repo_url']
-              if 'ref_url' in self.user_options:
-                  env['BINDER_REF_URL'] = self.user_options['ref_url']
-              if 'binder_url' in self.user_options:
-                  env['BINDER_URL'] = self.user_options['binder_url']
-              if 'persistent_binder_url' in self.user_options:
-                  env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
+                  env['BINDER_REPO_URL'] = self.user_options['repo_url']
+              for key in (
+                      'binder_ref_url',
+                      'binder_launch_host',
+                      'binder_persistent_request',
+                      'binder_request'):
+                  if key in self.user_options:
+                      env[key.upper()] = self.user_options[key]
               return env
 
         c.JupyterHub.spawner_class = BinderSpawner

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -102,8 +102,11 @@ jupyterhub:
           def get_env(self):
               if 'repo_url' not in self.user_options:
                   raise web.HTTPError(400, "repo_url required")
+              if 'ref_url' not in self.user_options:
+                  raise web.HTTPError(400, "ref_url required")
               env = super(BinderSpawner, self).get_env()
               env['BINDER_REPO_URL'] = self.user_options['repo_url']
+              env['BINDER_REF_URL'] = self.user_options['ref_url']
               return env
 
         c.JupyterHub.spawner_class = BinderSpawner

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -104,9 +104,15 @@ jupyterhub:
                   raise web.HTTPError(400, "repo_url required")
               if 'ref_url' not in self.user_options:
                   raise web.HTTPError(400, "ref_url required")
+              if 'binder_url' not in self.user_options:
+                  raise web.HTTPError(400, "binder_url required")
+              if 'persistent_binder_url' not in self.user_options:
+                  raise web.HTTPError(400, "persistent_binder_url required")
               env = super(BinderSpawner, self).get_env()
               env['BINDER_REPO_URL'] = self.user_options['repo_url']
               env['BINDER_REF_URL'] = self.user_options['ref_url']
+              env['BINDER_URL'] = self.user_options['binder_url']
+              env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
               return env
 
         c.JupyterHub.spawner_class = BinderSpawner

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -43,13 +43,14 @@ hub:
         def get_env(self):
             env = super(BinderSpawner, self).get_env()
             if 'repo_url' in self.user_options:
-              env['BINDER_REPO_URL'] = self.user_options['repo_url']
-            if 'ref_url' in self.user_options:
-                env['BINDER_REF_URL'] = self.user_options['ref_url']
-            if 'binder_url' in self.user_options:
-                env['BINDER_URL'] = self.user_options['binder_url']
-            if 'persistent_binder_url' in self.user_options:
-                env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
+                env['BINDER_REPO_URL'] = self.user_options['repo_url']
+            for key in (
+                    'binder_ref_url',
+                    'binder_launch_host',
+                    'binder_persistent_request',
+                    'binder_request'):
+                if key in self.user_options:
+                    env[key.upper()] = self.user_options[key]
             return env
 
       # launch jupyter notebook instead of jupyterhub-singleuser

--- a/testing/minikube/jupyterhub-helm-config.yaml
+++ b/testing/minikube/jupyterhub-helm-config.yaml
@@ -40,6 +40,18 @@ hub:
             self.image_spec = self.user_options['image']
             return super().start()
 
+        def get_env(self):
+            env = super(BinderSpawner, self).get_env()
+            if 'repo_url' in self.user_options:
+              env['BINDER_REPO_URL'] = self.user_options['repo_url']
+            if 'ref_url' in self.user_options:
+                env['BINDER_REF_URL'] = self.user_options['ref_url']
+            if 'binder_url' in self.user_options:
+                env['BINDER_URL'] = self.user_options['binder_url']
+            if 'persistent_binder_url' in self.user_options:
+                env['BINDER_PERSISTENT_URL'] = self.user_options['persistent_binder_url']
+            return env
+
       # launch jupyter notebook instead of jupyterhub-singleuser
       c.JupyterHub.spawner_class = BinderSpawner
 


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/mybinder.org-deploy/pull/1202

`repo_url` is already passed to to the spawner:
https://github.com/jupyterhub/binderhub/blob/e0d720d8b663f2078040c973876f656207e37817/binderhub/builder.py#L512-L513

https://github.com/jupyterhub/binderhub/blob/e0d720d8b663f2078040c973876f656207e37817/binderhub/launcher.py#L155-L159

So instead of setting it at build-time (only applies to new builds) it can be set at run-time.

I've called it `BINDER_REPO_URL` instead of `REPO_URL` used in https://github.com/jupyterhub/mybinder.org-deploy/pull/1202 to make it more specific.