### PR TITLE
Add "selector" to BinderHub Deployment object for k8s 1.16

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -1,9 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: binder
 spec:
   replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: binder
+      component: binder
+      release: {{ .Release.Name }}
   strategy:
     rollingUpdate:
         {{- if eq (.Values.replicas | int) 1 }}

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.dind.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Release.Name }}-dind

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -1,6 +1,6 @@
 {{ if .Values.imageCleaner.enabled -}}
 {{- $Values := .Values -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ .Release.Name }}-image-cleaner

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.ingress.enabled -}}
+# FIXME: Update before k8s 1.20 but after we no longer require support for k8s
+# 1.14. networking.k8s.io/v1beta1 was introduced in k8s 1.14 to replace
+# extensions/v1beta1 that goes away in k8s 1.20.
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
We also need to bump to a k8s 1.16 compateble z2jh helm chart release,
as the user-scheduler isn't working currently with k8s 1.16 for example.

Closes #1011 