### PR TITLE
Bump Z2JH for final part of K8s 1.16 compatibility

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.9.0-alpha.1.033.fd3e470"
+  version: "0.9.0-alpha.1.071.b0d70c2"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
Do not merge this until after #1012, that has other pieces of importance as well, and this has one of that PRs commits in it so it turns out good that way.