### PR TITLE
[MRG] Add top level path back to chartpress context to fix build issue

### DIFF
--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -6,6 +6,10 @@ charts:
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart
+    # We need the broader context to make sure we do not produce a chart
+    # tagged with an older version that contains a newer image
+    paths:
+      - ..
     resetTag: local
     resetVersion: 0.2.0
     # NOTE: All paths will be set relative to this file's location, which is in the


### PR DESCRIPTION
Without this wider context we sometimes produce an old chart version
with a new image inside.

This is a follow up for #1004 where we removed this but shouldn't have. Was spotted in https://github.com/jupyterhub/binderhub/issues/919#issuecomment-559370276

cc @bitnik @consideRatio 