### PR TITLE
[MRG] Update dockerd version used for DIND

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -145,7 +145,7 @@ dind:
   daemonset:
     image:
       name: docker
-      tag: 18.09.2-dind
+      tag: 19.03.5-dind
     # Additional command line arguments to pass to dockerd
     extraArgs: []
   storageDriver: overlay2


### PR DESCRIPTION
Upgrade from 18.x to 19.x for the dockerd we use for DIND.

Keeping current is probably a good thing.