### PR TITLE
[MRG] Add a "absolute" size mode to the image cleaner

### DIFF
--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -54,6 +54,8 @@ spec:
           value: /var/lib/docker
         - name: IMAGE_GC_DELAY
           value: {{ $Values.imageCleaner.delay | quote }}
+        - name: IMAGE_GC_THRESHOLD_TYPE
+          value: {{ $Values.imageCleaner.imageGCThresholdType }}
         - name: IMAGE_GC_THRESHOLD_HIGH
           value: {{ $Values.imageCleaner.imageGCThresholdHigh | quote }}
         - name: IMAGE_GC_THRESHOLD_LOW

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -161,6 +161,8 @@ imageCleaner:
     repository: jupyterhub/k8s-image-cleaner
   # delete an image at most every 5 seconds
   delay: 5
+  # Interpret threshold values as percentage or bytes
+  imageGCThresholdType: "relative"
   # when 80% of inodes are used,
   # cull images until it drops below 60%
   imageGCThresholdHigh: 80

--- a/helm-chart/images/image-cleaner/image-cleaner.py
+++ b/helm-chart/images/image-cleaner/image-cleaner.py
@@ -138,6 +138,11 @@ def main():
     client = docker.from_env(version='auto')
     images = get_docker_images(client)
 
+    # with the threshold type set to relative the thresholds are interpreted
+    # as a percentage of how full the partition is. In absolute mode the
+    # thresholds are interpreted as size in bytes. By default you should use
+    # "relative" mode. Use "absolute" mode when you are using DIND and your
+    # nodes only have one partition.
     if gc_threshold_type == "relative":
         get_used = get_used_percent
         used_msg = '{used:.1f}% used'


### PR DESCRIPTION
On some deployments with DIND enabled the docker images from our builds
and the k8s dockerd are on the same partition. This means the GC of DIND
and k8s get in each others way. The "absolute" mode computes the size of
the docker directory and acts if it is too big in bytes.

The problem arises because our image cleaner and the k8s garbage collection both look at the fractional fullness of the disk. What ends up happening is that one of the docker image stores gets emptied completely because even removing all the images from it doesn't drop the disk usage low enough.

With this "absolute" mode we can configure a maximum size in GB per docker image store.

The downside is that computing the size of a tree of directories is slower than asking for the fullness of a partition.

Merging this doesn't change the default behaviour, it is an option you can opt-in to. The reason I added this is so we can use it on the OVH cluster where we have exactly the problem I described above.