### PR TITLE
Bump chartpress to 0.5.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio
 pytest-cov
 requests
 ruamel.yaml>=0.15
-chartpress>=0.4.3,<0.5
+chartpress==0.5.*
 jupyterhub

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -16,7 +16,7 @@ nodeSelector: {}
 
 image:
   name: jupyterhub/k8s-binderhub
-  tag: local
+  tag: 'local'
 
 # registry here is only used to create docker config.json
 registry:
@@ -157,7 +157,7 @@ imageCleaner:
   enabled: true
   image:
     name: jupyterhub/k8s-image-cleaner
-    tag: local
+    tag: 'local'
     repository: jupyterhub/k8s-image-cleaner
   # delete an image at most every 5 seconds
   delay: 5

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -1,19 +1,16 @@
 # For a reference on this configuration, see the chartpress README file.
 # ref: https://github.com/jupyterhub/chartpress
+#
+# NOTE: All paths will be set relative to this file's location, which is in the
+#       helm-chart folder.
 charts:
   - name: binderhub
     imagePrefix: jupyterhub/k8s-
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart
-    # We need the broader context to make sure we do not produce a chart
-    # tagged with an older version that contains a newer image
-    paths:
-      - ..
     resetTag: local
     resetVersion: 0.2.0
-    # NOTE: All paths will be set relative to this file's location, which is in the
-    # helm-chart folder.
     images:
       image-cleaner:
         valuesPath: imageCleaner.image


### PR DESCRIPTION
Chartpress 0.5.0 contains a bugfix that makes a chart's images' context
paths be considered when determening the version of the chart as well as
the chart folder. This was not done before and caused issues, that made
us require https://github.com/jupyterhub/binderhub/pull/1014 which can
now be reverted in this commit.