### PR TITLE
[Do not merge] Bump chartpress 0.5.0 - A verification

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio
 pytest-cov
 requests
 ruamel.yaml>=0.15
-chartpress>=0.4.3,<0.5
+chartpress==0.5.*
 jupyterhub

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -1,19 +1,16 @@
 # For a reference on this configuration, see the chartpress README file.
 # ref: https://github.com/jupyterhub/chartpress
+#
+# NOTE: All paths will be set relative to this file's location, which is in the
+#       helm-chart folder.
 charts:
   - name: binderhub
     imagePrefix: jupyterhub/k8s-
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart
-    # We need the broader context to make sure we do not produce a chart
-    # tagged with an older version that contains a newer image
-    paths:
-      - ..
     resetTag: local
     resetVersion: 0.2.0
-    # NOTE: All paths will be set relative to this file's location, which is in the
-    # helm-chart folder.
     images:
       image-cleaner:
         valuesPath: imageCleaner.image

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,6 +1,6 @@
 pycurl==7.43.0.1
 tornado==5.0.*
-kubernetes==9.0.*
+kubernetes==10.0.*
 jupyterhub==1.0.0
 jsonschema==2.6.0
 # Logging sinks to send eventlogging events to


### PR DESCRIPTION
This is meant to verify that the chart version is bumped along with the image version in an additional commit added to this PR over the one in #1020.

To verify the chart version is bumped, we will inspect the CI build logs about what image tag and chart version is used. We want it to be the same and not to see the hub image tag to use a later version than the chart.