### PR TITLE
reduce configuration of authentication with named servers

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -165,11 +165,6 @@ class BinderHub(Application):
         start the new server for the logged in user.""",
         config=True)
 
-    use_named_servers = Bool(
-        False,
-        help="Use named servers when authentication is enabled.",
-        config=True)
-
     port = Integer(
         8585,
         help="""
@@ -593,7 +588,6 @@ class BinderHub(Application):
             'template_variables': self.template_variables,
             'executor': self.executor,
             'auth_enabled': self.auth_enabled,
-            'use_named_servers': self.use_named_servers,
             'event_log': self.event_log,
             'normalized_origin': self.normalized_origin
         })

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -501,7 +501,7 @@ class BuildHandler(BaseHandler):
                 # get logged in user's name
                 user_model = self.hub_auth.get_user(self)
                 username = user_model['name']
-                if self.settings['use_named_servers']:
+                if launcher.allow_named_servers:
                     # user can launch multiple servers, so create a unique server name
                     server_name = launcher.unique_name_from_repo(self.repo_url)
                 else:

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -35,6 +35,12 @@ class Launcher(LoggingConfigurable):
     hub_api_token = Unicode(help="The API token for the Hub")
     hub_url = Unicode(help="The URL of the Hub")
     create_user = Bool(True, help="Create a new Hub user")
+    allow_named_servers = Bool(
+        os.getenv('JUPYTERHUB_ALLOW_NAMED_SERVERS', False),
+        config=True,
+        help="Named user servers are allowed. This is used only when authentication is enabled and "
+             "to set unique names for user servers."
+    )
     retries = Integer(
         4,
         config=True,

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -36,7 +36,7 @@ class Launcher(LoggingConfigurable):
     hub_url = Unicode(help="The URL of the Hub")
     create_user = Bool(True, help="Create a new Hub user")
     allow_named_servers = Bool(
-        os.getenv('JUPYTERHUB_ALLOW_NAMED_SERVERS', False),
+        os.getenv('JUPYTERHUB_ALLOW_NAMED_SERVERS', "false") == "true",
         config=True,
         help="Named user servers are allowed. This is used only when authentication is enabled and "
              "to set unique names for user servers."

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -65,9 +65,6 @@ you have to enable named servers on JupyterHub:
 
 .. code:: yaml
 
-    config:
-      BinderHub:
-        use_named_servers: true
     jupyterhub:
       hub:
         allowNamedServers: true

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -103,7 +103,7 @@ spec:
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
         - name: JUPYTERHUB_ALLOW_NAMED_SERVERS
-          value: {{ .Values.jupyterhub.hub.allowNamedServers }}
+          value: {{ .Values.jupyterhub.hub.allowNamedServers | quote }}
         {{- end }}
         {{ if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -102,6 +102,8 @@ spec:
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_client_id | quote}}
         - name: JUPYTERHUB_OAUTH_CALLBACK_URL
           value: {{ .Values.jupyterhub.hub.services.binder.oauth_redirect_uri | quote}}
+        - name: JUPYTERHUB_ALLOW_NAMED_SERVERS
+          value: {{ .Values.jupyterhub.hub.allowNamedServers }}
         {{- end }}
         {{ if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 8 }}


### PR DESCRIPTION
This PR removes `use_named_servers` config from binderhub and makes `Launcher` to get it from an env variable which is set by `jupyterhub.hub.allowNamedServers`.