### PR TITLE
[MRG]: badge_base_url can be a function that gets the parameter from the HTTP RequestHandler

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -23,6 +23,7 @@ import tornado.web
 from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, default
 from traitlets.config import Application
 from jupyterhub.services.auth import HubOAuthCallbackHandler
+from jupyterhub.traitlets import Callable
 
 from .base import AboutHandler, Custom404, VersionHandler
 from .build import Build
@@ -158,6 +159,18 @@ class BinderHub(Application):
         if proposal.value and not proposal.value.endswith('/'):
             proposal.value = proposal.value + '/'
         return proposal.value
+
+    launch_host_allowed = Callable(
+        None,
+        config=True,
+        allow_none=True,
+        help="""
+        Callable that checks whether a Binder launch host passed via the
+        X-Binder-Launch-Host header is allowed
+
+        When set to None (default) the header is ignored.
+        """
+    )
 
     auth_enabled = Bool(
         False,
@@ -585,6 +598,7 @@ class BinderHub(Application):
             'build_docker_host': self.build_docker_host,
             'base_url': self.base_url,
             'badge_base_url': self.badge_base_url,
+            'launch_host_allowed': self.launch_host_allowed,
             "static_path": os.path.join(HERE, "static"),
             'static_url_prefix': url_path_join(self.base_url, 'static/'),
             'template_variables': self.template_variables,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -20,7 +20,7 @@ import tornado.options
 import tornado.log
 from tornado.log import app_log
 import tornado.web
-from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, default
+from traitlets import Unicode, Integer, Bool, Dict, validate, TraitError, Union, default
 from traitlets.config import Application
 from jupyterhub.services.auth import HubOAuthCallbackHandler
 from jupyterhub.traitlets import Callable
@@ -148,29 +148,31 @@ class BinderHub(Application):
             proposal.value = proposal.value + '/'
         return proposal.value
 
-    badge_base_url = Unicode(
-        '',
-        help="Base URL to use when generating launch badges",
+    badge_base_url = Union(
+        trait_types=[Unicode(), Callable()],
+        help="""
+        Base URL to use when generating launch badges.
+        Can also be a function that is passed the current handler and returns
+        the badge base URL, or "" for the default.
+
+        For example, you could get the badge_base_url from a custom HTTP
+        header, the Referer header, or from a request parameter
+        """,
         config=True
     )
+
+    @default('badge_base_url')
+    def _badge_base_url_default(self):
+        return '/'
+
     @validate('badge_base_url')
     def _valid_badge_base_url(self, proposal):
+        if callable(proposal.value):
+            return proposal.value
         # add a trailing slash only when a value is set
         if proposal.value and not proposal.value.endswith('/'):
             proposal.value = proposal.value + '/'
         return proposal.value
-
-    launch_host_allowed = Callable(
-        None,
-        config=True,
-        allow_none=True,
-        help="""
-        Callable that checks whether a Binder launch host passed via the
-        X-Binder-Launch-Host header is allowed
-
-        When set to None (default) the header is ignored.
-        """
-    )
 
     auth_enabled = Bool(
         False,
@@ -598,7 +600,6 @@ class BinderHub(Application):
             'build_docker_host': self.build_docker_host,
             'base_url': self.base_url,
             'badge_base_url': self.badge_base_url,
-            'launch_host_allowed': self.launch_host_allowed,
             "static_path": os.path.join(HERE, "static"),
             'static_url_prefix': url_path_join(self.base_url, 'static/'),
             'template_variables': self.template_variables,

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -52,6 +52,12 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
         return providers[provider_prefix](
             config=self.settings['traitlets_config'], spec=spec)
 
+    def get_badge_base_url(self):
+        badge_base_url = self.settings['badge_base_url']
+        if callable(badge_base_url):
+            badge_base_url = badge_base_url(self)
+        return badge_base_url
+
     def render_template(self, name, **extra_ns):
         """Render an HTML page"""
         ns = {}

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -258,7 +258,14 @@ class BuildHandler(BaseHandler):
         self.ref_url = await provider.get_resolved_ref_url()
         resolved_spec = await provider.get_resolved_spec()
 
-        self.binder_launch_host = self.settings['badge_base_url'] or '{proto}://{host}{base_url}'.format(
+        launch_host = None
+        if self.settings['launch_host_allowed']:
+            launch_host_hdr = self.request.headers.get('X-Binder-Launch-Host', '')
+            if self.settings['launch_host_allowed'](launch_host_hdr):
+                launch_host = launch_host_hdr
+                if launch_host and not launch_host.endswith('/'):
+                    launch_host += '/'
+        self.binder_launch_host = launch_host or self.settings['badge_base_url'] or '{proto}://{host}{base_url}'.format(
             proto=self.request.protocol,
             host=self.request.host,
             base_url=self.settings['base_url'],

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -258,9 +258,7 @@ class BuildHandler(BaseHandler):
         self.ref_url = await provider.get_resolved_ref_url()
         resolved_spec = await provider.get_resolved_spec()
 
-        badge_base_url = self.settings['badge_base_url']
-        if callable(badge_base_url):
-            badge_base_url = badge_base_url(self)
+        badge_base_url = self.get_badge_base_url()
         self.binder_launch_host = badge_base_url or '{proto}://{host}{base_url}'.format(
             proto=self.request.protocol,
             host=self.request.host,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -258,14 +258,10 @@ class BuildHandler(BaseHandler):
         self.ref_url = await provider.get_resolved_ref_url()
         resolved_spec = await provider.get_resolved_spec()
 
-        launch_host = None
-        if self.settings['launch_host_allowed']:
-            launch_host_hdr = self.request.headers.get('X-Binder-Launch-Host', '')
-            if self.settings['launch_host_allowed'](launch_host_hdr):
-                launch_host = launch_host_hdr
-                if launch_host and not launch_host.endswith('/'):
-                    launch_host += '/'
-        self.binder_launch_host = launch_host or self.settings['badge_base_url'] or '{proto}://{host}{base_url}'.format(
+        badge_base_url = self.settings['badge_base_url']
+        if callable(badge_base_url):
+            badge_base_url = badge_base_url(self)
+        self.binder_launch_host = badge_base_url or '{proto}://{host}{base_url}'.format(
             proto=self.request.protocol,
             host=self.request.host,
             base_url=self.settings['base_url'],

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -26,9 +26,12 @@ class MainHandler(BaseHandler):
 
     @authenticated
     def get(self):
+        badge_base_url = self.settings['badge_base_url']
+        if callable(badge_base_url):
+            badge_base_url = badge_base_url(self)
         self.render_template(
             "index.html",
-            badge_base_url=self.settings['badge_base_url'],
+            badge_base_url=badge_base_url,
             base_url=self.settings['base_url'],
             submit=False,
             google_analytics_code=self.settings['google_analytics_code'],
@@ -91,10 +94,13 @@ class ParameterizedMainHandler(BaseHandler):
             if response.code >= 400:
                 nbviewer_url = None
 
+        badge_base_url = self.settings['badge_base_url']
+        if callable(badge_base_url):
+            badge_base_url = badge_base_url(self)
         self.render_template(
             "loading.html",
             base_url=self.settings['base_url'],
-            badge_base_url=self.settings['badge_base_url'],
+            badge_base_url=badge_base_url,
             provider_spec=provider_spec,
             social_desc=social_desc,
             nbviewer_url=nbviewer_url,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -26,12 +26,9 @@ class MainHandler(BaseHandler):
 
     @authenticated
     def get(self):
-        badge_base_url = self.settings['badge_base_url']
-        if callable(badge_base_url):
-            badge_base_url = badge_base_url(self)
         self.render_template(
             "index.html",
-            badge_base_url=badge_base_url,
+            badge_base_url=self.get_badge_base_url(),
             base_url=self.settings['base_url'],
             submit=False,
             google_analytics_code=self.settings['google_analytics_code'],
@@ -94,13 +91,10 @@ class ParameterizedMainHandler(BaseHandler):
             if response.code >= 400:
                 nbviewer_url = None
 
-        badge_base_url = self.settings['badge_base_url']
-        if callable(badge_base_url):
-            badge_base_url = badge_base_url(self)
         self.render_template(
             "loading.html",
             base_url=self.settings['base_url'],
-            badge_base_url=badge_base_url,
+            badge_base_url=self.get_badge_base_url(),
             provider_spec=provider_spec,
             social_desc=social_desc,
             nbviewer_url=nbviewer_url,


### PR DESCRIPTION
This allows the `badge_base_url` setting and therefore the `BINDER_LAUNCH_HOST` environment variable to be set from a HTTP request, and is intended to allow a BinderHub to have different values of the variable depending on the original source of the request.

For example, Gesis currently has a mix of `https://mybinder.org` and `https://notebooks.gesis.org/binder` in different places. By changing `badge_base_url` to check for a parameter in the request it should be possible to have the URLs match consistently depending on whether the user was redirected from mybinder (e.g. the redirector could set a query parameter  `binder_launch_host=https://mybinder.org/`) or directly (no parameter, default behaviour).

For example:
```
    def badge_base_url(handler):
        launch_host = (
            handler.request.headers.get('X-Binder-Launch-Host', '') or
            handler.get_argument('binder_launch_host', ''))
        print('launch_host', launch_host)
        if launch_host and not launch_host.endswith('/'):
            launch_host += '/'
        if launch_host == 'https://mybinder.org/':
            return launch_host
        return ''
    c.BinderHub.badge_base_url = badge_base_url
```

See discussion starting from https://github.com/jupyterhub/mybinder.org-deploy/pull/1284#issuecomment-560273078

I've tested this locally using curl:
`curl http://binder-test-host/build/gh/manics/jupyter-offlinenotebook/7ba3520553c414d0b55e80b96c0f6df85f903078?binder_launch_host=https://mybinder.org`
this will spit out a URL and token that can be copied into a browser.

To work with the mybinder federation this will require the parameter to be passed in proxy requests made by the redirector:
- https://github.com/jupyterhub/mybinder.org-deploy/blob/f92e921b031876ad7dd9f5ac05b33eba793c12a6/images/federation-redirect/app.py#L117
- https://github.com/jupyterhub/mybinder.org-deploy/blob/f92e921b031876ad7dd9f5ac05b33eba793c12a6/images/federation-redirect/app.py#L166 