### PR TITLE
re-organize requirements files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ install:
   - export PATH=$PWD/bin:$PATH
   - pip install --upgrade pip setuptools
   - ./ci/install.sh
-  - pip install --upgrade -r dev-requirements.txt
+  - pip install --upgrade . -r dev-requirements.txt
   - npm install
   - npm run webpack
-  - pip install --upgrade . -r helm-chart/images/binderhub/requirements.txt
   - pip freeze
 
 script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ every day development.
 * Install JupyterHub in minikube with helm `./testing/minikube/install-hub`
 * Setup `docker` to use the same Docker daemon as your minikube cluster `eval $(minikube docker-env)`
 * Start BinderHub `python3 -m binderhub -f testing/minikube/binderhub_config.py`
-* Visit your BinderHub at[http://localhost:8585](http://localhost:8585)
+* Visit your BinderHub at [http://localhost:8585](http://localhost:8585)
 
 To execute most of our test suite you need a running minikube cluster.
 It does not need to have anything installed on it though:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ sudo apt install socat
 1. Install BinderHub and its development requirements:
 
     ```bash
-    python3 -m pip install -e . -r dev-requirements.txt -r helm-chart/images/binderhub/requirements.txt
+    python3 -m pip install -e . -r dev-requirements.txt
     ```
 
 1. Install JupyterHub in minikube with helm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ all images involved and deploy it locally. Steps to do this:
 1. setup docker to user the minikube dockerd `eval $(minikube docker-env)`
 1. build the helm chart `cd helm-chart && chartpress && cd ..`
 1. install the BinderHub chart with
-```
+```bash
 helm install \
   --name binder-test \
   --namespace binder-test-helm \
@@ -217,7 +217,7 @@ sudo apt install socat
 1. Install BinderHub and its development requirements:
 
     ```bash
-    python3 -m pip install -e . -r dev-requirements.txt
+    python3 -m pip install -e . -r dev-requirements.txt -r helm-chart/images/binderhub/requirements.txt
     ```
 
 1. Install JupyterHub in minikube with helm

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,3 @@ pytest-cov
 requests
 ruamel.yaml>=0.15
 chartpress==0.5.*
-jupyterhub

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 requests
 ruamel.yaml>=0.15
 chartpress==0.5.*
+-r helm-chart/images/binderhub/requirements.txt

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -6,17 +6,7 @@ traitlets
 pandas
 ruamel.yaml
 git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master
-# install BinderHub dependencies. We manually list them here because some
-# dependencies (like pycurl) can't be installed on ReadTheDocs and aren't
-# needed to build the docs.
-kubernetes==9.0.*
-escapism
-tornado
-traitlets
-docker
-jinja2
-prometheus_client
-python-json-logger
-jupyterhub
-jsonschema
-#pycurl Do not install for docs as it breaks the RTD build. Its primary use is for mocks in testing .
+# install BinderHub from source but because `pip install` is executed in the
+# root directory (not this directory) of this repository we write '.' here
+# not '..' as you might expect when thinking relative to this file.
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# When you change this file please also update `doc/doc-requirements.txt`
-# which needs to be kept in sync manually.
 kubernetes==9.0.*
 escapism
 tornado

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ prometheus_client
 python-json-logger
 jupyterhub
 jsonschema
-pycurl


### PR DESCRIPTION
I tried to re-organize requirements files and reduce them

1. added instruction to install `helm-chart/images/binderhub/requirements.txt` when installing BinderHub locally with minikube. this is also what [travis does](https://github.com/jupyterhub/binderhub/blob/fb977f4642638da69f184fdc7a7fd3c26a157a9f/.travis.yml#L19-L22) and I think they should be same f we want to have same results from tests.

2. removed `pycurl` from `requirements.txt` because it is already included in `helm-chart/images/binderhub/requirements.txt`. with this we don't have to manually update `doc-requirements.txt` each time `requirements.txt` is updated.

3. removed `jupyterhub` from `dev-requirements.txt` because it is not required for building docs, it is already included in `helm-chart/images/binderhub/requirements.txt` and they (`dev-requirements.txt` and `helm-chart/images/binderhub/requirements.txt`) are installed together.