### PR TITLE
Default badge_base_url should be empty not /

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -163,7 +163,7 @@ class BinderHub(Application):
 
     @default('badge_base_url')
     def _badge_base_url_default(self):
-        return '/'
+        return ''
 
     @validate('badge_base_url')
     def _valid_badge_base_url(self, proposal):


### PR DESCRIPTION
I inadvertently set the badge base url default to `"/"` instead of `""` in
https://github.com/jupyterhub/binderhub/pull/1031/files#diff-a15f2374919ff29de22fa29a192b1fd1L150-R166

Closes https://github.com/jupyterhub/binderhub/issues/1034