### PR TITLE
Bump chartpress for helm 3 compatebility of dev releases

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio
 pytest-cov
 requests
 ruamel.yaml>=0.15
-chartpress==0.5.*
+chartpress==0.6.*
 jupyterhub


### PR DESCRIPTION
This is important for Helm 3 compatebility, see the chartpress changelog: https://github.com/jupyterhub/chartpress/blob/master/CHANGELOG.md#060---2020-01-12