### PR TITLE
Serve UI config from the backend

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -729,7 +729,7 @@ class BinderHub(Application):
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
             (r'/health', HealthHandler, {'hub_url': self.hub_url_local}),
-            (r'/_config', ConfigHandler, {'repo_providers': self.repo_providers}),
+            (r'/_config', ConfigHandler),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -729,7 +729,7 @@ class BinderHub(Application):
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
             (r'/health', HealthHandler, {'hub_url': self.hub_url_local}),
-            (r'/_config', ConfigHandler),
+            (r'/_config', ConfigHandler, {'repo_providers': self.repo_providers}),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -39,6 +39,7 @@ from jupyterhub.traitlets import Callable
 from .base import AboutHandler, Custom404, VersionHandler
 from .build import Build
 from .builder import BuildHandler
+from .config import ConfigHandler
 from .health import HealthHandler
 from .launcher import Launcher
 from .log import log_request
@@ -728,6 +729,7 @@ class BinderHub(Application):
                 {'path': os.path.join(self.tornado_settings['static_path'], 'images')}),
             (r'/about', AboutHandler),
             (r'/health', HealthHandler, {'hub_url': self.hub_url_local}),
+            (r'/_config', ConfigHandler),
             (r'/', MainHandler),
             (r'.*', Custom404),
         ]

--- a/binderhub/config.py
+++ b/binderhub/config.py
@@ -3,12 +3,9 @@ from .base import BaseHandler
 
 class ConfigHandler(BaseHandler):
     """Serve config"""
-    def initialize(self, repo_providers=None):
-        self.repo_providers = repo_providers
-
     def generate_config(self):
         config = dict()
-        for repo_provider_class_alias, repo_provider_class in self.repo_providers.items():
+        for repo_provider_class_alias, repo_provider_class in self.settings["repo_providers"].items():
             config[repo_provider_class_alias] = repo_provider_class.labels
         return config
 

--- a/binderhub/config.py
+++ b/binderhub/config.py
@@ -1,0 +1,61 @@
+import os
+import json
+
+from tornado.log import app_log
+
+from .base import BaseHandler
+
+config = {
+    "gh": {
+       "text": "GitHub repository name or URL",
+       "tag_text": "Git ref (branch, tag, or commit)",
+       "ref_prop_disabled": False,
+       "label_prop_disabled": False,
+    },
+    "gist": {
+        "text": "Gist ID (username/gistId) or URL",
+        "tag_text": "Git commit SHA",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+
+    },
+    "gl": {
+        "text": "GitLab repository name or URL",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+    },
+    "git": {
+        "text": "Arbitrary git repository URL (http://git.example.com/repo)",
+        "tag_text": "Git ref (branch, tag, or commit) SHA",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+    },
+    "zenodo": {
+        "text": "Zenodo DOI (10.5281/zenodo.3242074)",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    },
+    "figshare": {
+        "text": "Figshare DOI (10.6084/m9.figshare.9782777.v1)",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    },
+    "dataverse": {
+        "text": "Dataverse DOI (10.7910/DVN/TJCLKP)",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    },
+}
+
+
+class ConfigHandler(BaseHandler):
+    """Serve config"""
+
+    async def get(self):
+        cfg = json.dumps(config)
+        loaded_r = json.loads(cfg)
+        self.write(loaded_r)

--- a/binderhub/config.py
+++ b/binderhub/config.py
@@ -1,61 +1,16 @@
-import os
-import json
-
 from tornado.log import app_log
-
 from .base import BaseHandler
-
-config = {
-    "gh": {
-       "text": "GitHub repository name or URL",
-       "tag_text": "Git ref (branch, tag, or commit)",
-       "ref_prop_disabled": False,
-       "label_prop_disabled": False,
-    },
-    "gist": {
-        "text": "Gist ID (username/gistId) or URL",
-        "tag_text": "Git commit SHA",
-        "ref_prop_disabled": False,
-        "label_prop_disabled": False,
-
-    },
-    "gl": {
-        "text": "GitLab repository name or URL",
-        "tag_text": "Git ref (branch, tag, or commit)",
-        "ref_prop_disabled": False,
-        "label_prop_disabled": False,
-    },
-    "git": {
-        "text": "Arbitrary git repository URL (http://git.example.com/repo)",
-        "tag_text": "Git ref (branch, tag, or commit) SHA",
-        "ref_prop_disabled": False,
-        "label_prop_disabled": False,
-    },
-    "zenodo": {
-        "text": "Zenodo DOI (10.5281/zenodo.3242074)",
-        "tag_text": "Git ref (branch, tag, or commit)",
-        "ref_prop_disabled": True,
-        "label_prop_disabled": True,
-    },
-    "figshare": {
-        "text": "Figshare DOI (10.6084/m9.figshare.9782777.v1)",
-        "tag_text": "Git ref (branch, tag, or commit)",
-        "ref_prop_disabled": True,
-        "label_prop_disabled": True,
-    },
-    "dataverse": {
-        "text": "Dataverse DOI (10.7910/DVN/TJCLKP)",
-        "tag_text": "Git ref (branch, tag, or commit)",
-        "ref_prop_disabled": True,
-        "label_prop_disabled": True,
-    },
-}
-
 
 class ConfigHandler(BaseHandler):
     """Serve config"""
+    def initialize(self, repo_providers=None):
+        self.repo_providers = repo_providers
+
+    def generate_config(self):
+        config = dict()
+        for repo_provider_class_alias, repo_provider_class in self.repo_providers.items():
+            config[repo_provider_class_alias] = repo_provider_class.labels
+        return config
 
     async def get(self):
-        cfg = json.dumps(config)
-        loaded_r = json.loads(cfg)
-        self.write(loaded_r)
+        self.write(self.generate_config())

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -35,6 +35,7 @@ class MainHandler(BaseHandler):
             google_analytics_code=self.settings['google_analytics_code'],
             google_analytics_domain=self.settings['google_analytics_domain'],
             extra_footer_scripts=self.settings['extra_footer_scripts'],
+            repo_providers=SPEC_NAMES,
         )
 
 

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -35,7 +35,7 @@ class MainHandler(BaseHandler):
             google_analytics_code=self.settings['google_analytics_code'],
             google_analytics_domain=self.settings['google_analytics_domain'],
             extra_footer_scripts=self.settings['extra_footer_scripts'],
-            repo_providers=SPEC_NAMES,
+            repo_providers=self.settings['repo_providers'],
         )
 
 

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -372,6 +372,13 @@ class HydroshareProvider(RepoProvider):
     name = Unicode("Hydroshare")
     url_regex = re.compile(r".*([0-9a-f]{32}).*")
 
+    labels = {
+        "text": "Hydroshare resource id or URL",
+        "tag_text": "Git branch, tag, or commit SHA",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    }
+
     def _parse_resource_id(self, spec):
         match = self.url_regex.match(spec)
         if not match:

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -582,7 +582,6 @@ class GitLabRepoProvider(RepoProvider):
     }
 
     def __init__(self, *args, **kwargs):
-        print("GITLAB contructor")
         super().__init__(*args, **kwargs)
         self.quoted_namespace, unresolved_ref = self.spec.split('/', 1)
         self.namespace = urllib.parse.unquote(self.quoted_namespace)

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -212,6 +212,8 @@ class ZenodoProvider(RepoProvider):
     """
     name = Unicode("Zenodo")
 
+    display_name = "Zenodo DOI"
+
     labels = {
         "text": "Zenodo DOI (10.5281/zenodo.3242074)",
         "tag_text": "Git ref (branch, tag, or commit)",
@@ -256,6 +258,9 @@ class FigshareProvider(RepoProvider):
     Users must provide a spec consisting of the Figshare DOI.
     """
     name = Unicode("Figshare")
+
+    display_name = "Figshare DOI"
+
     url_regex = re.compile(r"(.*)/articles/([^/]+)/([^/]+)/(\d+)(/)?(\d+)?")
 
     labels = {
@@ -305,6 +310,8 @@ class FigshareProvider(RepoProvider):
 
 class DataverseProvider(RepoProvider):
     name = Unicode("Dataverse")
+
+    display_name = "Dataverse DOI"
 
     labels = {
         "text": "Dataverse DOI (10.7910/DVN/TJCLKP)",
@@ -370,6 +377,9 @@ class HydroshareProvider(RepoProvider):
     Users must provide a spec consisting of the Hydroshare resource id.
     """
     name = Unicode("Hydroshare")
+
+    display_name = "Hydroshare resource"
+
     url_regex = re.compile(r".*([0-9a-f]{32}).*")
 
     labels = {
@@ -442,6 +452,8 @@ class GitRepoProvider(RepoProvider):
 
     name = Unicode("Git")
 
+    display_name = "Git repository"
+
     labels = {
         "text": "Arbitrary git repository URL (http://git.example.com/repo)",
         "tag_text": "Git ref (branch, tag, or commit) SHA",
@@ -511,6 +523,8 @@ class GitLabRepoProvider(RepoProvider):
 
     name = Unicode('GitLab')
 
+    display_name = "GitLab.com"
+
     hostname = Unicode('gitlab.com', config=True,
         help="""The host of the GitLab instance
 
@@ -568,6 +582,7 @@ class GitLabRepoProvider(RepoProvider):
     }
 
     def __init__(self, *args, **kwargs):
+        print("GITLAB contructor")
         super().__init__(*args, **kwargs)
         self.quoted_namespace, unresolved_ref = self.spec.split('/', 1)
         self.namespace = urllib.parse.unquote(self.quoted_namespace)
@@ -625,6 +640,8 @@ class GitLabRepoProvider(RepoProvider):
 class GitHubRepoProvider(RepoProvider):
     """Repo provider for the GitHub service"""
     name = Unicode('GitHub')
+
+    display_name = 'GitHub'
 
     # shared cache for resolved refs
     cache = Cache(1024)
@@ -872,8 +889,11 @@ class GistRepoProvider(GitHubRepoProvider):
     If master or no ref is specified the latest revision will be used.
     """
 
-    name = Unicode('Gist')
-    hostname = Unicode('gist.github.com')
+    name = Unicode("Gist")
+
+    display_name = "Gist"
+
+    hostname = Unicode("gist.github.com")
 
     allow_secret_gist = Bool(
         default_value=False,

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -384,7 +384,7 @@ class HydroshareProvider(RepoProvider):
 
     labels = {
         "text": "Hydroshare resource id or URL",
-        "tag_text": "Git branch, tag, or commit SHA",
+        "tag_text": "Git ref (branch, tag, or commit)",
         "ref_prop_disabled": True,
         "label_prop_disabled": True,
     }

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -575,7 +575,7 @@ class GitLabRepoProvider(RepoProvider):
         return ""
 
     labels = {
-        "text": "GitLab repository name or URL",
+        "text": "GitLab.com repository or URL",
         "tag_text": "Git ref (branch, tag, or commit)",
         "ref_prop_disabled": False,
         "label_prop_disabled": False,

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -456,7 +456,7 @@ class GitRepoProvider(RepoProvider):
 
     labels = {
         "text": "Arbitrary git repository URL (http://git.example.com/repo)",
-        "tag_text": "Git ref (branch, tag, or commit) SHA",
+        "tag_text": "Git ref (branch, tag, or commit)",
         "ref_prop_disabled": False,
         "label_prop_disabled": False,
     }

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -212,6 +212,13 @@ class ZenodoProvider(RepoProvider):
     """
     name = Unicode("Zenodo")
 
+    labels = {
+        "text": "Zenodo DOI (10.5281/zenodo.3242074)",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    }
+
     async def get_resolved_ref(self):
         client = AsyncHTTPClient()
         req = HTTPRequest("https://doi.org/{}".format(self.spec),
@@ -250,6 +257,13 @@ class FigshareProvider(RepoProvider):
     """
     name = Unicode("Figshare")
     url_regex = re.compile(r"(.*)/articles/([^/]+)/([^/]+)/(\d+)(/)?(\d+)?")
+
+    labels = {
+        "text": "Figshare DOI (10.6084/m9.figshare.9782777.v1)",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    }
 
     async def get_resolved_ref(self):
         client = AsyncHTTPClient()
@@ -291,6 +305,13 @@ class FigshareProvider(RepoProvider):
 
 class DataverseProvider(RepoProvider):
     name = Unicode("Dataverse")
+
+    labels = {
+        "text": "Dataverse DOI (10.7910/DVN/TJCLKP)",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    }
 
     async def get_resolved_ref(self):
         client = AsyncHTTPClient()
@@ -414,6 +435,13 @@ class GitRepoProvider(RepoProvider):
 
     name = Unicode("Git")
 
+    labels = {
+        "text": "Arbitrary git repository URL (http://git.example.com/repo)",
+        "tag_text": "Git ref (branch, tag, or commit) SHA",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.url, unresolved_ref = self.spec.split('/', 1)
@@ -524,6 +552,13 @@ class GitLabRepoProvider(RepoProvider):
         if self.private_token:
             return r'username=binderhub\npassword={token}'.format(token=self.private_token)
         return ""
+
+    labels = {
+        "text": "GitLab repository name or URL",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -656,6 +691,13 @@ class GitHubRepoProvider(RepoProvider):
             else:
                 return r'username={token}\npassword=x-oauth-basic'.format(token=self.access_token)
         return ""
+
+    labels = {
+        "text": "GitHub repository name or URL",
+        "tag_text": "Git ref (branch, tag, or commit)",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -831,6 +873,13 @@ class GistRepoProvider(GitHubRepoProvider):
         config=True,
         help="Flag for allowing usages of secret Gists.  The default behavior is to disallow secret gists.",
     )
+
+    labels = {
+        "text": "Gist ID (username/gistId) or URL",
+        "tag_text": "Git commit SHA",
+        "ref_prop_disabled": False,
+        "label_prop_disabled": False,
+    }
 
     def __init__(self, *args, **kwargs):
         # We dont need to initialize entirely the same as github

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -72,19 +72,16 @@ function loadConfig(callback) {
 
 function updateRepoText() {
  var provider = $("#provider_prefix").val();
-
  var text = config_dict[provider]["text"]
  var tag_text = config_dict[provider]["tag_text"]
  var ref_prop_disabled = config_dict[provider]["ref_prop_disabled"]
  var label_prop_disabled = config_dict[provider]["label_prop_disabled"]
  var placeholder = "HEAD";
 
- $("#ref").prop("disabled", ref_prop_disabled);
- $("label[for=ref]").prop("disabled", label_prop_disabled);
+ $("#ref").attr('placeholder', placeholder).prop("disabled", ref_prop_disabled);
+ $("label[for=ref]").text(tag_text).prop("disabled", label_prop_disabled);
  $("#repository").attr('placeholder', text);
  $("label[for=repository]").text(text);
- $("#ref").attr('placeholder', placeholder);
- $("label[for=ref]").text(tag_text);
 }
 
 function getBuildFormValues() {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -31,7 +31,7 @@ import {fit} from './vendor/xterm/addons/fit';
 
 var BASE_URL = $('#base-url').data().url;
 var BADGE_BASE_URL = $('#badge-base-url').data().url;
-var config_dict = {"gh": "caca"};
+var config_dict = {};
 
 function update_favicon(path) {
     var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
@@ -70,18 +70,29 @@ function loadConfig(callback) {
   req.send(null);
 }
 
-function updateRepoText() {
- var provider = $("#provider_prefix").val();
- var text = config_dict[provider]["text"]
- var tag_text = config_dict[provider]["tag_text"]
- var ref_prop_disabled = config_dict[provider]["ref_prop_disabled"]
- var label_prop_disabled = config_dict[provider]["label_prop_disabled"]
- var placeholder = "HEAD";
+function setLabels() {
+  var provider = $("#provider_prefix").val();
+  var text = config_dict[provider]["text"];
+  var tag_text = config_dict[provider]["tag_text"];
+  var ref_prop_disabled = config_dict[provider]["ref_prop_disabled"];
+  var label_prop_disabled = config_dict[provider]["label_prop_disabled"];
+  var placeholder = "HEAD";
 
- $("#ref").attr('placeholder', placeholder).prop("disabled", ref_prop_disabled);
- $("label[for=ref]").text(tag_text).prop("disabled", label_prop_disabled);
- $("#repository").attr('placeholder', text);
- $("label[for=repository]").text(text);
+  $("#ref").attr('placeholder', placeholder).prop("disabled", ref_prop_disabled);
+  $("label[for=ref]").text(tag_text).prop("disabled", label_prop_disabled);
+  $("#repository").attr('placeholder', text);
+  $("label[for=repository]").text(text);
+}
+
+function updateRepoText() {
+  if (Object.keys(config_dict).length === 0){
+    loadConfig(function(res) {
+      config_dict = JSON.parse(res);
+      setLabels();
+    });
+  } else {
+    setLabels();
+  }
 }
 
 function getBuildFormValues() {
@@ -250,10 +261,6 @@ function indexMain() {
 
     // setup badge dropdown and default values.
     updateUrls();
-
-    loadConfig(function(res) {
-      config_dict = JSON.parse(res);
-    });
 
     $("#provider_prefix_sel li").click(function(event){
       event.preventDefault();

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -59,50 +59,34 @@ function v2url(providerPrefix, repository, ref, path, pathType) {
   return url;
 }
 
+function loadConfig(callback) {
+  var req = new XMLHttpRequest();
+  req.onreadystatechange = function() {
+    if (req.readyState == 4 && req.status == 200)
+      callback(req.responseText)
+  };
+  req.open('GET', BASE_URL + "_config", true);
+  req.send(null);
+}
+
 function updateRepoText() {
-  var text;
-  var provider = $("#provider_prefix").val();
-  var tag_text = "Git ref (branch, tag, or commit)";
-  var placeholder = "HEAD";
-  // first enable branch/ref field, some providers later disable it
-  $("#ref").prop("disabled", false);
-  $("label[for=ref]").prop("disabled", false);
-  if (provider === "gh") {
-    text = "GitHub repository name or URL";
-  } else if (provider === "gl") {
-    text = "GitLab.com repository or URL";
-  }
-  else if (provider === "gist") {
-    text = "Gist ID (username/gistId) or URL";
-    tag_text = "Git commit SHA";
-  }
-  else if (provider === "git") {
-    text = "Arbitrary git repository URL (http://git.example.com/repo)";
-  }
-  else if (provider === "zenodo") {
-    text = "Zenodo DOI (10.5281/zenodo.3242074)";
-    $("#ref").prop("disabled", true);
-    $("label[for=ref]").prop("disabled", true);
-  }
-  else if (provider === "figshare") {
-    text = "Figshare DOI (10.6084/m9.figshare.9782777.v1)";
-    $("#ref").prop("disabled", true);
-    $("label[for=ref]").prop("disabled", true);
-  }
-  else if (provider === "hydroshare") {
-    text = "Hydroshare resource id or URL";
-    $("#ref").prop("disabled", true);
-    $("label[for=ref]").prop("disabled", true);
-  }
-  else if (provider === "dataverse") {
-    text = "Dataverse DOI (10.7910/DVN/TJCLKP)";
-    $("#ref").prop("disabled", true);
-    $("label[for=ref]").prop("disabled", true);
-  }
-  $("#repository").attr('placeholder', text);
-  $("label[for=repository]").text(text);
-  $("#ref").attr('placeholder', placeholder);
-  $("label[for=ref]").text(tag_text);
+  loadConfig(function(res) {
+    var cfg = JSON.parse(res);
+    var provider = $("#provider_prefix").val();
+
+    var text = cfg[provider]["text"]
+    var tag_text = cfg[provider]["tag_text"]
+    var ref_prop_disabled = cfg[provider]["ref_prop_disabled"]
+    var label_prop_disabled = cfg[provider]["label_prop_disabled"]
+    var placeholder = "HEAD";
+
+    $("#ref").prop("disabled", ref_prop_disabled);
+    $("label[for=ref]").prop("disabled", label_prop_disabled);
+    $("#repository").attr('placeholder', text);
+    $("label[for=repository]").text(text);
+    $("#ref").attr('placeholder', placeholder);
+    $("label[for=ref]").text(tag_text);
+  });
 }
 
 function getBuildFormValues() {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -31,6 +31,7 @@ import {fit} from './vendor/xterm/addons/fit';
 
 var BASE_URL = $('#base-url').data().url;
 var BADGE_BASE_URL = $('#badge-base-url').data().url;
+var config_dict = {"gh": "caca"};
 
 function update_favicon(path) {
     var link = document.querySelector("link[rel*='icon']") || document.createElement('link');
@@ -70,23 +71,20 @@ function loadConfig(callback) {
 }
 
 function updateRepoText() {
-  loadConfig(function(res) {
-    var cfg = JSON.parse(res);
-    var provider = $("#provider_prefix").val();
+ var provider = $("#provider_prefix").val();
 
-    var text = cfg[provider]["text"]
-    var tag_text = cfg[provider]["tag_text"]
-    var ref_prop_disabled = cfg[provider]["ref_prop_disabled"]
-    var label_prop_disabled = cfg[provider]["label_prop_disabled"]
-    var placeholder = "HEAD";
+ var text = config_dict[provider]["text"]
+ var tag_text = config_dict[provider]["tag_text"]
+ var ref_prop_disabled = config_dict[provider]["ref_prop_disabled"]
+ var label_prop_disabled = config_dict[provider]["label_prop_disabled"]
+ var placeholder = "HEAD";
 
-    $("#ref").prop("disabled", ref_prop_disabled);
-    $("label[for=ref]").prop("disabled", label_prop_disabled);
-    $("#repository").attr('placeholder', text);
-    $("label[for=repository]").text(text);
-    $("#ref").attr('placeholder', placeholder);
-    $("label[for=ref]").text(tag_text);
-  });
+ $("#ref").prop("disabled", ref_prop_disabled);
+ $("label[for=ref]").prop("disabled", label_prop_disabled);
+ $("#repository").attr('placeholder', text);
+ $("label[for=repository]").text(text);
+ $("#ref").attr('placeholder', placeholder);
+ $("label[for=ref]").text(tag_text);
 }
 
 function getBuildFormValues() {
@@ -255,6 +253,10 @@ function indexMain() {
 
     // setup badge dropdown and default values.
     updateUrls();
+
+    loadConfig(function(res) {
+      config_dict = JSON.parse(res);
+    });
 
     $("#provider_prefix_sel li").click(function(event){
       event.preventDefault();

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -52,14 +52,9 @@
               <span class="caret"></span>
               </button>
               <ul class="dropdown-menu" id="provider_prefix_sel">
-                <li class="dropdown-item" value="gh"><a href="#">GitHub</a></li>
-                <li class="dropdown-item" value="gist"><a href="#">Gist</a></li>
-                <li class="dropdown-item" value="gl"><a href="#">GitLab.com</a></li>
-                <li class="dropdown-item" value="git"><a href="#">Git repository</a></li>
-                <li class="dropdown-item" value="zenodo"><a href="#">Zenodo DOI</a></li>
-                <li class="dropdown-item" value="figshare"><a href="#">Figshare DOI</a></li>
-                <li class="dropdown-item" value="hydroshare"><a href="#">Hydroshare resource</a></li>
-                <li class="dropdown-item" value="dataverse"><a href="#">Dataverse DOI</a></li>
+                {% for provider_prefix, provider_name in repo_providers.items() %}
+                  <li class="dropdown-item" value={{provider_prefix}}><a href="#">{{provider_name}}</a></li>
+                {% endfor %}
               </ul>
             </div>
             <input class="form-control" type="text" id="repository" data-lpignore="true" placeholder="GitHub repository name or link"/>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -52,8 +52,8 @@
               <span class="caret"></span>
               </button>
               <ul class="dropdown-menu" id="provider_prefix_sel">
-                {% for provider_prefix, provider_name in repo_providers.items() %}
-                  <li class="dropdown-item" value={{provider_prefix}}><a href="#">{{provider_name}}</a></li>
+                {% for provider_prefix, provider in repo_providers.items() %}
+                  <li class="dropdown-item" value={{provider_prefix}}><a href="#">{{provider.display_name}}</a></li>
                 {% endfor %}
               </ul>
             </div>

--- a/binderhub/tests/test_app.py
+++ b/binderhub/tests/test_app.py
@@ -17,17 +17,21 @@ def test_help_all():
     check_output([sys.executable, '-m', 'binderhub', '--help-all'])
 
 def test_repo_providers():
+    # Check that repo_providers property is validated by traitlets.validate
+
     b = BinderHub()
 
     class Provider(RepoProvider):
         pass
 
+    # Setting providers that inherit from 'RepoProvider` should be allowed
     b.repo_providers = dict(gh=GitHubRepoProvider, gl=GitLabRepoProvider)
     b.repo_providers = dict(p=Provider)
 
     class BadProvider():
         pass
 
+    # Setting providers that don't inherit from 'RepoProvider` should raise an error
     wrong_repo_providers = [GitHubRepoProvider, {}, 'GitHub', BadProvider]
     for repo_providers in wrong_repo_providers:
         with pytest.raises(TraitError):


### PR DESCRIPTION
In my quest of learning more about the binderhub repo, I decided to try out the steps described in https://github.com/jupyterhub/binderhub/issues/1025, towards serving the config from the backend :sun_with_face:

- [x]  add a new endpoint at something like /_config that serves up a static config
- [x] add new code to our JS which loads the config
- [x] transfer the labels currently configured in the JS to the repo provider classes
- [x] modify the /_config endpoint to dynamically generate the JSON it serves from the repo provider classes