### PR TITLE
use jhub chart 0.9.0-beta.3.n007.hc58048a

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.9.0-beta.2"
+  version: "0.9.0-beta.3.n007.hc58048a"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,7 +1,7 @@
 pycurl==7.43.0.1
 tornado==5.0.*
 kubernetes==9.0.*
-jupyterhub==1.1.0b1
+jupyterhub==1.1.0
 jsonschema==2.6.0
 # Logging sinks to send eventlogging events to
 google-cloud-logging==1.8.*


### PR DESCRIPTION
This PR brings in the latest JupyterHub chart (0.9.0-beta.3.n007.hc58048a). That chart has JupyterHub 1.1.0 installed.

- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/bed779e...c58048a
- https://github.com/jupyterhub/jupyterhub/compare/1.1.0b1...1.1.0