### PR TITLE
Add contributor badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,10 @@
    :target: https://gitter.im/jupyterhub/binder
    :alt: Gitter
 
+.. image:: https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter
+  :target: https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md
+  :alt: Contribute
+
 What is BinderHub?
 ------------------
 


### PR DESCRIPTION
This makes the contributing guide one-click away from possible contributors :rocket:
(P.S. The badge has already been added to TLJH, check it out: [![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://the-littlest-jupyterhub.readthedocs.io/en/latest/contributing/index.html))