### PR TITLE
bump versions in chart images

### DIFF
--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,8 +1,10 @@
 # Using multi-stage builds
-# ref: https://docs.docker.com/develop/develop-images/multistage-build/
-FROM buildpack-deps:stretch as build-stage
+ARG DIST=buster
+FROM buildpack-deps:$DIST as build-stage
+# ARG has to occur twice to be used in both contents and FROM
+ARG DIST=buster
 
-RUN echo 'deb http://deb.nodesource.com/node_8.x artful main' > /etc/apt/sources.list.d/nodesource.list \
+RUN echo "deb http://deb.nodesource.com/node_12.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
 RUN apt-get update && \
@@ -22,7 +24,7 @@ RUN python3 setup.py bdist_wheel
 
 # The final stage
 # ---------------
-FROM python:3.6-stretch
+FROM python:3.7-$DIST
 WORKDIR /
 
 # Copy the built binderhub python wheel from the build-stage

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine3.6
+FROM python:3.8-alpine3.11
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt

--- a/helm-chart/images/image-cleaner/requirements.txt
+++ b/helm-chart/images/image-cleaner/requirements.txt
@@ -1,2 +1,2 @@
 docker==4.1.0
-kubernetes==10.0.0
+kubernetes==10.0.1

--- a/helm-chart/images/image-cleaner/requirements.txt
+++ b/helm-chart/images/image-cleaner/requirements.txt
@@ -1,2 +1,2 @@
-docker==3.2.1
-kubernetes==3.0.0
+docker==4.1.0
+kubernetes==10.0.0


### PR DESCRIPTION
- bump binderhub dist to current stable (buster), Python to 3.7
- make $DIST a variable, for easier future updates
- bump node to current LTS, 12.x
- bump image-cleaner requirements and Python version to current stable