### PR TITLE
[WIP] sketching API v2

### DIFF
--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -1,9 +1,12 @@
 """Base classes for request handlers"""
 
+import asyncio
 import json
 
 from http.client import responses
 from tornado import web
+from tornado.log import app_log
+from tornado.iostream import StreamClosedError
 from jupyterhub.services.auth import HubOAuthenticated, HubOAuth
 
 from . import __version__ as binder_version
@@ -103,6 +106,7 @@ class Custom404(BaseHandler):
 
 class AboutHandler(BaseHandler):
     """Serve the about page"""
+
     async def get(self):
         self.render_template(
             "about.html",
@@ -126,3 +130,63 @@ class VersionHandler(BaseHandler):
                 "binderhub": binder_version,
                 }
         ))
+
+
+class EventStreamHandler(BaseHandler):
+    """Base class for event-stream handlers"""
+
+    # emit keepalives every 25 seconds to avoid idle connections being closed
+    KEEPALIVE_INTERVAL = 25
+    build = None
+
+    async def emit(self, data):
+        """Emit an eventstream event"""
+        if type(data) is not str:
+            serialized_data = json.dumps(data)
+        else:
+            serialized_data = data
+        try:
+            self.write('data: {}\n\n'.format(serialized_data))
+            await self.flush()
+        except StreamClosedError:
+            app_log.warning("Stream closed while handling %s", self.request.uri)
+            # raise Finish to halt the handler
+            raise web.Finish()
+
+    def on_finish(self):
+        """Stop keepalive when finish has been called"""
+        self._keepalive = False
+
+    async def keep_alive(self):
+        """Constantly emit keepalive events
+
+        So that intermediate proxies don't terminate an idle connection
+        """
+        self._keepalive = True
+        while True:
+            await asyncio.sleep(self.KEEPALIVE_INTERVAL)
+            if not self._keepalive:
+                return
+            try:
+                # lines that start with : are comments
+                # and should be ignored by event consumers
+                self.write(':keepalive\n\n')
+                await self.flush()
+            except StreamClosedError:
+                return
+
+    def send_error(self, status_code, **kwargs):
+        """event stream cannot set an error code, so send an error event"""
+        exc_info = kwargs.get('exc_info')
+        message = ''
+        if exc_info:
+            message = self.extract_message(exc_info)
+        if not message:
+            message = responses.get(status_code, 'Unknown HTTP Error')
+
+        # this cannot be async
+        evt = json.dumps(
+            {'phase': 'failed', 'status_code': status_code, 'message': message + '\n'}
+        )
+        self.write('data: {}\n\n'.format(evt))
+        self.finish()

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -190,3 +190,9 @@ class EventStreamHandler(BaseHandler):
         )
         self.write('data: {}\n\n'.format(evt))
         self.finish()
+
+    def set_default_headers(self):
+        super().set_default_headers()
+        self.set_header('content-type', 'text/event-stream')
+        self.set_header('cache-control', 'no-cache')
+

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -150,9 +150,6 @@ class BuildHandler(EventStreamHandler):
         prefix = '/build/' + provider_prefix
         spec = self.get_spec_from_request(prefix)
 
-        # set up for sending event streams
-        self.set_header('content-type', 'text/event-stream')
-        self.set_header('cache-control', 'no-cache')
 
         # Verify if the provider is valid for EventSource.
         # EventSource cannot handle HTTP errors, so we must validate and send

--- a/binderhub/v2/__init__.py
+++ b/binderhub/v2/__init__.py
@@ -1,0 +1,1 @@
+from .handlers import default_handlers  # noqa

--- a/binderhub/v2/handlers.py
+++ b/binderhub/v2/handlers.py
@@ -1,0 +1,50 @@
+from ..base import BaseHandler
+
+
+class V2BuildHandler(BaseHandler):
+    """POST /v2/build/:provider/:spec triggers a build,
+
+    responding with a JWT token containing info
+
+    JWT contents:
+
+    {
+        username: Hub user name
+        servername: Hub server name (usually '')
+        image: The image to be launched
+        build-id: The build id for logging
+    }
+
+    Response (JSON):
+
+    {
+        launch_token: opaque token,
+        events_url: opaque url,
+
+    }
+    """
+
+    def post(self, provider, spec):
+        # generate username
+        # check for image
+        # trigger build (if needed)
+        # reply with:
+        pass
+
+
+class V2EventsHandler(BaseHandler):
+    """GET /v2/events/:token logs"""
+
+    def get(self, token):
+        # decode_jwt to get build-id, image
+        # get/relay build logs
+        pass
+
+
+class V2LaunchHandler(BaseHandler):
+    def post(self, token):
+        # decode_jwt to get username, servername, image
+        # validate???
+        # request launch
+        # redirect to launch URL
+        pass

--- a/binderhub/v2/handlers.py
+++ b/binderhub/v2/handlers.py
@@ -1,7 +1,7 @@
 from ..base import BaseHandler
 
 
-class V2BuildHandler(BaseHandler):
+class BuildHandler(BaseHandler):
     """POST /v2/build/:provider/:spec triggers a build,
 
     responding with a JWT token containing info
@@ -19,32 +19,46 @@ class V2BuildHandler(BaseHandler):
 
     {
         launch_token: opaque token,
-        events_url: opaque url,
-
+        events_url: opaque url with token,
     }
     """
+
+    path = r"/v2/build/([^/]+)/(.+)"
 
     def post(self, provider, spec):
         # generate username
         # check for image
         # trigger build (if needed)
-        # reply with:
+        # reply with event url, containing jwt token
         pass
 
 
-class V2EventsHandler(BaseHandler):
-    """GET /v2/events/:token logs"""
+class EventsHandler(BaseHandler):
+    """GET /v2/events/:token streams logs
+
+    No transactions should occur as a result of making this request.
+    Reconnects should always be stateless and harmless.
+    """
+
+    path = r"/v2/events/([^/]+)"
 
     def get(self, token):
         # decode_jwt to get build-id, image
         # get/relay build logs
+        # final event sends to the launch url
         pass
 
 
-class V2LaunchHandler(BaseHandler):
+class LaunchHandler(BaseHandler):
+    """POST /v2/launch/:token triggers the actual launch"""
+    path = r"/v2/launch/([^/]+)"
+
     def post(self, token):
         # decode_jwt to get username, servername, image
         # validate???
         # request launch
         # redirect to launch URL
         pass
+
+
+default_handlers = [BuildHandler, EventsHandler, LaunchHandler]

--- a/testing/minikube/install-hub
+++ b/testing/minikube/install-hub
@@ -43,7 +43,7 @@ jupyterhub = get_hub_chart_dependency()
 
 # update the helm repo
 check_call(['helm', 'repo', 'add', 'jupyterhub', jupyterhub['repository']])
-check_call(['helm', 'repo', 'update', 'jupyterhub'])
+check_call(['helm', 'repo', 'update'])
 
 # Deploying BinderHub normally automatically deploys JupyterHub from the same
 # configuration file.
@@ -70,11 +70,17 @@ if auth_enabled:
     auth_conf_file = os.path.join(here, 'jupyterhub-helm-auth-config.yaml')
     args.extend(['-f', auth_conf_file])
 
+# ensure namespace exists
+namespace_exists = namespace in check_output(['kubectl', 'get', 'namespace']).decode('utf8', 'replace').split()
+if not namespace_exists:
+    check_call(['kubecl', 'create', 'namespace', namespace])
+
 is_running = name in check_output(['helm', 'list', '-q']).decode('utf8', 'replace').split()
 if is_running:
     cmd = ['helm', 'upgrade', name]
 else:
-    cmd = ['helm', 'install', f'--name={name}']
+
+    cmd = ['helm', 'install', f'{name}']
 
 cmd.extend(args)
 print("\n    %s\n" % ' '.join(map(pipes.quote, cmd)))


### PR DESCRIPTION
The event stream errors return, which prompt me to want to take a stab at the proposal in #358, which should significantly reduce the consequences of event stream issues (in theory, to zero).

The gist of the design from #358, by @yuvipanda:

- POST to start build, replies with URL to watch events
- event stream requests only get logs, never result in transactions
- POST to launch
- opaque JWT tokens used to pass stateful args between stages (build id, hub username, token, etc.)

Python code design choices so far:

- create v1, v2 subfolders for API handlers
- split `builder.py` into a Builder class which implements building and a v1 BuildHandler. The Builder will be used in both v1 and v2
- create base EventStreamHandler class, used in both v1 and v2

My plan is to refactor things based on v2 plans, while keeping v1 fully working

### implementation log

This is a very early WIP. I'll update with progress notes.

implementation challenges: lots of coupling between different layers that make separating these actions tricky, plus preserving the old handlers without tons of duplicate code. Separating them will be helpful in the long run, but will take some doing.

Couplings found so far:
- build/watch/launch logic is all in BuildHandler, much of which will need to be re-used in both v1 and v2 handlers (Builder object should help with this)
- Start-build and watch-build are tied together in the Build object, when ~only the build-id and namespace are required for watching builds.

closes #358
closes #304
closes #13 
closes #15 