### PR TITLE
Catch tornado timeout error when pulling image manifest

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -290,8 +290,6 @@ class BuildHandler(BaseHandler):
         ).replace('_', '-').lower()
 
         if self.settings['use_registry']:
-            image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
-            image_found = bool(image_manifest)
             for _ in range(3):
                 try:
                     image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -296,7 +296,7 @@ class BuildHandler(BaseHandler):
                     image_found = bool(image_manifest)
                     break
                 except tornado.curl_httpclient.CurlError:
-                    app_log.warning("Tornado HTTP Timeout error: Failed to get image manifest for %s", image_name)
+                    app_log.exception("Tornado HTTP Timeout error: Failed to get image manifest for %s", image_name)
                     image_found = False
         else:
             # Check if the image exists locally!

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -296,6 +296,7 @@ class BuildHandler(BaseHandler):
                     image_found = bool(image_manifest)
                     break
                 except tornado.curl_httpclient.CurlError:
+                    app_log.warning("Tornado HTTP Timeout error: Failed to get image manifest for %s", image_name)
                     image_found = False
         else:
             # Check if the image exists locally!

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -297,7 +297,6 @@ class BuildHandler(BaseHandler):
                     break
                 except tornado.curl_httpclient.CurlError:
                     image_found = False
-                    pass
         else:
             # Check if the image exists locally!
             # Assume we're running in single-node mode or all binder pods are assigned to the same node!

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -292,6 +292,14 @@ class BuildHandler(BaseHandler):
         if self.settings['use_registry']:
             image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
             image_found = bool(image_manifest)
+            for _ in range(3):
+                try:
+                    image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
+                    image_found = bool(image_manifest)
+                    break
+                except tornado.curl_httpclient.CurlError:
+                    image_found = False
+                    pass
         else:
             # Check if the image exists locally!
             # Assume we're running in single-node mode or all binder pods are assigned to the same node!


### PR DESCRIPTION
This PR updates `binderhub/builder.py` to attempt to pull the image manifest from the registry 3 times and catch and log the tornado timeout HTTP 599 error we've been seeing on mybinder.org.

Related issue: https://github.com/jupyterhub/mybinder.org-deploy/issues/1323