### PR TITLE
[MRG] Update JupyterHub chart to the latest tag

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "0.9.0-beta.3.n007.hc58048a"
+  version: "0.9.0-beta.3.n023.h6a2b994"
   repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
This brings in the new culler which can remove named servers. This will allow users to remove named servers via the culler if they want to.

The named server culler PR is https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1558