### PR TITLE
add more blocks into templates

### DIFF
--- a/binderhub/templates/about.html
+++ b/binderhub/templates/about.html
@@ -1,10 +1,5 @@
 {% extends "page.html" %}
 
-{% block head %}
-<meta property="og:description" content="Reproducible, sharable, open, interactive computing environments.">
-{{ super() }}
-{% endblock head %}
-
 {% block main %}
 <div id="main" class="container">
   <div class="row">

--- a/binderhub/templates/about.html
+++ b/binderhub/templates/about.html
@@ -10,9 +10,11 @@
         <div id="explanation">
           <p>This website is powered by <a href="https://github.com/jupyterhub/binderhub">BinderHub</a> v{{ binder_version }}.
           </p>
+          {% if message %}
           <p>
             {{ message | safe }}
           </p>
+          {% endif %}
         </div>
       </div>
       {% endblock header %}

--- a/binderhub/templates/error.html
+++ b/binderhub/templates/error.html
@@ -1,5 +1,8 @@
 {% extends "page.html" %}
 
+{% block meta_social %}
+{% endblock meta_social %}
+
 {% block main %}
 <div class="container text-center jumbotron">
   <h1>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -4,17 +4,6 @@
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 <script src="{{static_url("dist/bundle.js")}}"></script>
-
-
-<!-- Social media previews -->
-<meta property="og:title" content="The Binder Project">
-<meta property="og:image" content="https://mybinder.org/static/images/logo_social.png">
-<meta property="og:description" content="Reproducible, sharable, interactive computing environments.">
-<meta property="og:image:width" content="1334">
-<meta property="og:image:height" content="700">
-<meta property="og:image:alt" content="The Binder Project Logo" />
-<meta name="twitter:card" content="summary_large_image">
-
 {{ super() }}
 {% endblock head %}
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -1,10 +1,14 @@
 {% extends "page.html" %}
 
-{% block head %}
+{% block meta %}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
-<script src="{{static_url("dist/bundle.js")}}"></script>
 {{ super() }}
+{% endblock meta %}
+
+{% block head %}
+{{ super() }}
+<script src="{{static_url("dist/bundle.js")}}"></script>
 {% endblock head %}
 
 {% block main %}

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -205,9 +205,9 @@
 </div>
 {% endblock main %}
 
-{% block footer %}
-{{ super () }}
+{% block scripts %}
+{{ super() }}
 <script type="text/javascript">
 indexMain();
 </script>
-{% endblock footer %}
+{% endblock scripts %}

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -1,9 +1,9 @@
 {% extends "page.html" %}
 
 {% block meta %}
+{{ super() }}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
-{{ super() }}
 {% endblock meta %}
 
 {% block head %}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -1,9 +1,9 @@
 {% extends "page.html" %}
 
 {% block meta %}
-{{ super() }}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
+{{ super() }}
 {% endblock meta %}
 
 {% block meta_social %}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -1,8 +1,11 @@
 {% extends "page.html" %}
 
-{% block head %}
+{% block meta %}
+{{ super() }}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
+{% endblock meta %}
+
 <!-- Other OG information in page.html -->
 <meta property="og:title" content="{{social_desc}}">
 <meta property="og:image" content="https://mybinder.org/static/images/logo_square.png">
@@ -12,12 +15,11 @@
 <meta property="og:image:alt" content="The Binder Project Logo" />
 <meta name="twitter:card" content="summary" />
 
+{% block head %}
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("dist/styles.css")}}" rel="stylesheet">
 <link href="{{static_url("loading.css")}}" rel="stylesheet">
-
-
 {% endblock head %}
 
 {% block main %}
@@ -58,7 +60,11 @@ Your binder will open automatically when it is ready.
 {% endblock main %}
 
 {% block footer %}
+{% endblock footer %}
+
+{% block scripts %}
+{{ super() }}
 <script type="text/javascript">
 loadingMain("{{provider_spec}}");
 </script>
-{% endblock footer %}
+{% endblock scripts %}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -19,7 +19,6 @@
 {% block head %}
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
-<link href="{{static_url("dist/styles.css")}}" rel="stylesheet">
 <link href="{{static_url("loading.css")}}" rel="stylesheet">
 {% endblock head %}
 

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -1,9 +1,9 @@
 {% extends "page.html" %}
 
 {% block meta %}
+{{ super() }}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
-{{ super() }}
 {% endblock meta %}
 
 {% block meta_social %}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -6,14 +6,15 @@
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 {% endblock meta %}
 
-<!-- Other OG information in page.html -->
+{% block meta_social %}
 <meta property="og:title" content="{{social_desc}}">
 <meta property="og:image" content="https://mybinder.org/static/images/logo_square.png">
-<meta property="og:description" content="Click to run this interactive environment. From the Binder Project: Reproducible, sharable, interactive computing environments.">
+<meta property="og:description" content="Click to run this interactive environment. From the Binder Project: Reproducible, sharable, open, interactive computing environments.">
 <meta property="og:image:width" content="217">
 <meta property="og:image:height" content="217">
 <meta property="og:image:alt" content="The Binder Project Logo" />
 <meta name="twitter:card" content="summary" />
+{% endblock meta_social %}
 
 {% block head %}
 {{ super() }}

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -2,19 +2,30 @@
 <html>
 <head>
   <title>{% block title %}Binder{% endblock %}</title>
-  {% block head %}
+
+  {% block meta %}
+  {% endblock meta %}
+
+  {% block favicon %}
   <link id="favicon" rel="shortcut icon" type="image/png" href="{{static_url("favicon.ico")}}" />
-  <link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>
+  {% endblock %}
+  {% block head %}
+  <link href="{{static_url("dist/styles.css")}}" rel="stylesheet">
   {% endblock head %}
+
+  {% block extra_head %}
+  {% endblock extra_head %}
 </head>
 <body>
   {% block body %}
 
+  {% block banner %}
   {% if banner %}
   <div id="banner-container">
     {{ banner | safe }}
   </div>
   {% endif %}
+  {% endblock banner %}
 
   {% block logo %}
   <div class="container">
@@ -37,6 +48,9 @@
   </div>
   {% endblock footer %}
 
+  {% block scripts %}
+  {% endblock scripts %}
+
   {% if google_analytics_code %}
   <script>
     // Only load GA if DNT is not set
@@ -57,6 +71,8 @@
   }
   </script>
   {% endif %}
+
+  {% block extra_footer_scripts %}
   {% if extra_footer_scripts %}
   {% for script in extra_footer_scripts|dictsort %}
   <script>
@@ -64,6 +80,8 @@
   </script>
   {% endfor %}
   {% endif %}
+  {% endblock extra_footer_scripts %}
+
   {% endblock body %}
 </body>
 </html>

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -3,9 +3,8 @@
 <head>
   <title>{% block title %}Binder{% endblock %}</title>
 
+  {% block head %}
   {% block meta %}
-  {% endblock meta %}
-
   {# Social media previews #}
   {% block meta_social %}
   <meta property="og:title" content="The Binder Project">
@@ -16,11 +15,11 @@
   <meta property="og:image:alt" content="The Binder Project Logo" />
   <meta name="twitter:card" content="summary_large_image">
   {% endblock meta_social %}
+  {% endblock meta %}
 
   {% block favicon %}
   <link id="favicon" rel="shortcut icon" type="image/png" href="{{static_url("favicon.ico")}}" />
   {% endblock %}
-  {% block head %}
   <link href="{{static_url("dist/styles.css")}}" rel="stylesheet">
   {% endblock head %}
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -6,6 +6,17 @@
   {% block meta %}
   {% endblock meta %}
 
+  {# Social media previews #}
+  {% block meta_social %}
+  <meta property="og:title" content="The Binder Project">
+  <meta property="og:image" content="https://mybinder.org/static/images/logo_social.png">
+  <meta property="og:description" content="Reproducible, sharable, open, interactive computing environments.">
+  <meta property="og:image:width" content="1334">
+  <meta property="og:image:height" content="700">
+  <meta property="og:image:alt" content="The Binder Project Logo" />
+  <meta name="twitter:card" content="summary_large_image">
+  {% endblock meta_social %}
+
   {% block favicon %}
   <link id="favicon" rel="shortcut icon" type="image/png" href="{{static_url("favicon.ico")}}" />
   {% endblock %}


### PR DESCRIPTION
The purpose of this PR is to make template customisation much easier. It also makes some minor changes.
 
- adds more blocks into templates
- re-organizes meta tags for social media preview. also fixes it in about.html
- removes styles.css from loading.html, it is already included in page.html

