### PR TITLE
[MRG] Increase duration for which we cache active pod numbers

### DIFF
--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -52,7 +52,7 @@ def false_if_raises(f):
     return wrapper
 
 
-def at_most_every(_f=None, *, interval=10):
+def at_most_every(_f=None, *, interval=60):
     """Call the wrapped function at most every `interval` seconds.
 
     Useful when `f` is (very) expensive to compute and you are happy


### PR DESCRIPTION
Right now on GKE it is taking about 5-6s to compute the number of active pods and we only cache the result for 10s.

This means we are recomputing the number of active user pods every 10s. I don't expect it to change dramatically on such a short time scale -> we are spending CPU and API requests to the k8s master on re-re-re-recomputing a health metric instead of serving users.

60s seems like a good time constant and we can keep tuning it we find it to be too slow.