### PR TITLE
fix catching of error checking registry

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -12,6 +12,7 @@ import escapism
 import docker
 from tornado.concurrent import chain_future, Future
 from tornado import gen
+from tornado.httpclient import HTTPClientError
 from tornado.web import Finish, authenticated
 from tornado.queues import Queue
 from tornado.iostream import StreamClosedError
@@ -295,7 +296,7 @@ class BuildHandler(BaseHandler):
                     image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
                     image_found = bool(image_manifest)
                     break
-                except tornado.curl_httpclient.CurlError:
+                except HTTPClientError:
                     app_log.exception("Tornado HTTP Timeout error: Failed to get image manifest for %s", image_name)
                     image_found = False
         else:

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -1,5 +1,5 @@
 pycurl==7.43.0.1
-tornado==5.0.*
+tornado==5.1.*
 kubernetes==9.0.*
 jupyterhub==1.1.0
 jsonschema==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-json-logger
 jupyterhub
 jsonschema
 pycurl
+tornado>=5.1


### PR DESCRIPTION
`tornado` wasn't imported, causing a NameError here.

While here, switch to higher-level HTTPClientError (of which CurlError is a subclass)
so we catch more similar errors.