### PR TITLE
cache 404 responses from GitHub API

### DIFF
--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -1,6 +1,7 @@
 """Miscellaneous utilities"""
 from collections import OrderedDict
 from hashlib import blake2b
+import time
 
 from traitlets import Integer, TraitError
 
@@ -88,15 +89,28 @@ class ByteSpecification(Integer):
 class Cache(OrderedDict):
     """Basic LRU Cache with get/set"""
 
-    def __init__(self, max_size=1024):
+    def __init__(self, max_size=1024, max_age=0):
         self.max_size = max_size
+        self.max_age = max_age
+        self._ages = {}
+
+    def _now(self):
+        return time.perf_counter()
+
+    def _check_expired(self, key):
+        if not self.max_age:
+            return False
+        if self._ages[key] + self.max_age < self._now():
+            self.pop(key)
+            return True
+        return False
 
     def get(self, key, default=None):
         """Get an item from the cache
 
         same as dict.get
         """
-        if key in self:
+        if key in self and not self._check_expired(key):
             self.move_to_end(key)
         return super().get(key, default)
 
@@ -107,10 +121,16 @@ class Cache(OrderedDict):
         - if full, delete the oldest item
         """
         self[key] = value
+        self._ages[key] = self._now()
         self.move_to_end(key)
         if len(self) > self.max_size:
             first_key = next(iter(self))
             self.pop(first_key)
+
+    def pop(self, key):
+        result = super().pop(key)
+        self._ages.pop(key)
+        return result
 
 
 def url_path_join(*pieces):


### PR DESCRIPTION
adds max_age support to Cache type

this avoids DOS against our GitHub API limit from a flood of requests for a repo or ref that doesn't exist (this happened earlier this week, I suspect from an eventstream API consumer, given the request rate).

404s are cached for five minutes.