### PR TITLE
[MRG] Pin the version of the sphinx theme used

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -5,7 +5,7 @@ sphinx-copybutton
 traitlets
 pandas
 ruamel.yaml
-git+https://github.com/pandas-dev/pandas-sphinx-theme.git@master
+https://github.com/pandas-dev/pandas-sphinx-theme/archive/ade576c92cfe46a372b6783fb83f45c44fc67976.zip
 # install BinderHub dependencies. We manually list them here because some
 # dependencies (like pycurl) can't be installed on ReadTheDocs and aren't
 # needed to build the docs.


### PR DESCRIPTION
Closes #1069 

This should trigger a rebuild of our docs and pins us to a specific revision of the theme. We should move the pin forwards every once in a while to stay current. With a pinned revision we can explicitly check that things still work when we do update.