### PR TITLE
remove styles.css from loading.html, it is already included in page.html

### DIFF
--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -14,7 +14,6 @@
 
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
-<link href="{{static_url("dist/styles.css")}}" rel="stylesheet">
 <link href="{{static_url("loading.css")}}" rel="stylesheet">
 
 


### PR DESCRIPTION
Here in page.html `styles.css` is already included:
https://github.com/jupyterhub/binderhub/blob/b21f341c956f01f4243db227e935d6cf87ce230b/binderhub/templates/page.html#L7

and because in loading.html we extend the head block, we dont have to include it again.

If you check the source of view-source:https://mybinder.org/v2/gh/binder-examples/requirements/masters, you will see that `styles.css` is included 2 times.