### PR TITLE
put meta tags for social media previews into block

### DIFF
--- a/binderhub/templates/about.html
+++ b/binderhub/templates/about.html
@@ -1,10 +1,5 @@
 {% extends "page.html" %}
 
-{% block head %}
-<meta property="og:description" content="Reproducible, sharable, open, interactive computing environments.">
-{{ super() }}
-{% endblock head %}
-
 {% block main %}
 <div id="main" class="container">
   <div class="row">

--- a/binderhub/templates/error.html
+++ b/binderhub/templates/error.html
@@ -1,5 +1,8 @@
 {% extends "page.html" %}
 
+{% block meta_social %}
+{% endblock meta_social %}
+
 {% block main %}
 <div class="container text-center jumbotron">
   <h1>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -4,17 +4,6 @@
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 <script src="{{static_url("dist/bundle.js")}}"></script>
-
-
-<!-- Social media previews -->
-<meta property="og:title" content="The Binder Project">
-<meta property="og:image" content="https://mybinder.org/static/images/logo_social.png">
-<meta property="og:description" content="Reproducible, sharable, interactive computing environments.">
-<meta property="og:image:width" content="1334">
-<meta property="og:image:height" content="700">
-<meta property="og:image:alt" content="The Binder Project Logo" />
-<meta name="twitter:card" content="summary_large_image">
-
 {{ super() }}
 {% endblock head %}
 

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -1,10 +1,6 @@
 {% extends "page.html" %}
 
-{% block head %}
-<meta id="base-url" data-url="{{base_url}}">
-<meta id="badge-base-url" data-url="{{badge_base_url}}">
-<meta id="build-token" data-token="{{ build_token }}">
-<!-- Other OG information in page.html -->
+{% block meta_social %}
 <meta property="og:title" content="{{social_desc}}">
 <meta property="og:image" content="https://mybinder.org/static/images/logo_square.png">
 <meta property="og:description" content="Click to run this interactive environment. From the Binder Project: Reproducible, sharable, interactive computing environments.">
@@ -12,12 +8,15 @@
 <meta property="og:image:height" content="217">
 <meta property="og:image:alt" content="The Binder Project Logo" />
 <meta name="twitter:card" content="summary" />
+{% endblock meta_social %}
 
+{% block head %}
+<meta id="base-url" data-url="{{base_url}}">
+<meta id="badge-base-url" data-url="{{badge_base_url}}">
+<meta id="build-token" data-token="{{ build_token }}">
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("loading.css")}}" rel="stylesheet">
-
-
 {% endblock head %}
 
 {% block main %}

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -2,6 +2,16 @@
 <html>
 <head>
   <title>{% block title %}Binder{% endblock %}</title>
+  {% block meta_social %}
+  {# Social media previews #}
+  <meta property="og:title" content="The Binder Project">
+  <meta property="og:image" content="https://mybinder.org/static/images/logo_social.png">
+  <meta property="og:description" content="Reproducible, sharable, open, interactive computing environments.">
+  <meta property="og:image:width" content="1334">
+  <meta property="og:image:height" content="700">
+  <meta property="og:image:alt" content="The Binder Project Logo" />
+  <meta name="twitter:card" content="summary_large_image">
+  {% endblock meta_social %}
   {% block head %}
   <link id="favicon" rel="shortcut icon" type="image/png" href="{{static_url("favicon.ico")}}" />
   <link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>


### PR DESCRIPTION
This PR puts social media preview tags into block. This makes it easier to customize templates.

Currently on about page (https://mybinder.org/about), there is only description info for social media previews: `<meta property="og:description" content="Reproducible, sharable, open, interactive computing environments.">`. I also changed it, so about page has the same tags as index page for social media. I can also totally remove it from about page. What do you think?