### PR TITLE
Edits to Binder homepage

### DIFF
--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -32,7 +32,7 @@
   {% block footer %}
   <div class="container">
     <div class="row text-center">
-      <h3>questions?<br />join the <a href="https://gitter.im/jupyterhub/binder">chat</a>, read the <a href="https://mybinder.readthedocs.io/en/latest/">docs</a>, see the <a href="https://github.com/jupyterhub/binderhub">code</a></h3>
+      <h3>questions?<br />join the <a href="https://discourse.jupyter.org">discussion</a>, read the <a href="https://mybinder.readthedocs.io/en/latest/">docs</a>, see the <a href="https://github.com/jupyterhub/binderhub">code</a></h3>
     </div>
   </div>
   {% endblock footer %}

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -32,7 +32,7 @@
   {% block footer %}
   <div class="container">
     <div class="row text-center">
-      <h3>questions?<br />join the <a href="https://discourse.jupyter.org">discussion</a>, read the <a href="https://mybinder.readthedocs.io/en/latest/">docs</a>, see the <a href="https://github.com/jupyterhub/binderhub">code</a></h3>
+      <h3>questions?<br />join the <a href="https://discourse.jupyter.org/c/binder">discussion</a>, read the <a href="https://mybinder.readthedocs.io/en/latest/">docs</a>, see the <a href="https://github.com/jupyterhub/binderhub">code</a></h3>
     </div>
   </div>
   {% endblock footer %}


### PR DESCRIPTION
This commit changes the wording on the Binder homepage to read
"join the dicussion,..." instead of "join the chat,..." and now
points to the discourse forum instead of gitter. This is to
properly direct users to the best place for support.

**Outstanding TODO:** I'm not sure of the best way to move this section further up the webpage so it's more discoverable.

fixes https://github.com/jupyterhub/team-compass/issues/281