### PR TITLE
[MRG] Inline helm setup instructions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,19 +179,6 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
-# -- Custom scripts -------------------------------------------
-
-# Grab the latest version of the k8s and helm install instructions.
-helm_instructions = "https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/setup-jupyterhub/setup-helm.rst"
-
-resp = requests.get(helm_instructions)
-with open('./helm.txt', 'w') as ff:
-    # Bump section headers
-    lines = resp.text.split('\n')
-    for ii, ln in enumerate(lines):
-        if ln.startswith('---'):
-            lines[ii] = ln.replace('-', '~')
-    ff.write('\n'.join(lines))
 
 # -- Add custom CSS ----------------------------------------------
 def setup(app):

--- a/doc/create-cloud-resources.rst
+++ b/doc/create-cloud-resources.rst
@@ -1,16 +1,15 @@
 .. _create-cluster:
 
-Create your cloud resources
-===========================
+Set up the prerequisites
+========================
 
 BinderHub is built to run on top of Kubernetes, a distributed cluster manager.
-It uses a JupyterHub to launch/manage user servers, as well as a
+It uses a JupyterHub to launch and manage user servers, as well as a
 docker registry to cache images.
 
-To create your own BinderHub, you'll first need to set up a properly
-configured Kubernetes Cluster on the cloud, and then configure the
-various components correctly. The following instructions will assist you
-in doing so.
+To create your own BinderHub, you'll first need to set up a Kubernetes Cluster
+and then configure its various components correctly. The following instructions
+will assist you in doing so.
 
 .. note::
 
@@ -33,11 +32,124 @@ First, install Kubernetes by following the
 `instructions in the Zero to JupyterHub guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/google/step-zero-gcp.html>`_.
 When you're done, move on to the next section.
 
-Install Helm
-------------
 
-.. include:: helm.txt
-   :start-after: ===============
-   :end-before: Next Step
+Installing Helm
+---------------
+
+`Helm <https://helm.sh/>`_, the package manager for Kubernetes, is a useful tool
+for: installing, upgrading and managing applications on a Kubernetes cluster.
+Helm packages are called *charts*.
+We will be installing and managing JupyterHub on
+our Kubernetes cluster using a Helm chart.
+
+Charts are abstractions describing how to install packages onto a Kubernetes
+cluster. When a chart is deployed, it works as a templating engine to populate
+multiple `yaml` files for package dependencies with the required variables, and
+then runs `kubectl apply` to apply the configuration to the resource and install
+the package.
+
+Helm has two parts: a client (`helm`) and a server (`tiller`). Tiller runs
+inside of your Kubernetes cluster as a pod in the kube-system namespace. Tiller
+manages both, the *releases* (installations) and *revisions* (versions) of charts deployed
+on the cluster. When you run `helm` commands, your local Helm client sends
+instructions to `tiller` in the cluster that in turn make the requested changes.
+
+
+.. note::
+
+   These instructions are for Helm 2.
+   Helm 3 includes several major breaking changes and is not yet officially
+   supported
+
+Several `methods to install Helm
+<https://github.com/helm/helm/blob/master/docs/install.md>`_ exist, the
+simplest way to install Helm is to run Helm's installer script in a terminal:
+
+.. code:: bash
+
+  curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+
+Initializing Helm
+~~~~~~~~~~~~~~~~~
+
+After installing helm on your machine, initialize Helm on your Kubernetes
+cluster:
+
+1. Set up a `ServiceAccount
+   <https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/>`_
+   for use by `tiller`.
+
+   .. code-block:: bash
+
+      kubectl --namespace kube-system create serviceaccount tiller
+
+2. Give the `ServiceAccount` full permissions to manage the cluster.
+
+   .. code-block:: bash
+
+      kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+
+3. Initialize `helm` and `tiller`.
+
+   .. code-block:: bash
+
+      helm init --service-account tiller --history-max 100 --wait
+
+   This command only needs to run once per Kubernetes cluster, it will create a
+   `tiller` deployment in the kube-system namespace and setup your local `helm`
+   client.
+   This command installs and configures the `tiller` part of Helm (the whole
+   project, not the CLI) on the remote kubernetes cluster. Later when you want
+   to deploy changes with `helm` (the local CLI), it will talk to `tiller`
+   and tell it what to do. `tiller` then executes these instructions from
+   within the cluster.
+   We limit the history to 100 previous installs as very long histories slow
+   down helm commands a lot.
+
+   .. note::
+
+      If you wish to install `helm` on another computer, you won't need to setup
+      `tiller` again but you still need to initialize `helm`:
+
+      .. code-block:: bash
+
+         helm init --client-only
+
+Securing Helm
+~~~~~~~~~~~~~
+
+Ensure that `tiller` is secured against access from inside the cluster:
+
+.. code:: bash
+
+   kubectl patch deployment tiller-deploy --namespace=kube-system --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
+
+By default `tiller`'s port is exposed in the cluster without authentication and
+if you probe this port directly (i.e. by bypassing `helm`) then `tiller`'s
+permissions can be exploited. This step forces `tiller` to listen to commands
+from localhost (i.e. `helm`) *only* so that other pods inside the cluster cannot
+ask `tiller` to install a new chart granting them arbitrary, elevated RBAC
+privileges which they could then exploit.
+`More details here. <https://engineering.bitnami.com/articles/helm-security.html>`_
+
+Verifying the setup
+~~~~~~~~~~~~~~~~~~~
+
+You can verify that you have the correct version and that it installed properly
+by running:
+
+.. code:: bash
+
+   helm version
+
+It should provide output like below. If you just installed everything for the
+first time it might take one or two minutes to show the output. Make sure you
+have at least version 2.11.0 and that the client (`helm`) and server
+version (`tiller`) match!
+
+.. code-block:: bash
+
+   Client: &version.Version{SemVer:"v2.11.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a339489417b146b", GitTreeState:"clean"}
+   Server: &version.Version{SemVer:"v2.11.0", GitCommit:"2e55dbe1fdb5fdb96b75ff144a339489417b146b", GitTreeState:"clean"}
 
 Now that you've installed Kubernetes and Helm, it's time to :ref:`setup-registry`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,12 +25,6 @@ your BinderHub deployment.
 
 To get started creating your own BinderHub, start with :ref:`zero-to-binderhub`.
 
-.. note::
-
-   BinderHub uses a JupyterHub running on Kubernetes for much of its functionality.
-   For information on setting up and customizing your JupyterHub, we recommend reading
-   the `Zero to JupyterHub Guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/index.html#customization-guide>`_.
-
 
 BinderHub Deployments
 =====================

--- a/doc/zero-to-binderhub/index.rst
+++ b/doc/zero-to-binderhub/index.rst
@@ -5,8 +5,15 @@ Zero to BinderHub
 =================
 
 A guide to help you create your own BinderHub from scratch. Each section below
-covers various aspects of creating cloud resources and setting up a BinderHub
-for your users.
+covers one of the aspects of setting up a BinderHub for your users.
+
+.. note::
+
+   BinderHub uses a JupyterHub running on Kubernetes for most of its functionality.
+   This guide assumes you have experience with setting up a JupyterHub on Kubernetes.
+   We recommend you follow the `Zero to JupyterHub Guide <https://zero-to-jupyterhub.readthedocs.io/en/latest/index.html#customization-guide>`_
+   to familiarize yourself with JupyterHub on Kubernetes before attempting to
+   setup a BinderHub.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This implements https://github.com/jupyterhub/binderhub/pull/1089#issuecomment-619507780 by inlining the helm setup instructions.

It also makes a few tweaks to where notes are placed.

Once this is merged we can merge #1089 and #1090 which are currently blocked because of the broken docs build.