### PR TITLE
Add podAnnotations config for the binder deployment - will enable checksum change based restarts

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         # This lets us autorestart when the configmap changes!
         checksum/config-map: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- if .Values.annotations }}
+        {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
     spec:
       {{ if .Values.initContainers -}}
       initContainers:

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         # This lets us autorestart when the configmap changes!
         checksum/config-map: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- if .Values.annotations }}
-        {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
       {{ if .Values.initContainers -}}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -197,4 +197,4 @@ initContainers: []
 extraVolumes: []
 extraVolumeMounts: []
 extraEnv: []
-annotations: {}
+podAnnotations: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -197,3 +197,4 @@ initContainers: []
 extraVolumes: []
 extraVolumeMounts: []
 extraEnv: []
+annotations: {}


### PR DESCRIPTION
This makes it possible to add additional annotations to binder deployment.