### PR TITLE
decodeURIComponent the spec so it gets shown unquoted in the status message.

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -163,7 +163,7 @@ function build(providerSpec, log, path, pathType) {
   var spec = providerSpec.slice(providerSpec.indexOf('/') + 1);
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
-    $('div#loader-text p.launching').text("Starting repository: " + spec)
+    $('div#loader-text p.launching').text("Starting repository: " + decodeURIComponent(spec))
   }
 
   $('#build-progress .progress-bar').addClass('hidden');


### PR DESCRIPTION
The spec gets passed into the javascript (and the loading template)
quoted and is also used in build url created by BinderImage, so I did
not want to remove the url quoting for the spec everywhere, just in the
display string.
Intended to fix https://github.com/jupyterhub/binderhub/issues/942

If someone else is already working on this, please disregard my pull request, I'm just poking about to understand the codebase.