### PR TITLE
add allowed list as alternative to banned list of repos

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -67,11 +67,29 @@ class RepoProvider(LoggingConfigurable):
         """
     )
 
+    allowed_specs = List(
+        help="""
+        List of specs to allow building.
+
+        Should be a list of regexes (not regex objects) that match specs which
+        should be allowed.
+
+        A spec is allowed if:
+        1. it matches allowed_specs and does not match banned_specs or
+        2. allowed_specs is unspecified and the spec does not match banned_specs.
+        """,
+        config=True
+    )
+
     banned_specs = List(
         help="""
         List of specs to blacklist building.
 
         Should be a list of regexes (not regex objects) that match specs which should be blacklisted
+
+        A spec is allowed if:
+        1. it matches allowed_specs and does not match banned_specs or
+        2. allowed_specs is unspecified and the spec does not match banned_specs.
         """,
         config=True,
     )
@@ -112,13 +130,22 @@ class RepoProvider(LoggingConfigurable):
 
     def is_banned(self):
         """
-        Return true if the given spec has been banned
+        Return true if the given spec has been banned or explicitly
+        not allowed.
         """
         for banned in self.banned_specs:
             # Ignore case, because most git providers do not
             # count DS-100/textbook as different from ds-100/textbook
             if re.match(banned, self.spec, re.IGNORECASE):
                 return True
+        if self.allowed_specs and len(self.allowed_specs):
+            for allowed in self.allowed_specs:
+                if re.match(allowed, self.spec, re.IGNORECASE):
+                    return False
+            # allowed_specs is not empty but spec is not in it: banned.
+            return True
+        # allowed_specs unspecified or empty and spec does not match
+        # banned_specs: not banned.
         return False
 
     def has_higher_quota(self):

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -78,7 +78,7 @@ class RepoProvider(LoggingConfigurable):
         1. it matches allowed_specs and does not match banned_specs or
         2. allowed_specs is unspecified and the spec does not match banned_specs.
         """,
-        config=True
+        config=True,
     )
 
     banned_specs = List(

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -297,6 +297,39 @@ def test_allowed_but_banned():
     assert provider.is_banned()
 
 
+def test_allowed():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        allowed_specs=[
+            '^jupyterhub.*'
+        ]
+    )
+    assert not provider.is_banned()
+
+
+def test_not_allowed():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        allowed_specs=[
+            '^yuvipanda.*'
+        ]
+    )
+    assert provider.is_banned()
+
+
+def test_allowed_but_banned():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        allowed_specs=[
+            '^jupyterhub.*'
+        ],
+        banned_specs=[
+            '.*zero-to-.*'
+        ]
+    )
+    assert provider.is_banned()
+
+
 def test_higher_quota():
     provider = GitHubRepoProvider(
         spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", high_quota_specs=["^yuvipanda.*"]

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -287,29 +287,6 @@ def test_allowed_but_banned():
     assert provider.is_banned()
 
 
-def test_allowed():
-    provider = GitHubRepoProvider(
-        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", allowed_specs=["^jupyterhub.*"]
-    )
-    assert not provider.is_banned()
-
-
-def test_not_allowed():
-    provider = GitHubRepoProvider(
-        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", allowed_specs=["^yuvipanda.*"]
-    )
-    assert provider.is_banned()
-
-
-def test_allowed_but_banned():
-    provider = GitHubRepoProvider(
-        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4",
-        allowed_specs=["^jupyterhub.*"],
-        banned_specs=[".*zero-to-.*"],
-    )
-    assert provider.is_banned()
-
-
 def test_higher_quota():
     provider = GitHubRepoProvider(
         spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", high_quota_specs=["^yuvipanda.*"]

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -264,6 +264,39 @@ def test_banned():
     assert provider.is_banned()
 
 
+def test_allowed():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        allowed_specs=[
+            '^jupyterhub.*'
+        ]
+    )
+    assert not provider.is_banned()
+
+
+def test_not_allowed():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        allowed_specs=[
+            '^yuvipanda.*'
+        ]
+    )
+    assert provider.is_banned()
+
+
+def test_allowed_but_banned():
+    provider = GitHubRepoProvider(
+        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
+        allowed_specs=[
+            '^jupyterhub.*'
+        ],
+        banned_specs=[
+            '.*zero-to-.*'
+        ]
+    )
+    assert provider.is_banned()
+
+
 def test_higher_quota():
     provider = GitHubRepoProvider(
         spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", high_quota_specs=["^yuvipanda.*"]

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -266,66 +266,46 @@ def test_banned():
 
 def test_allowed():
     provider = GitHubRepoProvider(
-        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
-        allowed_specs=[
-            '^jupyterhub.*'
-        ]
+        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", allowed_specs=["^jupyterhub.*"]
     )
     assert not provider.is_banned()
 
 
 def test_not_allowed():
     provider = GitHubRepoProvider(
-        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
-        allowed_specs=[
-            '^yuvipanda.*'
-        ]
+        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", allowed_specs=["^yuvipanda.*"]
     )
     assert provider.is_banned()
 
 
 def test_allowed_but_banned():
     provider = GitHubRepoProvider(
-        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
-        allowed_specs=[
-            '^jupyterhub.*'
-        ],
-        banned_specs=[
-            '.*zero-to-.*'
-        ]
+        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4",
+        allowed_specs=["^jupyterhub.*"],
+        banned_specs=[".*zero-to-.*"],
     )
     assert provider.is_banned()
 
 
 def test_allowed():
     provider = GitHubRepoProvider(
-        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
-        allowed_specs=[
-            '^jupyterhub.*'
-        ]
+        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", allowed_specs=["^jupyterhub.*"]
     )
     assert not provider.is_banned()
 
 
 def test_not_allowed():
     provider = GitHubRepoProvider(
-        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
-        allowed_specs=[
-            '^yuvipanda.*'
-        ]
+        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4", allowed_specs=["^yuvipanda.*"]
     )
     assert provider.is_banned()
 
 
 def test_allowed_but_banned():
     provider = GitHubRepoProvider(
-        spec='jupyterhub/zero-to-jupyterhub-k8s/v0.4',
-        allowed_specs=[
-            '^jupyterhub.*'
-        ],
-        banned_specs=[
-            '.*zero-to-.*'
-        ]
+        spec="jupyterhub/zero-to-jupyterhub-k8s/v0.4",
+        allowed_specs=["^jupyterhub.*"],
+        banned_specs=[".*zero-to-.*"],
     )
     assert provider.is_banned()
 


### PR DESCRIPTION
this is a draft for https://github.com/jupyterhub/binderhub/issues/280

I don't know if this is the right way. this approach will get confusing if we add more configuration options based on repo patterns in the future, since the sets of repositories identified by the regexes may overlap. But regexp on the repository name does seem like a natural way to identify banned vs. allowed repositories at least.