### PR TITLE
Add a tip about ad blocker in the loading messages

### DIFF
--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -10,6 +10,7 @@ const help_messages = [
     'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that you can deploy yourself.',
     'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide</a> that talks about what it is like to run a BinderHub.',
     'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>.',
+    'Empty log? Notebook not loading? Maybe your ad blocker is interfering. Consider whitelisting mybinder.org in your ad blocker.',
     'Your launch may take longer the first few times a repository is used. This is because our machine needs to create your environment.',
 ]
 

--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -10,7 +10,7 @@ const help_messages = [
     'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that you can deploy yourself.',
     'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide</a> that talks about what it is like to run a BinderHub.',
     'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>.',
-    'Empty log? Notebook not loading? Maybe your ad blocker is interfering. Consider whitelisting mybinder.org in your ad blocker.',
+    'Empty log? Notebook not loading? Maybe your ad blocker is interfering. Consider whitelisting this site in your ad blocker.',
     'Your launch may take longer the first few times a repository is used. This is because our machine needs to create your environment.',
 ]
 


### PR DESCRIPTION
I was having problems with empty log and notebook not loading. In gitter, @sgibson91 and @betatim suggested that my ad blocker was interfering. Whitelisting mybinder.org did the trick.
 
This PR adds that tip into the loading messages.