### PR TITLE
add resolved ref information into launch events

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -322,9 +322,10 @@ class BuildHandler(BaseHandler):
             })
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube, provider)
-            self.event_log.emit('binderhub.jupyter.org/launch', 3, {
+            self.event_log.emit('binderhub.jupyter.org/launch', 4, {
                 'provider': provider.name,
                 'spec': spec,
+                'ref': ref,
                 'status': 'success',
                 'origin': self.settings['normalized_origin'] if self.settings['normalized_origin'] else self.request.host
             })
@@ -428,9 +429,10 @@ class BuildHandler(BaseHandler):
             BUILD_COUNT.labels(status='success', **self.repo_metric_labels).inc()
             with LAUNCHES_INPROGRESS.track_inprogress():
                 await self.launch(kube, provider)
-            self.event_log.emit('binderhub.jupyter.org/launch', 3, {
+            self.event_log.emit('binderhub.jupyter.org/launch', 4, {
                 'provider': provider.name,
                 'spec': spec,
+                'ref': ref,
                 'status': 'success',
                 'origin': self.settings['normalized_origin'] if self.settings['normalized_origin'] else self.request.host
             })

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -24,7 +24,7 @@
         },
         "ref": {
             "type": "string",
-            "description": "Resolved reference to the repo when it is being launched"
+            "description": "Resolved reference for the repo at the time of launch"
         },
         "status": {
             "enum": ["success", "failure"],

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -1,6 +1,6 @@
 {
     "$id": "binderhub.jupyter.org/launch",
-    "version": 3,
+    "version": 4,
     "title": "BinderHub Launch Events",
     "description": "BinderHub emits this event whenever a new repo is launched",
     "type": "object",
@@ -21,6 +21,10 @@
         "spec": {
             "type": "string",
             "description": "Provider specification for the repo being launched. Usually, <reponame>/<commit-specification>"
+        },
+        "ref": {
+            "type": "string",
+            "description": "Resolved reference to the repo when it is being launched"
         },
         "status": {
             "enum": ["success", "failure"],

--- a/doc/eventlogging.rst
+++ b/doc/eventlogging.rst
@@ -52,6 +52,7 @@ This event is emitted whenever a new repo is launched.
 
 Schemas:
 
-- `version 1 <https://github.com/jupyterhub/binderhub/blob/ba15091b0940174c1001aefd2c89b96daa8005cb/binderhub/event-schemas/launch.json>`_
+- `version 1 <https://github.com/jupyterhub/binderhub/blob/3da0f0c07eeea1b4517e5c7d1ec4a3166b3ca11c/binderhub/event-schemas/launch.json>`_
 - `version 2 <https://github.com/jupyterhub/binderhub/blob/5cc0f496cac98d6c9b7d645e6fb236fd1e5277f4/binderhub/event-schemas/launch.json>`_
-- `version 3 <https://github.com/jupyterhub/binderhub/blob/master/binderhub/event-schemas/launch.json>`_
+- `version 3 <https://github.com/jupyterhub/binderhub/blob/3bfee95f7c53d16604ea29f46b7e7c5aa1b49a63/binderhub/event-schemas/launch.json>`_
+- `version 4 <https://github.com/jupyterhub/binderhub/blob/master/binderhub/event-schemas/launch.json>`_


### PR DESCRIPTION
We have (unresolved) spec in launch events. I think having resolved ref info is also useful for later analysis.