### PR TITLE
Add links to Zero to Binder tutorials to Binder homepage

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -29,6 +29,9 @@
           Have a repository full of Jupyter notebooks? With Binder, open those notebooks in an executable environment, making your code immediately reproducible by anyone, anywhere.
         </div>
       </div>
+      <div id="tutorials" class="text-center">
+        <h4>New to Binder? Get started with a Zero to Binder tutorial in <a href="http://bit.ly/zero-to-binder-julia">Julia</a>, <a href="http://bit.ly/zero-to-binder-python">Python</a> or <a href="http://bit.ly/zero-to-binder-r">R</a>.</h4>
+      </div>
       {% endblock header %}
 
       {% block form %}

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div id="tutorials" class="text-center">
-        <h4>New to Binder? Get started with a Zero to Binder tutorial in <a href="http://bit.ly/zero-to-binder-julia">Julia</a>, <a href="http://bit.ly/zero-to-binder-python">Python</a> or <a href="http://bit.ly/zero-to-binder-r">R</a>.</h4>
+        <h4>New to Binder? Get started with a Zero to Binder tutorial in <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-julia.md">Julia</a>, <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-python.md">Python</a> or <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-r.md">R</a>.</h4>
       </div>
       {% endblock header %}
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div id="tutorials" class="text-center">
-        <h4>New to Binder? Get started with a Zero to Binder tutorial in <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-julia.md">Julia</a>, <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-python.md">Python</a> or <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-r.md">R</a>.</h4>
+        <h4>New to Binder? Get started with a Zero-to-Binder tutorial in <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-julia.md">Julia</a>, <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-python.md">Python</a> or <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-r.md">R</a>.</h4>
       </div>
       {% endblock header %}
 


### PR DESCRIPTION
This Pull Request adds the links to the 3 Zero to Binder tutorials to the Binder homepage. When rendered, it will look as follows:

<img width="883" alt="Screenshot 2020-06-18 at 13 45 56" src="https://user-images.githubusercontent.com/44771837/85021812-4c1f7080-b16a-11ea-98fd-48290e196936.png">
