### PR TITLE
[MRG] Fix escaping of non SHA1 refs

### DIFF
--- a/binderhub/tests/test_builder.py
+++ b/binderhub/tests/test_builder.py
@@ -1,0 +1,21 @@
+import pytest
+
+from binderhub.builder import _generate_build_name
+
+
+@pytest.mark.parametrize('ref,build_slug', [
+    # a long ref, no special characters at critical positions
+    ('3035124.v3.0', 'dataverse-dvn-2ftjclkp'),
+    # with ref_length=6 this has a full stop that gets escaped to a -
+    # as the last character, this used to cause an error
+    ('20460.v1.0', 'dataverse-s6-2fde95rt'),
+    # short ref, should just work and need no special processing
+    ('123456', 'dataverse-s6-2fde95rt')
+])
+def test_build_name(build_slug, ref):
+    # Build names have to be usable as pod names, which means they have to
+    # be usable as hostnames as well.
+    build_name = _generate_build_name(build_slug, ref)
+
+    last_char = build_name[-1]
+    assert last_char not in ("-", "_", ".")

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -134,12 +134,18 @@ async def test_hydroshare_doi():
     resolved_spec = await provider.get_resolved_spec()
     assert resolved_spec == repo_url
 
+
 @pytest.mark.parametrize('spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug', [
     ['10.7910/DVN/TJCLKP',
      '10.7910/DVN/TJCLKP',
      '3035124.v3.0',
      'https://doi.org/10.7910/DVN/TJCLKP',
      'dataverse-dvn-2ftjclkp'],
+    ['10.25346/S6/DE95RT',
+     '10.25346/S6/DE95RT',
+     '20460.v1.0',
+     'https://doi.org/10.25346/S6/DE95RT',
+     'dataverse-s6-2fde95rt']
 ])
 async def test_dataverse(spec, resolved_spec, resolved_ref, resolved_ref_url, build_slug):
     provider = DataverseProvider(spec=spec)


### PR DESCRIPTION
Refs that aren't a SHA1 can contain punctuation which cause us to
construct build pod names that aren't DNS safe. This PR makes sure refs
are escaped as well as specs.

closes #1133 