### PR TITLE
Allow head requests for the health endpoint

### DIFF
--- a/binderhub/tests/test_health.py
+++ b/binderhub/tests/test_health.py
@@ -27,3 +27,7 @@ async def test_basic_health(app):
         quota_check["total_pods"]
         == quota_check["build_pods"] + quota_check["user_pods"]
     )
+
+    # HEAD requests should work as well
+    r = await async_requests.head(app.url + "/health")
+    assert r.status_code == 200


### PR DESCRIPTION
We're considering running our own binderhub, and one of the uptime checkers we're using only sends HEAD requests. Tornado doesn't like the HEAD requests and return a 405, so this patch makes it respond to HEAD requests as well as GET. I've tested it in minikube and it should work.