### PR TITLE
fix default value of hub_url in config

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
               key: "binder.hub-token"
         {{- if .Values.config.BinderHub.auth_enabled }}
         - name: JUPYTERHUB_API_URL
-          value: {{ (print (.Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
+          value: {{ print (.Values.config.BinderHub.hub_url | default "" | trimSuffix "/") "/hub/api/" }}
         - name: JUPYTERHUB_BASE_URL
           value: {{ .Values.jupyterhub.hub.baseUrl | quote }}
         - name: JUPYTERHUB_CLIENT_ID

--- a/helm-chart/images/binderhub/binderhub_config.py
+++ b/helm-chart/images/binderhub/binderhub_config.py
@@ -84,7 +84,8 @@ if os.getenv('BUILD_NAMESPACE'):
     c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
 
 if c.BinderHub.auth_enabled:
-    hub_url = urlparse(c.BinderHub.hub_url)
+    hub_url = get_value('config.BinderHub.hub_url', '')
+    hub_url = urlparse(hub_url)
     c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)
     if 'base_url' in c.BinderHub:
         c.HubOAuth.base_url = c.BinderHub.base_url


### PR DESCRIPTION
In https://github.com/gesiscss/persistent_binderhub/issues/5 we found out that if someone installs BinderHub with auth enabled, 
deployment fails with 
`Error: render error in "persistent_binderhub/charts/binderhub/templates/deployment.yaml": template: persistent_binderhub/charts/binderhub/templates/deployment.yaml:98:74: executing "persistent_binderhub/charts/binderhub/templates/deployment.yaml" at <"/">: invalid value; expected string
` 

The error indicates https://github.com/jupyterhub/binderhub/blob/23ae2061decdf8e9f7b94829cabe602b6ed36519/helm-chart/binderhub/templates/deployment.yaml#L98 and it happens only if the deployment is not an upgrade from a standard BinderHub deployment (auth disabled), but it is an installation of BinderHub directly with authentication included. The reason is that on cloud-based environments `BinderHub.hub_url` is missing during the first round of the installation (https://binderhub.readthedocs.io/en/latest/zero-to-binderhub/setup-binderhub.html#install-binderhub), because it is provided after the first installation when JupyerterHub is ready (https://binderhub.readthedocs.io/en/latest/zero-to-binderhub/setup-binderhub.html#connect-binderhub-and-jupyterhub).

This PR fixes the default value of  `BinderHub.hub_url` in helm config, so helm won't complain about it during the first installation and then user can set `BinderHub.hub_url` when it is available. It also fixes it `binderhub_config.py`, so it uses default value of hub_url "" instead of `LazyConfigValue`.