### PR TITLE
[MRG] Pin version of docker client library to 4.2.0 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ install:
   - npm install
   - npm run webpack
   - pip install --upgrade . -r helm-chart/images/binderhub/requirements.txt
+  # NOTE: The latest docker python package (4.3.0) requires a more modern docker
+  #       version (newer than 18.06.0-ce / API version: 1.38) which is not yet
+  #       available on travis.
+  #       ref: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1743
   - pip install -U "docker~=4.2.0"
   - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - npm install
   - npm run webpack
   - pip install --upgrade . -r helm-chart/images/binderhub/requirements.txt
+  - pip install -U "docker~=4.2.0"
   - pip freeze
 
 script:


### PR DESCRIPTION
Newer versions of docker-py use a default API version of 1.39 which is too new for the version of docker on travis.

xref: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1743