### PR TITLE
add build_memory_request config

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -306,6 +306,21 @@ class BinderHub(Application):
         config=True
     )
 
+    build_memory_request = ByteSpecification(
+        0,
+        help="""
+        Amount of memory to request when scheduling a build
+
+        0 reserves no memory.
+
+        This is used as the request for the pod that is spawned to do the building,
+        even though the pod itself will not be using that much memory
+        since the docker building is happening outside the pod.
+        However, it makes kubernetes aware of the resources being used,
+        and lets it schedule more intelligently.
+        """,
+        config=True,
+    )
     build_memory_limit = ByteSpecification(
         0,
         help="""
@@ -313,13 +328,12 @@ class BinderHub(Application):
 
         0 sets no limit.
 
-        This is used as both the memory limit & request for the pod
-        that is spawned to do the building, even though the pod itself
-        will not be using that much memory since the docker building is
-        happening outside the pod. However, it makes kubernetes aware of
-        the resources being used, and lets it schedule more intelligently.
+        This is applied to the docker build itself via repo2docker,
+        though it is also applied to our pod that submits the build,
+        even though that pod will rarely consume much memory.
+        Still, it makes it easier to see the resource limits in place via kubernetes.
         """,
-        config=True
+        config=True,
     )
 
     debug = Bool(
@@ -598,6 +612,7 @@ class BinderHub(Application):
             'extra_footer_scripts': self.extra_footer_scripts,
             'jinja2_env': jinja_env,
             'build_memory_limit': self.build_memory_limit,
+            'build_memory_request': self.build_memory_request,
             'build_docker_host': self.build_docker_host,
             'base_url': self.base_url,
             'badge_base_url': self.badge_base_url,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -36,9 +36,28 @@ class Build:
         API instead of having to invent our own locking code.
 
     """
-    def __init__(self, q, api, name, namespace, repo_url, ref, git_credentials, build_image,
-                 image_name, push_secret, memory_limit, docker_host, node_selector,
-                 appendix='', log_tail_lines=100, sticky_builds=False):
+
+    def __init__(
+        self,
+        q,
+        api,
+        name,
+        *,
+        namespace,
+        repo_url,
+        ref,
+        build_image,
+        docker_host,
+        image_name,
+        git_credentials=None,
+        push_secret=None,
+        memory_limit=0,
+        memory_request=0,
+        node_selector=None,
+        appendix="",
+        log_tail_lines=100,
+        sticky_builds=False,
+    ):
         self.q = q
         self.api = api
         self.repo_url = repo_url
@@ -50,6 +69,7 @@ class Build:
         self.build_image = build_image
         self.main_loop = IOLoop.current()
         self.memory_limit = memory_limit
+        self.memory_request = memory_request
         self.docker_host = docker_host
         self.node_selector = node_selector
         self.appendix = appendix
@@ -255,7 +275,7 @@ class Build:
                         volume_mounts=volume_mounts,
                         resources=client.V1ResourceRequirements(
                             limits={'memory': self.memory_limit},
-                            requests={'memory': self.memory_limit}
+                            requests={'memory': self.memory_request},
                         ),
                         env=env
                     )

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -357,6 +357,7 @@ class BuildHandler(BaseHandler):
             push_secret=push_secret,
             build_image=self.settings['build_image'],
             memory_limit=self.settings['build_memory_limit'],
+            memory_request=self.settings['build_memory_request'],
             docker_host=self.settings['build_docker_host'],
             node_selector=self.settings['build_node_selector'],
             appendix=appendix,


### PR DESCRIPTION
allows separate memory_request and memory_limit on the build pod

required to implement plan in https://github.com/jupyterhub/mybinder.org-deploy/issues/1529


the build pod doesn't itself consume much resources, but this allows separate request and limit *for* the build, applied via the build pods.

limit is actually applied on the build via repo2docker flag and request allows kubernetes to assign builds more appropriately across nodes

Took the opportunity to make Build's many constructor arguments explicitly keyword-only via `*`.