### PR TITLE
Handle k8s deprecation of Ingress resources' apiVersion

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.ingress.enabled -}}
-# FIXME: Update before k8s 1.20 but after we no longer require support for k8s
-# 1.14. networking.k8s.io/v1beta1 was introduced in k8s 1.14 to replace
-# extensions/v1beta1 that goes away in k8s 1.20.
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: binderhub


### PR DESCRIPTION
This PR safeguards against future issues when k8s stops supporting outdated resources using the currently recommended practice﻿ of Helm. Related to this PR is https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1718.
