### PR TITLE
fix: launch retrying

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -531,14 +531,8 @@ class BuildHandler(BaseHandler):
                                                     server_name=server_name,
                                                     repo_url=self.repo_url,
                                                     extra_args=extra_args)
-                duration = time.perf_counter() - launch_starttime
-                LAUNCH_TIME.labels(status="success", retries=i).observe(duration)
-                LAUNCH_COUNT.labels(
-                    status='success', **self.repo_metric_labels,
-                ).inc()
-                app_log.info("Launched %s in %.0fs", self.repo_url, duration)
-
             except Exception as e:
+                duration = time.perf_counter() - launch_starttime
                 if i + 1 == launcher.retries:
                     status = 'failure'
                 else:
@@ -580,6 +574,12 @@ class BuildHandler(BaseHandler):
                 continue
             else:
                 # success
+                duration = time.perf_counter() - launch_starttime
+                LAUNCH_TIME.labels(status="success", retries=i).observe(duration)
+                LAUNCH_COUNT.labels(
+                    status='success', **self.repo_metric_labels,
+                ).inc()
+                app_log.info("Launched %s in %.0fs", self.repo_url, duration)
                 break
         event = {
             'phase': 'ready',


### PR DESCRIPTION
When a launch fails, binder doesnt retry but raises "Internal Server Error" because variable `duration` is not defined:

https://github.com/jupyterhub/binderhub/blob/de1d0cf8a19f7cbbebc4a7d45f68b7b3ec13948e/binderhub/builder.py#L522-L568

The problem is with line 534 where `duration` is defined. When line 529 (`launcher.launch`) fails, line 562 (inside except block) logs a retry message including duration. But it fails because variable `duration` is not defined.