### PR TITLE
[MRG] Use slim-buster as base image for binderhub and image-cleaner

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -17,18 +17,4 @@ sphinx-copybutton
 # automatically building documentation based on inspection of the binderhub
 # package, which means we need to install it on RTD so it is available for
 # inspection.
-#
-# The binderhub package dependencies include pycurl though, and pycurl cannot be
-# installed on RTD, so due to that we maintain a copy of binderhub's
-# requirements.txt where we comment out pyrcurl.
-docker
-escapism
-jinja2
-jsonschema
-jupyterhub
-kubernetes
-prometheus_client
-#pycurl
-python-json-logger
-tornado>=5.1
-traitlets
+-r ../requirements.txt

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -6,7 +6,7 @@ ARG DIST=buster
 # The build stage
 # ---------------
 FROM python:3.8-$DIST as build-stage
-# ARG DIST has to be defined again to made available inside this build stage.
+# ARG DIST is defined again to be made available in this build stage's scope.
 # ref: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG DIST
 

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,8 +1,8 @@
 # Using multi-stage builds
-ARG DIST=slim-buster
+ARG DIST=buster
 FROM buildpack-deps:$DIST as build-stage
 # ARG has to occur twice to be used in both contents and FROM
-ARG DIST=slim-buster
+ARG DIST=buster
 
 RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
@@ -24,7 +24,7 @@ RUN python3 setup.py bdist_wheel
 
 # The final stage
 # ---------------
-FROM python:3.8-$DIST
+FROM python:3.8-slim-$DIST
 WORKDIR /
 
 # Copy the built binderhub python wheel from the build-stage

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,8 +1,8 @@
 # Using multi-stage builds
-ARG DIST=buster
+ARG DIST=slim-buster
 FROM buildpack-deps:$DIST as build-stage
 # ARG has to occur twice to be used in both contents and FROM
-ARG DIST=buster
+ARG DIST=slim-buster
 
 RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -22,8 +22,7 @@ COPY . /tmp/binderhub
 WORKDIR /tmp/binderhub
 
 # Build the binderhub python library into a wheel and save it to the ./dist
-# folder. Also build pycurl into a wheel as doing it requires curl-config and
-# gcc that aren't available in the slim version of the final stage.
+# folder. There are no pycurl wheels so we build our own in the build stage.
 RUN python setup.py bdist_wheel
 RUN pip wheel pycurl --wheel-dir ./dist
 

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -13,9 +13,10 @@ ARG DIST
 # Install node as required to package binderhub to a wheel
 RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN apt-get update && \
-    apt-get install --yes \
-        nodejs
+RUN apt-get update \
+ && apt-get install --yes \
+        nodejs \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy the whole git repository to /tmp/binderhub
 COPY . /tmp/binderhub
@@ -33,9 +34,11 @@ FROM python:3.8-slim-$DIST
 WORKDIR /
 
 # The slim version doesn't include git as required by binderhub
-RUN apt-get update && \
-    apt-get install --yes \
-        git
+RUN apt-get update \
+ && apt-get install --yes \
+        git \
+ && rm -rf /var/lib/apt/lists/*
+
 
 # Copy the built wheels from the build-stage. Also copy the image
 # requirements.txt built from the binderhub package requirements.txt and the

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -33,6 +33,11 @@ RUN pip wheel pycurl --wheel-dir ./dist
 FROM python:3.8-slim-$DIST
 WORKDIR /
 
+# The slim version doesn't include git as required by binderhub
+RUN apt-get update && \
+    apt-get install --yes \
+        git
+
 # Copy the built wheels from the build-stage. Also copy the image
 # requirements.txt built from the binderhub package requirements.txt and the
 # requirements.in file using the ./dependency script.

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -1,48 +1,52 @@
-# Using multi-stage builds
-ARG DIST=buster
-FROM buildpack-deps:$DIST as build-stage
-# ARG has to occur twice to be used in both contents and FROM
+# We use a build stage to package binderhub and pycurl into a wheel which we
+# then install by itself in the final image which is relatively slimmed.
 ARG DIST=buster
 
+
+# The build stage
+# ---------------
+FROM python:3.8-$DIST as build-stage
+# ARG DIST has to be defined again to made available inside this build stage.
+# ref: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG DIST
+
+# Install node as required to package binderhub to a wheel
 RUN echo "deb http://deb.nodesource.com/node_14.x $DIST main" > /etc/apt/sources.list.d/nodesource.list \
  && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-
 RUN apt-get update && \
     apt-get install --yes \
-        nodejs \
-        python3 \
-        python3-pip \
-        python3-wheel \
-        python3-setuptools
+        nodejs
 
 # Copy the whole git repository to /tmp/binderhub
 COPY . /tmp/binderhub
 WORKDIR /tmp/binderhub
 
-# Build binderhub the python library
-RUN python3 setup.py bdist_wheel
+# Build the binderhub python library into a wheel and save it to the ./dist
+# folder. Also build pycurl into a wheel as doing it requires curl-config and
+# gcc that aren't available in the slim version of the final stage.
+RUN python setup.py bdist_wheel
+RUN pip wheel pycurl --wheel-dir ./dist
+
 
 # The final stage
 # ---------------
 FROM python:3.8-slim-$DIST
 WORKDIR /
 
-# Copy the built binderhub python wheel from the build-stage
-# to the current directory within the container.
-COPY --from=build-stage /tmp/binderhub/dist/*.whl .
-
-# Copy the additional Python requirements for our Docker container from the
-# build context. These can be certain pinned versions or peer dependencies.
+# Copy the built wheels from the build-stage. Also copy the image
+# requirements.txt built from the binderhub package requirements.txt and the
+# requirements.in file using the ./dependency script.
+COPY --from=build-stage /tmp/binderhub/dist/*.whl pre-built-wheels/
 COPY helm-chart/images/binderhub/requirements.txt .
+
+# Install pre-built wheels and the generated requirements.txt for the image.
 RUN pip install --no-cache-dir \
-        *.whl \
+        pre-built-wheels/*.whl \
         -r requirements.txt
 
-# when building the image used to compute the "frozen"
-# dependencies we add `pip-tools` which is for computing
-# the dependencies.
-# It is not added when chartpress builds the image used by
-# the helm chart when deploying BinderHub
+# When using the ./dependency script to output a frozen environment, we do it
+# from within this container. So below we conditionally install pip-tools for
+# use by the ./dependency script.
 ARG PIP_TOOLS=
 RUN test -z "$PIP_TOOLS" || pip install --no-cache pip-tools==$PIP_TOOLS
 

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -11,6 +11,3 @@ google-cloud-logging
 kubernetes==9.*
 # jupyterhub is pinned to match the JupyterHub Helm chart's version of jupyterhub
 jupyterhub==1.1.*
-# For pycurl v7.43.0.6 there are no wheels available on pypi.org, so stick
-# to the previous version for now.
-pycurl==7.43.0.5

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -38,7 +38,6 @@ protobuf==3.14.0          # via google-api-core, googleapis-common-protos
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pycurl==7.43.0.5          # via -r binderhub.in, -r requirements.in
 pyopenssl==19.1.0         # via certipy
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via alembic, jupyterhub, kubernetes

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -1,4 +1,4 @@
-ARG DIST=buster
+ARG DIST=slim-buster
 FROM python:3.7-$DIST
 
 ADD requirements.txt /tmp/requirements.txt

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -1,10 +1,9 @@
-ARG DIST=3.8-slim-buster
-FROM python:$DIST
+FROM python:3.8-slim-buster
 
-ADD requirements.txt /tmp/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-ADD image-cleaner.py /usr/local/bin/image-cleaner.py
+COPY image-cleaner.py /usr/local/bin/image-cleaner.py
 # set PYTHONUNBUFFERED to ensure output is produced
 ENV PYTHONUNBUFFERED=1
 CMD image-cleaner.py

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -1,5 +1,5 @@
-ARG DIST=slim-buster
-FROM python:3.7-$DIST
+ARG DIST=3.8-slim-buster
+FROM python:$DIST
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt

--- a/helm-chart/images/image-cleaner/Dockerfile
+++ b/helm-chart/images/image-cleaner/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.8-alpine3.11
+ARG DIST=buster
+FROM python:3.7-$DIST
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # About pycurl:
-# - pycurl is strongly recommended for performance but not strictly required by
-#   BinderHub.
-# - pycurl require both `curl-config` and `gcc` to be available when installing.
-# - The binderhub package require pycurl, but it is a dependency augmented to
-#   this files listed dependencies from within setup.py so that it can be
-#   either omitted as in our ReadTheDocs build that does code inspection of the
-#   binderhub package, or be installed in a separate build step as in the
-#   BinderHub docker image.
+# - pycurl is a dependency but not listed here, only in `setup.py`
+# - pycurl requires both `curl-config` and `gcc` to be available when installing
+#   it from source.
+# - the reason we do not list pycurl here is that it is not needed when our
+#   code is imported to generate the documentation and it is tricky to install
+#   in the ReadTheDocs build environment.
+# - instead we manually add pycurl to the list of dependencies in setup.py
+#   which is the list used when installing the binderhub package.
 docker
 escapism
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,12 @@
-# Keep this file in sync with `doc/doc-requirements.txt`!
+# About pycurl:
+# - pycurl is strongly recommended for performance but not strictly required by
+#   BinderHub.
+# - pycurl require both `curl-config` and `gcc` to be available when installing.
+# - The binderhub package require pycurl, but it is a dependency augmented to
+#   this files listed dependencies from within setup.py so that it can be
+#   either omitted as in our ReadTheDocs build that does code inspection of the
+#   binderhub package, or be installed in a separate build step as in the
+#   BinderHub docker image.
 docker
 escapism
 jinja2
@@ -6,7 +14,6 @@ jsonschema
 jupyterhub
 kubernetes
 prometheus_client
-pycurl
 python-json-logger
 tornado>=5.1
 traitlets

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ with open(os.path.join(here, 'requirements.txt')) as f:
         l.strip() for l in f.readlines()
         if not l.strip().startswith('#')
     ]
-    # pycurl is augmented to requirements.txt as a dependency for the binderhub
-    # package for reasons explained within requirements.txt.
+    # manually add pycurl here, see comment in requirements.txt
     requirements.append("pycurl")
 
 with open(os.path.join(here, 'README.rst'), encoding="utf8") as f:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ with open(os.path.join(here, 'requirements.txt')) as f:
         l.strip() for l in f.readlines()
         if not l.strip().startswith('#')
     ]
+    # pycurl is augmented to requirements.txt as a dependency for the binderhub
+    # package for reasons explained within requirements.txt.
+    requirements.append("pycurl")
 
 with open(os.path.join(here, 'README.rst'), encoding="utf8") as f:
     readme = f.read()


### PR DESCRIPTION
Using Alpine as base distro means we have to build wheels for a lot of
packages which often requires a compiler and other native dependencies.
By using a debian base image we get wheels from pypi for free. The
BinderHub image uses buster already so while the individual image might
be larger the layers will be shared with an image that is already
present in the cluster.

Found during #1157 where the CI failed.