### PR TITLE
Specify service type as ClusterIP

### DIFF
--- a/doc/https.rst
+++ b/doc/https.rst
@@ -99,8 +99,13 @@ with the following sections and apply it using ``helm upgrade ...``.
     config:
       BinderHub:
         hub_url: https://<jupyterhub-URL>
+    service:
+      type: ClusterIP
 
     jupyterhub:
+      proxy:
+        service:
+        type: ClusterIP
       ingress:
         enabled: true
         hosts:

--- a/doc/https.rst
+++ b/doc/https.rst
@@ -105,7 +105,7 @@ with the following sections and apply it using ``helm upgrade ...``.
     jupyterhub:
       proxy:
         service:
-        type: ClusterIP
+          type: ClusterIP
       ingress:
         enabled: true
         hosts:


### PR DESCRIPTION
Ensure that binder and proxy-public services are of type ClusterIP and use nginx-ingress as LoadBalancer.