### PR TITLE
WIP: Upload build logs to S3

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -457,6 +457,12 @@ class BinderHub(Application):
         """
     )
 
+    s3_logs_endpoint = Unicode("", help="S3 endpoint", config=True)
+    s3_logs_access_key = Unicode("", help="S3 access key ", config=True)
+    s3_logs_secret_key = Unicode("", help="S3 secret key", config=True)
+    s3_logs_bucket = Unicode("", help="S3 bucket", config=True)
+    s3_logs_region = Unicode("", help="S3 region", config=True)
+
     # FIXME: Come up with a better name for it?
     builder_required = Bool(
         True,
@@ -626,6 +632,11 @@ class BinderHub(Application):
                 "auth_enabled": self.auth_enabled,
                 "event_log": self.event_log,
                 "normalized_origin": self.normalized_origin,
+                "s3_logs_endpoint": self.s3_logs_endpoint,
+                "s3_logs_access_key": self.s3_logs_access_key,
+                "s3_logs_secret_key": self.s3_logs_secret_key,
+                "s3_logs_bucket": self.s3_logs_bucket,
+                "s3_logs_region": self.s3_logs_region,
             }
         )
         if self.auth_enabled:

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -425,6 +425,7 @@ class BuildHandler(BaseHandler):
                         failed = True
                         BUILD_TIME.labels(status='failure').observe(time.perf_counter() - build_starttime)
                         BUILD_COUNT.labels(status='failure', **self.repo_metric_labels).inc()
+                        done = True
                     templogfile.write(payload.get("message"))
                     app_log.debug(f'log: {payload.get("message")}')
                 await self.emit(event)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 kubernetes==9.0.*
 escapism
 traitlets
-aiobotocore
+boto3
 docker
 jinja2
 prometheus_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 kubernetes==9.0.*
 escapism
 traitlets
+aiobotocore
 docker
 jinja2
 prometheus_client


### PR DESCRIPTION
Playing around with S3 logs again (https://github.com/jupyterhub/binderhub/issues/1156). This time uploading repo2docker logs from the BinderHub side instead of the [repo2docker side](https://github.com/jupyterhub/repo2docker/pull/967).
