### PR TITLE
Allow dynamic repository credentials for authenticated Binderhub instances.

### DIFF
--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -149,6 +149,9 @@ class VersionHandler(BaseHandler):
 
     # demote logging of 200 responses to debug-level
     log_success_debug = True
+    # allow version-check requests from banned hosts
+    # (e.g. mybinder.org federation when blocking cloud datacenters)
+    skip_check_request_ip = True
 
     async def get(self):
         self.set_header("Content-type", "application/json")

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -229,7 +229,7 @@ class BuildHandler(BaseHandler):
 
         # get a provider object that encapsulates the provider and the spec
         try:
-            provider = self.get_provider(provider_prefix, spec=spec)
+            provider = await self.get_provider(provider_prefix, spec=spec)
         except Exception as e:
             app_log.exception("Failed to get provider for %s", key)
             await self.fail(str(e))

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -182,10 +182,18 @@ class BuildHandler(BaseHandler):
         self.event_log = self.settings['event_log']
 
     async def fail(self, message):
-        await self.emit({
-            'phase': 'failed',
-            'message': message + '\n',
-        })
+        await self.emit(
+            {
+                "phase": "failed",
+                "message": message + "\n",
+            }
+        )
+
+    def set_default_headers(self):
+        super().set_default_headers()
+        # set up for sending event streams
+        self.set_header("content-type", "text/event-stream")
+        self.set_header("cache-control", "no-cache")
 
     @authenticated
     async def get(self, provider_prefix, _unescaped_spec):
@@ -205,10 +213,6 @@ class BuildHandler(BaseHandler):
         """
         prefix = '/build/' + provider_prefix
         spec = self.get_spec_from_request(prefix)
-
-        # set up for sending event streams
-        self.set_header('content-type', 'text/event-stream')
-        self.set_header('cache-control', 'no-cache')
 
         # Verify if the provider is valid for EventSource.
         # EventSource cannot handle HTTP errors, so we must validate and send

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -47,7 +47,7 @@ class ParameterizedMainHandler(BaseHandler):
         spec = self.get_spec_from_request(prefix)
         spec = spec.rstrip("/")
         try:
-            self.get_provider(provider_prefix, spec=spec)
+            await self.get_provider(provider_prefix, spec=spec)
         except HTTPError:
             raise
         except Exception as e:


### PR DESCRIPTION
This PR is related to issue #1154 

## Proposed change
Make it possible to fill repo provider / git credentials for a forge (e.g. gitlab instance) dynamically using the currently logged-in user information. This would help set up binderhub instances for use with private repositories for organizations that run a forge (e.g. gitlab instance).


## Scope
This change is meant for authenticated Binderhubs (e.g. an instance of BinderHub that is authenticated against a Gitlab instance and whose main purpose is to build repositories hosted in that instance). It does not address building private repositories from an anonymous Binderhub instance (which would probably entail UI changes and/or a complex authentication workflow?).

In that use case, an auth-aware RepoProvider could assume that auth information is available.

## Issues

- The example RepoProvider (`AuthGitLabProvider`) in issue #1154 makes a blocking http call in the initializer to retrieve auth info -- this should be made asynchronous, but I'm not sure how.

- It should be possible to fill default traitlets config attributes (e.g. `default_git_credentials`) using dynamic credentials, after retrieving those credentials asynchronously. How can that be implemented?

- The RepoProviders should probably made aware of the auth info in order to be able to fetch private repositories, but are RepoProviders the right place to implement authorization / access controls ? If not, would a pre_build_hook as suggested in #1117 help?

## Testing this PR locally

- Install this branch of Binderhub locally using minikube as per the CONTRIBUTING instructions

- Start minikube (e.g. run `minikube start --memory 8192`) and note the minikube IP (run `minikube ip`)

- Register for an account at gitlab.com (user will be called `user1`)

- Create a private project 

- Create an application on gitlab.com ("settings" on your user profile) for authentication purposes (e.g. `bhubtest`). 

    * In the `redirect URL` field, use `http://<minikube ip>:30123/hub/oauth_callback` (note that the minikube IP may change when minikube restarts, usually alternating between two values. If so, put both in the `redirect_uri` field to ease testing). 
    * Give the application the `api` and `read_repository` scopes. 
    * Note the values of Application ID and Application Secret. 
    * **Note**: it would be nice to restrict the scope to `read_api` now that gitlab offers this...

- Install the `requests` package (used by the example repo provider) e.g. `pip install requests`

- change the file `testing/minikube/binderhub_auth_config.py` so that it looks like this

```
import json
from urllib.parse import urlparse
import os
import requests
from traitlets import default

from binderhub.repoproviders import GitLabRepoProvider

here = os.path.abspath(os.path.dirname(__file__))
load_subconfig(os.path.join(here, 'binderhub_config.py'))

c.BinderHub.base_url = '/'
c.BinderHub.auth_enabled = True
# configuration for authentication
hub_url = urlparse(c.BinderHub.hub_url)
c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)
c.HubOAuth.api_token = c.BinderHub.hub_api_token
c.HubOAuth.api_url = c.BinderHub.hub_url + '/hub/api/'
c.HubOAuth.base_url = c.BinderHub.base_url
c.HubOAuth.hub_prefix = c.BinderHub.base_url + 'hub/'
c.HubOAuth.oauth_redirect_uri = 'http://127.0.0.1:8585/oauth_callback'
c.HubOAuth.oauth_client_id = '<client ID from the newly-created gitlab application>'

class AuthGitLabProvider(GitLabRepoProvider):
    def __init__(self, *args, handler, **kwargs):
        super().__init__(*args, **kwargs)
        self.handler = handler
        ud = self.get_user_data(self.handler.get_current_user()['name'])
        self.access_token = ud['auth_state']['access_token']

    def get_user_data(self, username):
        r = requests.get(c.HubOAuth.api_url + f'/users/{username}',
            headers={
             'Authorization': 'token %s' % c.HubOAuth.api_token,
            }
        )
        r.raise_for_status()
        return r.json()

    @default('git_credentials')
    def _default_git_credentials(self):
        if self.access_token:
            return r'username=oauth2\npassword={token}'.format(token=self.access_token)
        return ""

c.BinderHub.repo_providers = {'gl': AuthGitLabProvider}
```

- change the file `testing/minikube/jupyterhub-helm-auth-config.yaml` so that it looks like this

```
cull:
  users: false
hub:
  services:
    binder:
      oauth_no_confirm: true
      oauth_redirect_uri: "http://127.0.0.1:8585/oauth_callback"
      # gitlab application id
      oauth_client_id: <newly-created Gitlab app ID>

custom:
  binderauth_enabled: true

singleuser:
  # to make notebook servers aware of hub
  cmd: jupyterhub-singleuser

auth:
  type: gitlab
  gitlab:
    callbackUrl: http://<minikube IP>:30123/hub/oauth_callback
    # retrieved from the GitLab UI (see above)
    clientId: "<newly-created Gitlab app ID>"
    clientSecret: "<newly-created Gitlab app secret>"
  state:
    enabled: true
    cryptoKey: "<output of `openssl rand -hex 32`>"
```

- Install jupyterhub by running `./testing/minikube/install-hub --auth`

- Run binderhub: `python3 -m binderhub -f testing/minikube/binderhub_auth_config.py`

- Access http://127.0.0.1:8585 using your browser. You will be prompted to login using gitlab.com

- Authorize the application, you should end up at the familiar BinderHub UI (phew!)

- Try building your private repository: in the provider dropdown, select gitlab.com and enter the "namespace" (user1/project) for your private project. Check that it builds and launches

- Register a new gitlab user (`user2`), create a new private project for user2. 

- Check that user2 can build its own private project, but not user1's

(Note that whenever the minikube IP changes due to a restart, the file `testing/minikube/jupyterhub-helm-auth-config.yaml` should be updated accordingly and `./testing/minikube/install-hub --auth` should be run again)