### PR TITLE
Update BinderHub error message for GitHub main/master branches

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -254,16 +254,12 @@ class BuildHandler(BaseHandler):
         if ref is None:
             error_message = ["Could not resolve ref for %s. Double check your URL." % key]
 
-            split_key = key.split("/")
-            repo_provider = split_key[0].split(":")[0]
-            resolved_branch = split_key[-1]
-
-            if repo_provider == "gh":
+            if provider.name == "GitHub":
                 error_message.append('GitHub recently changed default branches from "master" to "main".')
 
-                if resolved_branch == "master":
+                if provider.unresolved_ref == "master":
                     error_message.append('Did you mean the "main" branch?')
-                elif resolved_branch == "main":
+                elif provider.unresolved_ref == "main":
                     error_message.append('Did you mean the "master" branch?')
 
             else:


### PR DESCRIPTION
This PR updates the error message return when a commit ref is not resolved. When the repo provider is GitHub and the resolved branch is either `main` or `master`, we ask the user if that's the branch the meant indicating a change to the GitHub platform.

~~I tried to test this locally using the minikube instructions [here](https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md#one-time-installation) but ran into a "connection refused" error at server launch time.~~

~~`[E 201023 10:54:22 builder:556] Retrying launch of https://github.com/binder-examples/requirements after error (duration=0s, attempt=3): ConnectionRefusedError(61, 'Connection refused')`~~

Ok, I got the minikube deployment to work. (I think my problem was that I edited code while waiting for something to build. `pip install -e .` means the package gets auto-updated and minikube doesn't like that.)

<img width="886" alt="Screenshot 2020-10-23 at 13 23 46" src="https://user-images.githubusercontent.com/44771837/97003444-56e07c80-1533-11eb-8ac6-5148d1899488.png">
