### PR TITLE
Update UI and launch main branch by default for GitHub repos

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -101,7 +101,7 @@ function updateRepoText() {
   }
   $("#repository").attr('placeholder', text);
   $("label[for=repository]").text(text);
-  $("#ref").attr('placeholder', tag_text);
+  $("#ref").attr('placeholder', 'main');
   $("label[for=ref]").text(tag_text);
 }
 
@@ -121,7 +121,7 @@ function getBuildFormValues() {
     repo = encodeURIComponent(repo);
   }
 
-  var ref = $('#ref').val().trim() || 'main';
+  var ref = $('#ref').val().trim() || $("#ref").attr("placeholder");
   if (providerPrefix === 'zenodo' || providerPrefix === 'figshare' || providerPrefix === 'dataverse' ||
       providerPrefix === 'hydroshare') {
     ref = "";

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -63,6 +63,10 @@ function updateRepoText() {
   var text;
   var provider = $("#provider_prefix").val();
   var tag_text = "Git branch, tag, or commit";
+  var placeholder = "master";
+  if (provider === "gh") {
+    placeholder = "main";
+  }
   // first enable branch/ref field, some providers later disable it
   $("#ref").prop("disabled", false);
   $("label[for=ref]").prop("disabled", false);
@@ -101,12 +105,7 @@ function updateRepoText() {
   }
   $("#repository").attr('placeholder', text);
   $("label[for=repository]").text(text);
-  if (provider === "gh") {
-    $("#ref").attr('placeholder', 'main');
-  }
-  else {
-    $("#ref").attr('placeholder', tag_text);
-  }
+  $("#ref").attr('placeholder', placeholder);
   $("label[for=ref]").text(tag_text);
 }
 

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -101,7 +101,12 @@ function updateRepoText() {
   }
   $("#repository").attr('placeholder', text);
   $("label[for=repository]").text(text);
-  $("#ref").attr('placeholder', 'main');
+  if (provider === "gh") {
+    $("#ref").attr('placeholder', 'main');
+  }
+  else {
+    $("#ref").attr('placeholder', tag_text);
+  }
   $("label[for=ref]").text(tag_text);
 }
 

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -121,7 +121,7 @@ function getBuildFormValues() {
     repo = encodeURIComponent(repo);
   }
 
-  var ref = $('#ref').val().trim() || 'master';
+  var ref = $('#ref').val().trim() || 'main';
   if (providerPrefix === 'zenodo' || providerPrefix === 'figshare' || providerPrefix === 'dataverse' ||
       providerPrefix === 'hydroshare') {
     ref = "";


### PR DESCRIPTION
This PR updates the placeholder for the "Git branch, commit or tag" field to be `main` and also defaults to launching the `main` branch for GitHub repos.

fixes #1168 

Screenshot of how the UI now looks:

<img width="956" alt="Screenshot 2020-10-28 at 15 38 37" src="https://user-images.githubusercontent.com/44771837/97486222-0ca43480-1953-11eb-9d4d-9dda41b84b18.png">