### PR TITLE
Remove no longer used doc/environment.yml

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,9 +1,0 @@
-name: binderhub
-channels:
-  - conda-forge
-dependencies:
-  - python=3.6
-  - traitlets>=4.1
-  - tornado>=4.1
-  - pip:
-      - -r doc-requirements.txt


### PR DESCRIPTION
This file was used for a while by RTD, but now we rely on
doc-requirements.txt entirely. This is defined in .readthedocs.yml.
