### PR TITLE
CI: Test using Node 14 - now an active LTS release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 before_install:
-  - nvm install 12; nvm use 12
+  - nvm install 14; nvm use 14
   - pip install --upgrade pip setuptools
 install:
   - export PATH=$PWD/bin:$PATH


### PR DESCRIPTION
This is just influencing the CI environment, verifying things work with Node 14 which is now the active LTS release recommended for most users.
