### PR TITLE
pin kubernetes, jupyterhub in requirements.in

### DIFF
--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -6,5 +6,8 @@
 google-cloud-logging
 
 # pins for our image
+# kubernetes is pinned to 9 because we have observed a performance issue in 12
+# where listing pods took ~6s instead of ~1s
 kubernetes==9.*
+# jupyterhub is pinned to match the JupyterHub Helm chart's version of jupyterhub
 jupyterhub==1.1.*

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -4,3 +4,7 @@
 #    ./dependencies freeze --upgrade
 #
 google-cloud-logging
+
+# pins for our image
+kubernetes==9.*
+jupyterhub==1.1.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -27,8 +27,8 @@ ipython-genutils==0.2.0   # via traitlets
 jinja2==2.11.2            # via -r binderhub.in, jupyterhub
 jsonschema==3.2.0         # via -r binderhub.in, jupyter-telemetry
 jupyter-telemetry==0.1.0  # via jupyterhub
-jupyterhub==1.2.0         # via -r binderhub.in
-kubernetes==12.0.0        # via -r binderhub.in
+jupyterhub==1.1.0         # via -r binderhub.in, -r requirements.in
+kubernetes==9.0.1         # via -r binderhub.in, -r requirements.in
 mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
 oauthlib==3.1.0           # via jupyterhub, requests-oauthlib


### PR DESCRIPTION
- performance issue with kubernetes v12 means we need to do some other fixes to be safe before upgrading (same as https://github.com/jupyterhub/kubespawner/pull/424) where k8s 12 is several times slower than v9.
- jupyterhub upgrade *may* also be relevant, but not sure.

this lets us land the latest changes without the significant dependency bumps, so we can deploy those in isolation for easier testing