### PR TITLE
Update v1beta to v1 in rbac resources

### DIFF
--- a/helm-chart/binderhub/templates/rbac.yaml
+++ b/helm-chart/binderhub/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.enabled -}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -16,7 +16,7 @@ rules:
   verbs: ["get"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app: binderhub
@@ -47,7 +47,7 @@ metadata:
 # image-cleaner role
 # needs to cordon nodes during image cleaning
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app: binderhub
@@ -61,7 +61,7 @@ rules:
   verbs: ["get", "patch"]
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     app: binderhub


### PR DESCRIPTION
This is not a problem to bump without a conditional check, as z2jh has done it two years ago when k8s 1.9 were out.

```
W1103 12:01:58.056881   10226 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
W1103 12:01:58.066375   10226 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W1103 12:01:58.071477   10226 warnings.go:67] rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
W1103 12:01:58.078640   10226 warnings.go:67] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
```
