### PR TITLE
CI: stop asserting local binderhub version match remote version

### DIFF
--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -80,7 +80,6 @@ async def test_about_handler(app):
     r = await async_requests.get(app.url + "/about")
     assert r.status_code == 200
     assert "This website is powered by" in r.text
-    assert binder_version in r.text
 
 
 @pytest.mark.remote


### PR DESCRIPTION
Closes #1200 by no longer asserting the remote test environment will have the binderhub version according to versioneer which use git commits to decide its version, compared to the built image.

The image would rebuild if binderhub the Python package had changed at all, but it wouldn't if something unrelated has been committed. The \_version.py script doesn't care about this though, and decides the binderhub package is even newer than the image and observes a version mismatch.

Due to this, I suggest we stop asserting this. I don't see this assertion to be helpful to make unless we tighten down the test to only be relevant in a few cases, and that doesn't seem to be helpful enough to motivate it. Due to this, I'll go ahead and remove this assertion from the /about test.
