### PR TITLE
Syntax error fix to publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |
           . ./ci/common
-          setup_helm v3.4.0
+          setup_helm v3.4.1
           pip install --no-cache-dir chartpress
 
       - name: Setup push rights to jupyterhub/helm-chart

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
         include:
             # This version of k3s uses kubernetes v1.18
             - k3s-version: v1.18.10+k3s2
-              helm_version: v3.4.0
+              helm_version: v3.4.1
               test: main
             - k3s-version: v1.18.10+k3s2
-              helm_version: v3.4.0
+              helm_version: v3.4.1
               test: auth
             - k3s-version: v1.18.10+k3s2
-              helm_version: v3.4.0
+              helm_version: v3.4.1
               test: helm
     steps:
       - uses: actions/checkout@v2

--- a/ci/common
+++ b/ci/common
@@ -1,10 +1,10 @@
 #!/bin/sh
 # Use https://www.shellcheck.net/ to reduce mistakes if you make changes to this file.
 
-setup_helm () {
-    helm_version = $1
+setup_helm() {
+    helm_version="${1}"
     echo "setup helm ${helm_version}"
-    curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION=v${helm_version} bash
+    curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION="${helm_version}" bash
 }
 
 await_jupyterhub() {
@@ -22,7 +22,7 @@ await_binderhub() {
     kubectl rollout status --watch --timeout 300s deployment/binder
 }
 
-full_namespace_report () {
+full_namespace_report() {
     # list config (secret,configmap)
     kubectl get secret,cm
     # list networking (service,ingress)


### PR DESCRIPTION
#1209 needed a followup to fix the following error. It was caused by `var_name = $1` where varName was interpreted as a command to execute rather than a variable to assign to, so this PR fixes it by doing `var_name=$1`. I also bumped the Helm version.

[![image](https://user-images.githubusercontent.com/3837114/99098602-7ff7a880-25d9-11eb-9f96-5b05f17ace37.png)](https://github.com/jupyterhub/binderhub/actions/runs/361986200)