### PR TITLE
[MRG] Pin pycurl version in binderhub image

### DIFF
--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -11,3 +11,6 @@ google-cloud-logging
 kubernetes==9.*
 # jupyterhub is pinned to match the JupyterHub Helm chart's version of jupyterhub
 jupyterhub==1.1.*
+# For pycurl v7.43.0.6 there are no wheels available on pypi.org, so stick
+# to the previous version for now.
+pycurl==7.43.0.5

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -6,9 +6,9 @@
 #
 alembic==1.4.3            # via jupyterhub
 async-generator==1.10     # via jupyterhub
-attrs==20.2.0             # via jsonschema
+attrs==20.3.0             # via jsonschema
 cachetools==4.1.1         # via google-auth
-certifi==2020.6.20        # via kubernetes, requests
+certifi==2020.11.8        # via kubernetes, requests
 certipy==0.1.3            # via jupyterhub
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
@@ -17,7 +17,7 @@ docker==4.3.1             # via -r binderhub.in
 entrypoints==0.3          # via jupyterhub
 escapism==1.0.1           # via -r binderhub.in
 google-api-core[grpc]==1.23.0  # via google-cloud-core, google-cloud-logging
-google-auth==1.22.1       # via google-api-core, kubernetes
+google-auth==1.23.0       # via google-api-core, kubernetes
 google-cloud-core==1.4.3  # via google-cloud-logging
 google-cloud-logging==1.15.1  # via -r requirements.in
 googleapis-common-protos==1.52.0  # via google-api-core
@@ -34,28 +34,28 @@ markupsafe==1.1.1         # via jinja2, mako
 oauthlib==3.1.0           # via jupyterhub, requests-oauthlib
 pamela==1.0.0             # via jupyterhub
 prometheus-client==0.8.0  # via -r binderhub.in, jupyterhub
-protobuf==3.13.0          # via google-api-core, googleapis-common-protos
+protobuf==3.14.0          # via google-api-core, googleapis-common-protos
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pycurl==7.43.0.6          # via -r binderhub.in
+pycurl==7.43.0.5          # via -r binderhub.in, -r requirements.in
 pyopenssl==19.1.0         # via certipy
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via alembic, jupyterhub, kubernetes
 python-editor==1.0.4      # via alembic
 python-json-logger==2.0.1  # via -r binderhub.in, jupyter-telemetry
-pytz==2020.1              # via google-api-core
+pytz==2020.4              # via google-api-core
 pyyaml==5.3.1             # via kubernetes
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.24.0          # via docker, google-api-core, jupyterhub, kubernetes, requests-oauthlib
+requests==2.25.0          # via docker, google-api-core, jupyterhub, kubernetes, requests-oauthlib
 rsa==4.6                  # via google-auth
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via jupyter-telemetry
 six==1.15.0               # via cryptography, docker, google-api-core, google-auth, grpcio, jsonschema, kubernetes, protobuf, pyopenssl, python-dateutil, websocket-client
 sqlalchemy==1.3.20        # via alembic, jupyterhub
-tornado==6.0.4            # via -r binderhub.in, jupyterhub
+tornado==6.1              # via -r binderhub.in, jupyterhub
 traitlets==5.0.5          # via -r binderhub.in, jupyter-telemetry, jupyterhub
-urllib3==1.25.11          # via kubernetes, requests
+urllib3==1.26.2           # via kubernetes, requests
 websocket-client==0.57.0  # via docker, kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This pins pycurl to 7.43.0.5 because the newer version (.6) does [not have wheels on pypi.org](https://pypi.org/project/pycurl/7.43.0.6/#files). Something that is weird is that we have previously built the binderhub docker image with .6, so maybe wheels used to exist? But I thought that once you upload files to pypi you aren't allowed to remove them again to prevent situations like this.

This seems like the simplest fix as there is no reason we need to be using the latest version. An alternative would be to add another build stage to the BinderHub image build process, build the pycurl wheel, and then copy it to the final stage.

Noticed this while investigating why #1158's CI steps failed. One run here: https://github.com/jupyterhub/binderhub/pull/1158/checks?check_run_id=1405660478