### PR TITLE
[MRG] Manual trigger of tests and fix tag pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish helm chart and docker images
 on:
   push:
     branches: [main, master]
-    tags:
+    tags: ["**"]
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [master, main]
+    tags: ["**"]
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
While it is possible to push on tags by just defining the `tags` keyword as well as branches by specififying the `branches` keyword, whenever one of these have a value set, the other is ignored unless it has a value as well.

> If you define only tags or only branches, the workflow won't run for events affecting the undefined Git refs

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

Due to this, we won't trigger on tags as it currently is, but this PR fixes this. This PR also adds the ability to manually trigger the test workflow which can be useful as a sanity check sometimes, for example if a PR has a failing build but you wonder if its related to the PR or if a regression in the main branch.
