### PR TITLE
[MRG] Always provide k8s namespace report, limit step timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,7 @@ jobs:
               --set config.BinderHub.hub_url_local=http://proxy-public \
               --set config.BinderHub.access_token=$GITHUB_ACCESS_TOKEN
       - name: Wait for JupyterHub to be ready
+        timeout-minutes: 10
         run: |
             # Wait for JupyterHub to be ready
             set -e
@@ -130,8 +131,9 @@ jobs:
             echo
             echo "curl http://localhost:30902/hub/api/" should print the JupyterHub version
             curl http://localhost:30902/hub/api/
-      - name: Wait for binderhub to be ready
+      - name: Wait for BinderHub to be ready
         if: matrix.test == 'helm'
+        timeout-minutes: 10
         run: |
             # Wait for BinderHub to be ready
             set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,13 +154,11 @@ jobs:
             export BINDER_URL=http://localhost:30901
             pytest -m "remote" -vx --cov binderhub
       - name: Kubernetes namespace report
-        if: ${{ failure() }}
+        if: ${{ always() }}
         run: |
           # Display debugging information
           . ci/common
           full_namespace_report
       - name: Upload coverage stats
         uses: codecov/codecov-action@v1
-        # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-        # Upload regardless of whether tests pass or fail
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}


### PR DESCRIPTION
In trying to figure out why https://github.com/jupyterhub/binderhub/runs/1416598746 never completed (bhub didn't become ready, but why??) I am setting up the kubernetes namespace report to always run. Previously it would only run on error, but when a step gets cancelled that isn't an error. There seems to be no downside to always running the report as the log output is folded away by default.

I also set a timeout for the two "await hub" steps of ten minutes. My thinking is that if they don't complete in ~10m then they will never complete, even if we wait 6hours. By using a smaller timeout we save on build minutes and get people results sooner.