### PR TITLE
clear outstanding health check on failure

### DIFF
--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -74,10 +74,12 @@ def at_most_every(_f=None, *, interval=60):
             now = time.monotonic()
             if now > last_time + interval:
                 outstanding = asyncio.ensure_future(f(*args, **kwargs))
-                last_result = await outstanding
-                # complete, clear outstanding future and note the time
-                outstanding = None
-                last_time = time.monotonic()
+                try:
+                    last_result = await outstanding
+                finally:
+                    # complete, clear outstanding future and note the time
+                    outstanding = None
+                    last_time = time.monotonic()
             return last_result
 
         return wrapper


### PR DESCRIPTION
should always be cleared when it completes, whether it was a success or failure. As it is now, a failure would be remembered forever.

I believe this fixes the main issue in https://github.com/jupyterhub/mybinder.org-deploy/issues/1720