### PR TITLE
[MRG] ci: bugfix of chartpress fixed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           . ./ci/common
           setup_helm v3.4.1
-          pip install --no-cache-dir chartpress
+          pip install --no-cache-dir chartpress==1.0.*
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-chartpress==0.7.*
+chartpress==1.0.*
 click
 codecov
 html5lib

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -57,5 +57,6 @@ traitlets==5.0.5          # via -r binderhub.in, jupyter-telemetry, jupyterhub
 urllib3==1.26.2           # via kubernetes, requests
 websocket-client==0.57.0  # via docker, kubernetes
 
+
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Chartpress 1.0.0 contained a regression, and our publishing pipeline was using chartpress 1.0.0 instead of 0.7.0, so it was affected. This made the image version used by binderhub since chartpress 1.0.0 was released in 21 Nov 2020 be the same version as the image-cleaner image.

The only PR that was influenced by this mishap was a PR merged ~2 hours. With this commit, it should not happen again.

@sgibson91 with this merged, we should get a Henchbot PR for mybinder.org-deploy that will be correctly containing #1220 within the image as set by the binderhub helm chart.