### PR TITLE
set allow_origin_pat when CORS checks are disabled

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -90,6 +90,10 @@ jupyterhub:
                     allow_origin = cors.get('allowOrigin')
                     if allow_origin:
                         args.append('--NotebookApp.allow_origin=' + allow_origin)
+                    # allow_origin=* doesn't properly allow cross-origin requests to single files
+                    # see https://github.com/jupyter/notebook/pull/5898
+                    if allow_origin == '*':
+                        args.append('--NotebookApp.allow_origin_pat=.*')
                     args += self.args
                 return args
 


### PR DESCRIPTION
notebook server doesn't properly apply allow_origin=* on server-side validation, e.g. direct requests for /blob/somefile

closes https://github.com/jupyterhub/mybinder.org-deploy/issues/1638

fixed submitted upstream: https://github.com/jupyter/notebook/pull/5898