### PR TITLE
Do not mount host docker.sock into image cleaner pod if it is not enabled

### DIFF
--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -64,6 +64,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 0
       volumes:
+      {{- if .Values.imageCleaner.host.enabled }}
       - name: dockerlib-host
         hostPath:
           path: {{ .Values.imageCleaner.host.dockerLibDir }}
@@ -71,6 +72,7 @@ spec:
         hostPath:
           path: {{ .Values.imageCleaner.host.dockerSocket }}
           type: Socket
+      {{- end }}
       {{- if .Values.dind.enabled }}
       - name: dockerlib-dind
         hostPath:


### PR DESCRIPTION
Currently if you run binderhub with dind and no host Docker daemon, the image cleaner pod still declares `dockerlib-host` and `dockersocket-host` as volumes even if `imageCleaner.host.enabled` is false, even if the host docker socket is nonexistent. This PR adds a check and only adds the host docker socket as a volume if `imageCleaner.host.enabled` is true.

The image cleaner pod actually would still work, because no containers in that pod actually use the volumes. Still, it would be nice to remove them from the pod declaration altogether.