### PR TITLE
ci: make pytest colored in github workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,16 +147,16 @@ jobs:
       - name: Run main tests
         if: matrix.test == 'main'
         # running the "main" tests means "all tests that aren't auth"
-        run: pytest -m "not auth" -v --maxfail=2 --cov binderhub --durations=10
+        run: pytest -m "not auth" -v --maxfail=2 --cov binderhub --durations=10 --color=yes
       - name: Run auth tests
         if: matrix.test == 'auth'
         # running the "auth" tests means "all tests that are marked as auth"
-        run: pytest -m "auth" -v --maxfail=2 --cov binderhub --durations=10
+        run: pytest -m "auth" -v --maxfail=2 --cov binderhub --durations=10 --color=yes
       - name: Run helm tests
         if: matrix.test == 'helm'
         run: |
             export BINDER_URL=http://localhost:30901
-            pytest -m "remote" -v --maxfail=2 --cov binderhub --durations=10
+            pytest -m "remote" -v --maxfail=2 --cov binderhub --durations=10 --color=yes
       - name: Kubernetes namespace report
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
GitHub actions behave differently than travisci, forcing us to explicitly say that pytest and git diff etc should use colors.

Test failure unrelated.