### PR TITLE
binder image: jh 1.1 -> 1.2, k8s-client 9 -> 12

### DIFF
--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -8,6 +8,6 @@ google-cloud-logging
 # pins for our image
 # kubernetes is pinned to 9 because we have observed a performance issue in 12
 # where listing pods took ~6s instead of ~1s
-kubernetes==9.*
+kubernetes==12.*
 # jupyterhub is pinned to match the JupyterHub Helm chart's version of jupyterhub
-jupyterhub==1.1.*
+jupyterhub==1.2.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -7,38 +7,39 @@
 alembic==1.4.3            # via jupyterhub
 async-generator==1.10     # via jupyterhub
 attrs==20.3.0             # via jsonschema
-cachetools==4.1.1         # via google-auth
-certifi==2020.11.8        # via kubernetes, requests
+cachetools==4.2.0         # via google-auth
+certifi==2020.12.5        # via kubernetes, requests
 certipy==0.1.3            # via jupyterhub
-cffi==1.14.3              # via cryptography
-chardet==3.0.4            # via requests
-cryptography==3.2.1       # via pyopenssl
-docker==4.3.1             # via -r binderhub.in
+cffi==1.14.4              # via cryptography
+chardet==4.0.0            # via requests
+cryptography==3.3.1       # via pyopenssl
+docker==4.4.0             # via -r binderhub.in
 entrypoints==0.3          # via jupyterhub
 escapism==1.0.1           # via -r binderhub.in
-google-api-core[grpc]==1.23.0  # via google-cloud-core, google-cloud-logging
-google-auth==1.23.0       # via google-api-core, kubernetes
-google-cloud-core==1.4.3  # via google-cloud-logging
-google-cloud-logging==1.15.1  # via -r requirements.in
+google-api-core[grpc]==1.24.1  # via google-cloud-core, google-cloud-logging
+google-auth==1.24.0       # via google-api-core, kubernetes
+google-cloud-core==1.5.0  # via google-cloud-logging
+google-cloud-logging==2.0.2  # via -r requirements.in
 googleapis-common-protos==1.52.0  # via google-api-core
-grpcio==1.33.2            # via google-api-core
+grpcio==1.34.0            # via google-api-core
 idna==2.10                # via requests
 ipython-genutils==0.2.0   # via traitlets
 jinja2==2.11.2            # via -r binderhub.in, jupyterhub
 jsonschema==3.2.0         # via -r binderhub.in, jupyter-telemetry
 jupyter-telemetry==0.1.0  # via jupyterhub
-jupyterhub==1.1.0         # via -r binderhub.in, -r requirements.in
-kubernetes==9.0.1         # via -r binderhub.in, -r requirements.in
+jupyterhub==1.2.2         # via -r binderhub.in, -r requirements.in
+kubernetes==12.0.1        # via -r binderhub.in, -r requirements.in
 mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
 oauthlib==3.1.0           # via jupyterhub, requests-oauthlib
 pamela==1.0.0             # via jupyterhub
-prometheus-client==0.8.0  # via -r binderhub.in, jupyterhub
-protobuf==3.14.0          # via google-api-core, googleapis-common-protos
+prometheus-client==0.9.0  # via -r binderhub.in, jupyterhub
+proto-plus==1.13.0        # via google-cloud-logging
+protobuf==3.14.0          # via google-api-core, googleapis-common-protos, proto-plus
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pyopenssl==19.1.0         # via certipy
+pyopenssl==20.0.1         # via certipy
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via alembic, jupyterhub, kubernetes
 python-editor==1.0.4      # via alembic
@@ -46,17 +47,16 @@ python-json-logger==2.0.1  # via -r binderhub.in, jupyter-telemetry
 pytz==2020.4              # via google-api-core
 pyyaml==5.3.1             # via kubernetes
 requests-oauthlib==1.3.0  # via kubernetes
-requests==2.25.0          # via docker, google-api-core, jupyterhub, kubernetes, requests-oauthlib
+requests==2.25.1          # via docker, google-api-core, jupyterhub, kubernetes, requests-oauthlib
 rsa==4.6                  # via google-auth
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via jupyter-telemetry
-six==1.15.0               # via cryptography, docker, google-api-core, google-auth, grpcio, jsonschema, kubernetes, protobuf, pyopenssl, python-dateutil, websocket-client
-sqlalchemy==1.3.20        # via alembic, jupyterhub
+six==1.15.0               # via cryptography, docker, google-api-core, google-auth, google-cloud-core, grpcio, jsonschema, kubernetes, protobuf, pyopenssl, python-dateutil, websocket-client
+sqlalchemy==1.3.22        # via alembic, jupyterhub
 tornado==6.1              # via -r binderhub.in, jupyterhub
 traitlets==5.0.5          # via -r binderhub.in, jupyter-telemetry, jupyterhub
 urllib3==1.26.2           # via kubernetes, requests
 websocket-client==0.57.0  # via docker, kubernetes
-
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This is a followup to the z2jh chart bump. We hesitated a bit upgrading this because we observed issues so I'll monitor the binderhub pod specifically along with this bump.
