### PR TITLE
Revert to kubernetes API client v9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,16 +147,16 @@ jobs:
       - name: Run main tests
         if: matrix.test == 'main'
         # running the "main" tests means "all tests that aren't auth"
-        run: pytest -m "not auth" -v --maxfail=2 --cov binderhub --durations=10 --color=yes
+        run: pytest -m "not auth" -v --maxfail=10 --cov binderhub --durations=10 --color=yes
       - name: Run auth tests
         if: matrix.test == 'auth'
         # running the "auth" tests means "all tests that are marked as auth"
-        run: pytest -m "auth" -v --maxfail=2 --cov binderhub --durations=10 --color=yes
+        run: pytest -m "auth" -v --maxfail=10 --cov binderhub --durations=10 --color=yes
       - name: Run helm tests
         if: matrix.test == 'helm'
         run: |
             export BINDER_URL=http://localhost:30901
-            pytest -m "remote" -v --maxfail=2 --cov binderhub --durations=10 --color=yes
+            pytest -m "remote" -v --maxfail=10 --cov binderhub --durations=10 --color=yes
       - name: Kubernetes namespace report
         if: ${{ always() }}
         run: |

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -11,4 +11,4 @@ google-cloud-logging==1.*
 # jupyterhub and kubernetes is pinned to match the JupyterHub Helm chart's
 # version of jupyterhub
 jupyterhub==1.2.*
-kubernetes==12.*
+kubernetes==9.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,59 +4,167 @@
 #
 #    ./dependencies freeze --upgrade
 #
-alembic==1.4.3            # via jupyterhub
-async-generator==1.10     # via jupyterhub
-attrs==20.3.0             # via jsonschema
-cachetools==4.2.0         # via google-auth
-certifi==2020.12.5        # via kubernetes, requests
-certipy==0.1.3            # via jupyterhub
-cffi==1.14.4              # via cryptography
-chardet==4.0.0            # via requests
-cryptography==3.3.1       # via pyopenssl
-docker==4.4.0             # via -r binderhub.in
-entrypoints==0.3          # via jupyterhub
-escapism==1.0.1           # via -r binderhub.in
-google-api-core[grpc]==1.24.1  # via google-cloud-core, google-cloud-logging
-google-auth==1.24.0       # via google-api-core, kubernetes
-google-cloud-core==1.5.0  # via google-cloud-logging
-google-cloud-logging==1.15.1  # via -r requirements.in
-googleapis-common-protos==1.52.0  # via google-api-core
-grpcio==1.34.0            # via google-api-core
-idna==2.10                # via requests
-ipython-genutils==0.2.0   # via traitlets
-jinja2==2.11.2            # via -r binderhub.in, jupyterhub
-jsonschema==3.2.0         # via -r binderhub.in, jupyter-telemetry
-jupyter-telemetry==0.1.0  # via jupyterhub
-jupyterhub==1.2.2         # via -r binderhub.in, -r requirements.in
-kubernetes==12.0.1        # via -r binderhub.in, -r requirements.in
-mako==1.1.3               # via alembic
-markupsafe==1.1.1         # via jinja2, mako
-oauthlib==3.1.0           # via jupyterhub, requests-oauthlib
-pamela==1.0.0             # via jupyterhub
-prometheus-client==0.9.0  # via -r binderhub.in, jupyterhub
-protobuf==3.14.0          # via google-api-core, googleapis-common-protos
-pyasn1-modules==0.2.8     # via google-auth
-pyasn1==0.4.8             # via pyasn1-modules, rsa
-pycparser==2.20           # via cffi
-pyopenssl==20.0.1         # via certipy
-pyrsistent==0.17.3        # via jsonschema
-python-dateutil==2.8.1    # via alembic, jupyterhub, kubernetes
-python-editor==1.0.4      # via alembic
-python-json-logger==2.0.1  # via -r binderhub.in, jupyter-telemetry
-pytz==2020.4              # via google-api-core
-pyyaml==5.3.1             # via kubernetes
-requests-oauthlib==1.3.0  # via kubernetes
-requests==2.25.1          # via docker, google-api-core, jupyterhub, kubernetes, requests-oauthlib
-rsa==4.6                  # via google-auth
-ruamel.yaml.clib==0.2.2   # via ruamel.yaml
-ruamel.yaml==0.16.12      # via jupyter-telemetry
-six==1.15.0               # via cryptography, docker, google-api-core, google-auth, google-cloud-core, grpcio, jsonschema, kubernetes, protobuf, pyopenssl, python-dateutil, websocket-client
-sqlalchemy==1.3.22        # via alembic, jupyterhub
-tornado==6.1              # via -r binderhub.in, jupyterhub
-traitlets==5.0.5          # via -r binderhub.in, jupyter-telemetry, jupyterhub
-urllib3==1.26.2           # via kubernetes, requests
-websocket-client==0.57.0  # via docker, kubernetes
-
+alembic==1.4.3
+    # via jupyterhub
+async-generator==1.10
+    # via jupyterhub
+attrs==20.3.0
+    # via jsonschema
+cachetools==4.2.0
+    # via google-auth
+certifi==2020.12.5
+    # via
+    #   kubernetes
+    #   requests
+certipy==0.1.3
+    # via jupyterhub
+cffi==1.14.4
+    # via cryptography
+chardet==4.0.0
+    # via requests
+cryptography==3.3.1
+    # via pyopenssl
+docker==4.4.1
+    # via -r binderhub.in
+entrypoints==0.3
+    # via jupyterhub
+escapism==1.0.1
+    # via -r binderhub.in
+google-api-core[grpc]==1.24.1
+    # via
+    #   google-cloud-core
+    #   google-cloud-logging
+google-auth==1.24.0
+    # via
+    #   google-api-core
+    #   kubernetes
+google-cloud-core==1.5.0
+    # via google-cloud-logging
+google-cloud-logging==1.15.1
+    # via -r requirements.in
+googleapis-common-protos==1.52.0
+    # via google-api-core
+grpcio==1.34.0
+    # via google-api-core
+idna==2.10
+    # via requests
+ipython-genutils==0.2.0
+    # via traitlets
+jinja2==2.11.2
+    # via
+    #   -r binderhub.in
+    #   jupyterhub
+jsonschema==3.2.0
+    # via
+    #   -r binderhub.in
+    #   jupyter-telemetry
+jupyter-telemetry==0.1.0
+    # via jupyterhub
+jupyterhub==1.2.2
+    # via
+    #   -r binderhub.in
+    #   -r requirements.in
+kubernetes==9.0.1
+    # via
+    #   -r binderhub.in
+    #   -r requirements.in
+mako==1.1.3
+    # via alembic
+markupsafe==1.1.1
+    # via
+    #   jinja2
+    #   mako
+oauthlib==3.1.0
+    # via
+    #   jupyterhub
+    #   requests-oauthlib
+pamela==1.0.0
+    # via jupyterhub
+prometheus-client==0.9.0
+    # via
+    #   -r binderhub.in
+    #   jupyterhub
+protobuf==3.14.0
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
+pyasn1-modules==0.2.8
+    # via google-auth
+pyasn1==0.4.8
+    # via
+    #   pyasn1-modules
+    #   rsa
+pycparser==2.20
+    # via cffi
+pyopenssl==20.0.1
+    # via certipy
+pyrsistent==0.17.3
+    # via jsonschema
+python-dateutil==2.8.1
+    # via
+    #   alembic
+    #   jupyterhub
+    #   kubernetes
+python-editor==1.0.4
+    # via alembic
+python-json-logger==2.0.1
+    # via
+    #   -r binderhub.in
+    #   jupyter-telemetry
+pytz==2020.5
+    # via google-api-core
+pyyaml==5.3.1
+    # via kubernetes
+requests-oauthlib==1.3.0
+    # via kubernetes
+requests==2.25.1
+    # via
+    #   docker
+    #   google-api-core
+    #   jupyterhub
+    #   kubernetes
+    #   requests-oauthlib
+rsa==4.6
+    # via google-auth
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.16.12
+    # via jupyter-telemetry
+six==1.15.0
+    # via
+    #   cryptography
+    #   docker
+    #   google-api-core
+    #   google-auth
+    #   google-cloud-core
+    #   grpcio
+    #   jsonschema
+    #   kubernetes
+    #   protobuf
+    #   pyopenssl
+    #   python-dateutil
+    #   websocket-client
+sqlalchemy==1.3.22
+    # via
+    #   alembic
+    #   jupyterhub
+tornado==6.1
+    # via
+    #   -r binderhub.in
+    #   jupyterhub
+traitlets==5.0.5
+    # via
+    #   -r binderhub.in
+    #   jupyter-telemetry
+    #   jupyterhub
+urllib3==1.26.2
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==0.57.0
+    # via
+    #   docker
+    #   kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Newer versions use a lot more CPU than v9. Going back to this version to
confirm if the CPU load on mybinder.org drops again as soon as we deploy
this change.