### PR TITLE
Change regex to match new(?) figshare URL scheme

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -249,7 +249,7 @@ class FigshareProvider(RepoProvider):
     Users must provide a spec consisting of the Figshare DOI.
     """
     name = Unicode("Figshare")
-    url_regex = re.compile(r"(.*)/articles/([^/]+)/(\d+)(/)?(\d+)?")
+    url_regex = re.compile(r"(.*)/articles/([^/]+)/([^/]+)/(\d+)(/)?(\d+)?")
 
     async def get_resolved_ref(self):
         client = AsyncHTTPClient()
@@ -258,8 +258,8 @@ class FigshareProvider(RepoProvider):
         r = await client.fetch(req)
 
         match = self.url_regex.match(r.effective_url)
-        article_id = match.groups()[2]
-        article_version = match.groups()[4]
+        article_id = match.groups()[3]
+        article_version = match.groups()[5]
         if not article_version:
             article_version = "1"
         self.record_id = "{}.v{}".format(article_id, article_version)


### PR DESCRIPTION
It looks like figshare.com URLs now have a new layout: https://figshare.com/articles/code/Binder-ready_openSenseMap_Analysis/9782777 is what I get when I follow https://doi.org/10.6084/m9.figshare.9782777.v1.

Based on the regex we use I think the old URLs looked like https://figshare.com/articles/Binder-ready_openSenseMap_Analysis/9782777 (or so).

With this new regex we can parse the new URLs. Maybe there is a way to make this more robust to future changes but my regex-fu isn't strong enough.

Is it a good idea to switch to using `/(\d+)(/)?(\d+)?$` as regex (to get the numbers we need), a separate check that `/articles/` appears in the URL and that the hostname contains `figshare`?