### PR TITLE
dummy commit to force rebuild of binder image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ prometheus_client
 python-json-logger
 tornado>=5.1
 traitlets
+
+#dummy change to trigger a rebuild


### PR DESCRIPTION
Conclusion, the checks succeed because this triggers a rebuild of the image which makes it available directly and the binder pod starts fast. This influence the the race condition to have the binder pod ready before we curl it.