### PR TITLE
[MRG] helm chart: add readinessProbe and let probes be configurable

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -121,10 +121,23 @@ spec:
         ports:
           - containerPort: 8585
             name: binder
+        {{- if .Values.deployment.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.config.BinderHub.base_url | default "/" }}versions
+            port: binder
+          initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.deployment.readinessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.deployment.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: {{ .Values.config.BinderHub.base_url | default "/" }}versions
             port: binder
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 10
+          initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.deployment.livenessProbe.failureThreshold }}
+        {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -145,6 +145,18 @@ jupyterhub:
       enabled: false
 
 deployment:
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    failureThreshold: 1000  # we rely on the liveness probe to resolve issues if needed
+    timeoutSeconds: 3
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    failureThreshold: 3
+    timeoutSeconds: 10
   labels: {}
 
 dind:


### PR DESCRIPTION
My diagnosis of #1237 is that for whatever reason, the ci test fails because it is `curl`ing the /version endpoint before it is ready. Further, from testing in various dummy PRs, that this is an outcome influenced quite reliably based on if the binder image has been recently rebuilt or not.

When the binder image has been rebuilt recently, it means that it will be available without a download step that risks queing behind other image downloads etc, which makes pods startup in sequence. When pods startup in sequence, its plausible that the binder pod starts late and won't get a chance to startup properly.

With this PR, we introduce a readinessProbe that will never make the pod unready before the livenessProbe triggers a restart. Due to this, the purpose becomes solely to ensure that the pod is started properly before accepting network traffic.

Benefits:
- Provides a clear criteria to know if it has properly started up useful in CI system, closes #1237.
- Helps when multiple replicas are used to ensure traffic isn't redirected to a recently started byt not yet responsive binder pod.

Drawbacks:
- Can clutter logs, _but only_ if we use debug logging because of an exception to /health and /version is made to only log successful requests if debug mode is enabled.
- Can delay readiness with up to 5 seconds because `periodSeconds: 5` of actual readiness. This value is a compromise of not cluttering logs and not waiting too long for readiness on startup.