### PR TITLE
adding a path suffix parameter for ingress

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          - path: /
+          - path: /{{ $.Values.ingress.pathSuffix }}
             backend:
               serviceName: binder
               servicePort: 80

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -203,6 +203,9 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  pathSuffix: ''
+    # Suffix added to Ingress's routing path pattern.
+    # Specify `*` if your ingress matches path by glob pattern.
   tls: []
     # Secrets must be manually created in the namespace.
     # - secretName: chart-example-tls


### PR DESCRIPTION
Configuration for binderhub ingress to work correctly withGCP load balancers. Similar to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/c2bd79903df714c2e20bc20cdf7b60b3652ed866


```
response 404 (backend NotFound), service rules for [ /static/logo.svg ] non-existent 
```