### PR TITLE
fix URLs of files in styles.css for binderhubs that are not served at "/"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,11 @@ module.exports = {
                 test: /\.css$/,
                 use: ExtractTextPlugin.extract({
                     fallback: "style-loader",
-                    use: "css-loader"
+                    use: "css-loader",
+                    // Set publicPath as relative path ("./").
+                    // By default it uses the `output.publicPath` ("/static/dist/"), when it rewrites the URLs in styles.css.
+                    // And it causes these files unavailabe if BinderHub has a different base_url than "/".
+                    publicPath: "./"
                 })
             },
             {


### PR DESCRIPTION
fixes https://github.com/jupyterhub/binderhub/issues/793

Overrides the publicPath for the loader used in `ExtractTextPlugin`. By default it uses the publicPath of the application ("/static/dist/"), when it rewrites the URLs in styles.css. But this makes these files available only if BinderHub is served under "/" (base_url is "/"), and not available if BinderHub has a different base_url, e.g. "/binder/". So if we set publicPath relative to root ("./"), these files will be always available. 