### PR TITLE
Pin chartpress to 1.0.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           . ./ci/common
           setup_helm v3.4.1
-          pip install --no-cache-dir chartpress==1.0.*
+          pip install --no-cache-dir chartpress==1.0.3
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-chartpress==1.0.*
+chartpress==1.0.3
 click
 codecov
 html5lib


### PR DESCRIPTION
A new version of chartpress was released and now our chart publishing job thinks that it does not need to publish anything. More details in https://github.com/henchbot/mybinder.org-upgrades/issues/7#issuecomment-766126450

Let's merge this and see if this brings the chart publishing back to life. If not we know it wasn't the chartpress release, if yes we can use the old version of chartpress until there is a fix.

It might make sense to keep the chartpress version pinned for a "long time" and rely on explicit upgrades of it so that we don't have to investigate why our machinery has started failing. In particular as there were no problems with the old chartpress version from a BinderHub point of view.