### PR TITLE
ci fix: add webpack.config.js to chartpress.yaml

### DIFF
--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -31,6 +31,7 @@ charts:
         paths:
           - images/binderhub/requirements.txt
           - ../setup.py
-          - ../package.json
           - ../binderhub
+          - ../package.json
+          - ../webpack.config.js
         valuesPath: image


### PR DESCRIPTION
Ensures that chartpress considers it relevant to bump the helm chart version when webpack.config.js changes, as it can influence the JS content shipped with the binderhub package.

Note that merging this will trigger chartpress to run, and it will now think the latest chart version is newer than before and due to that publish what wasn't published before.

---

The conclusion of this being a fix is based on @betatim's observations in https://github.com/henchbot/mybinder.org-upgrades/issues/7#issuecomment-766126450 and the fact that https://github.com/jupyterhub/binderhub/pull/1247/files didn't change any other files than webpack.config.js.

---

I have verified this solves the issue as chartpress now think its version `0.2.0-n496.h988aca0` is the latest version of the chart, while without this, it thought it was `0.2.0-n472.h32e06ee` before and after the #1247 that changed the webpack.config.js file.