### PR TITLE
[MRG] In unit tests close client connection once 'ready' message arrives

### DIFF
--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -52,6 +52,13 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
             events.append(event)
             assert 'message' in event
             sys.stdout.write(event['message'])
+            # this is the signal that everything is ready, pod is launched
+            # and server is up inside the pod. Break out of the loop now
+            # because BinderHub keeps the connection open for many seconds
+            # after to avoid "reconnects" from slow clients
+            if event.get('phase') == 'ready':
+                r.close()
+                break
 
     final = events[-1]
     assert 'phase' in final


### PR DESCRIPTION
In our tests when we pretend to be a web browser we were waiting for
BinderHub to close the network connection while streaming the response.
Because BinderHub waits "a long time" after sending the "ready" message
this was slowing down the tests, as they sat around twiddling their
thumbs.

This is a follow up/fix for behaviour observed in https://github.com/jupyterhub/binderhub/pull/1251#issuecomment-766155383

I think this means we don't explicitly test that the last message the hub sends is the "ready" message as we close the stream when we get it. So if other messages are sent (by accident) we wouldn't know. I think that is fine or could be tested explicitly in a different test. I can't think of a case were a "ready" message is sent in a successful build, which would lead us astray here.

-> nice optimisation to make the tests a bit quicker.