### PR TITLE
build_docker_config added, enables augmentation of the build pod's docker config

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -297,7 +297,7 @@ class BinderHub(Application):
     )
 
     push_secret = Unicode(
-        'binder-push-secret',
+        'binder-build-docker-config',
         allow_none=True,
         help="""
         A kubernetes secret object that provides credentials for pushing built images.
@@ -374,6 +374,22 @@ class BinderHub(Application):
         if parts.scheme != 'unix' or parts.netloc != '':
             raise TraitError("Only unix domain sockets on same node are supported for build_docker_host")
         return proposal.value
+
+    build_docker_config = Dict(
+        None,
+        allow_none=True,
+        help="""
+        A dict which will be merged into the .docker/config.json of the build container (repo2docker)
+        Here, you could for example pass proxy settings as described here:
+        https://docs.docker.com/network/proxy/#configure-the-docker-client
+
+        Note: if you provide your own push_secret, this values wont
+        have an effect, as the push_secrets will overwrite
+        .docker/config.json
+        In this case, make sure that you include your config in your push_secret
+        """,
+        config=True
+    )
 
     hub_api_token = Unicode(
         help="""API token for talking to the JupyterHub API""",
@@ -693,6 +709,7 @@ class BinderHub(Application):
                 "build_memory_limit": self.build_memory_limit,
                 "build_memory_request": self.build_memory_request,
                 "build_docker_host": self.build_docker_host,
+                "build_docker_config": self.build_docker_config,
                 "base_url": self.base_url,
                 "badge_base_url": self.badge_base_url,
                 "static_path": os.path.join(HERE, "static"),

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -248,9 +248,9 @@ class Build:
         )]
 
         if self.push_secret:
-            volume_mounts.append(client.V1VolumeMount(mount_path="/root/.docker", name='docker-push-secret'))
+            volume_mounts.append(client.V1VolumeMount(mount_path="/root/.docker", name='docker-config'))
             volumes.append(client.V1Volume(
-                name='docker-push-secret',
+                name='docker-config',
                 secret=client.V1SecretVolumeSource(secret_name=self.push_secret)
             ))
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -351,7 +351,7 @@ class BuildHandler(BaseHandler):
         # Prepare to build
         q = Queue()
 
-        if self.settings['use_registry']:
+        if self.settings['use_registry'] or self.settings['build_docker_config']:
             push_secret = self.settings['push_secret']
         else:
             push_secret = None

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -16,9 +16,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Render docker config.json for the registry-publishing secret.
+Render docker config.json for the registry-publishing secret and other docker configuration.
 */}}
-{{- define "registryDockerConfig" -}}
+{{- define "buildDockerConfig" -}}
 
 {{- /* default auth url */ -}}
 {{- $url := (default "https://index.docker.io/v1" .Values.registry.url) }}
@@ -36,11 +36,13 @@ Render docker config.json for the registry-publishing secret.
 {{- end }}
 {{- $username := .Values.registry.username -}}
 
-{
-  "auths": {
-    "{{ $url }}": {
-      "auth": "{{ printf "%s:%s" $username .Values.registry.password | b64enc }}"
-    }
-  }
-}
+{{- /* initialize a dict to represent a docker config with registry credentials */}}
+{{- $dockerConfig := dict "auths" (dict $url (dict "auth" (printf "%s:%s" $username .Values.registry.password | b64enc))) }}
+
+{{- /* augment our initialized docker config with buildDockerConfig */}}
+{{- if .Values.config.BinderHub.buildDockerConfig }}
+{{- $dockerConfig := merge $dockerConfig .Values.config.BinderHub.buildDockerConfig }}
+{{- end }}
+
+{{- $dockerConfig | toPrettyJson }}
 {{- end }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -16,12 +16,12 @@ data:
   {{- end }}
   values.yaml: {{ $values | toYaml | b64enc | quote }}
 ---
-{{- if .Values.config.BinderHub.use_registry }}
+{{- if or .Values.config.BinderHub.use_registry .Values.config.BinderHub.buildDockerConfig }}
 kind: Secret
 apiVersion: v1
 metadata:
-  name: binder-push-secret
+  name: binder-build-docker-config
 type: Opaque
 data:
-  config.json: {{ include "registryDockerConfig" . | b64enc | quote }}
+  config.json: {{ include "buildDockerConfig" . | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## PR Summary by Erik

The BinderHub configuration `build_docker_config` is added to allow an augmentation of the build pods docker config (`config.json`) that previously have only contained container registry credentials when `use_registry` was set to to True.

A motivation for adding this configuration option is to enable the ability to configure network proxy settings for docker, so for example traffic going to download an apt package during the build process is done through a proxy. Such configuration is documented [here](https://docs.docker.com/network/proxy/) for example.

This PR does not introduce any breaking changes, but it does rename a k8s Secret (managed directly by the Helm chart) from `binder-push-secret` to `binder-build-docker-config`. By doing so, a build pod starting up in the wrong moment could get stuck in pending by referencing the old name but not being able to mount it. If a pod is already running everything will be fine though, the content mounted won't be deleted just because the mounted k8s Secret was deleted.

I think this PR makes sense, is well scoped, and while could cause a disruption during a very brief moment in time for new builds does the right thing to rename the k8s Secret.

---

## Original PR summary

This is the build pod part of the PR  #990
It will allow to build images with repo2docker behind a proxy.
Prerequisite:
https://github.com/jupyterhub/repo2docker/pull/1003#pullrequestreview-574870630