### PR TITLE
bump jupyterhub chart to 0.11.1

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "0.10.6"
+    version: "0.11.1"
     repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -125,11 +125,9 @@ jupyterhub:
       binder:
         admin: true
         apiToken:
-  auth:
-    type: custom
-    custom:
-      # disable login (users created exclusively via API)
-      className: nullauthenticator.NullAuthenticator
+  config:
+    JupyterHub:
+      authenticator_class: "nullauthenticator.NullAuthenticator"
   singleuser:
     # start jupyter notebook
     cmd: jupyter-notebook

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
@@ -10,8 +10,8 @@ hub:
       oauth_no_confirm: true
       oauth_redirect_uri: "http://127.0.0.1:8585/oauth_callback"
       oauth_client_id: "binder-oauth-client-test"
-
-auth:
-  type: dummy
-  dummy:
-    password: dummy
+  config:
+    JupyterHub:
+      authenticator_class: "dummy"
+    DummyAuthenticator:
+      password: "dummy"


### PR DESCRIPTION
gets kubespawner 0.15, jupyterhub 1.3

adds hub.config passthrough

changes auth config, shouldn't be much else backward-incompatible

@consideRatio any other expected changes I missed that you think might affect binderhub?