### PR TITLE
fix: location of hub config should be hub.config

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -63,6 +63,9 @@ jupyterhub:
   rbac:
     enabled: true
   hub:
+    config:
+      JupyterHub:
+        authenticator_class: nullauthenticator.NullAuthenticator
     extraConfig:
       00-binder: |
         from tornado import web
@@ -125,9 +128,6 @@ jupyterhub:
       binder:
         admin: true
         apiToken:
-  config:
-    JupyterHub:
-      authenticator_class: "nullauthenticator.NullAuthenticator"
   singleuser:
     # start jupyter notebook
     cmd: jupyter-notebook


### PR DESCRIPTION
Followup to #1258 that had typo with regards to where the correct configuration was nested within values.yaml.