### PR TITLE
add BinderHub.ban_networks

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -25,8 +25,6 @@ from traitlets import (
     Bool,
     Dict,
     Integer,
-    List,
-    Set,
     TraitError,
     Unicode,
     Union,
@@ -496,25 +494,25 @@ class BinderHub(Application):
         """
     )
 
-    ban_networks = Set(
+    ban_networks = Dict(
         config=True,
         help="""
-        List of networks from which requests should be rejected with 403
+        Dict of networks from which requests should be rejected with 403
 
-        Use CIDR notation (e.g. '1.2.3.4/32').
-        Strings will be parsed with `ipaddress.ip_network()`.
+        Keys are CIDR notation (e.g. '1.2.3.4/32'),
+        values are a label used in log / error messages.
+        CIDR strings will be parsed with `ipaddress.ip_network()`.
         """,
     )
 
     @validate("ban_networks")
     def _cast_ban_networks(self, proposal):
         """Cast CIDR strings to IPv[4|6]Network objects"""
-        networks = []
-        for cidr in proposal.value:
-            networks.append(ipaddress.ip_network(cidr))
+        networks = {}
+        for cidr, message in proposal.value.items():
+            networks[ipaddress.ip_network(cidr)] = message
 
-        # collapse networks in case of overlap:
-        return set(ipaddress.collapse_addresses(networks))
+        return networks
 
     ban_networks_min_prefix_len = Integer(
         1,

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -1,9 +1,11 @@
 """Base classes for request handlers"""
 
 import json
+from ipaddress import ip_address
 
 from http.client import responses
 from tornado import web
+from tornado.log import app_log
 from jupyterhub.services.auth import HubOAuthenticated, HubOAuth
 
 from . import __version__ as binder_version
@@ -16,6 +18,23 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
         super().initialize()
         if self.settings['auth_enabled']:
             self.hub_auth = HubOAuth.instance(config=self.settings['traitlets_config'])
+
+    def prepare(self):
+        super().prepare()
+        # check request ips early on all handlers
+        self.check_request_ip()
+
+    skip_check_request_ip = False
+
+    def check_request_ip(self):
+        """Check network block list, if any"""
+        if self.skip_check_request_ip or not self.settings.get("ban_networks"):
+            return
+        request_ip = ip_address(self.request.remote_ip)
+        for network in self.settings["ban_networks"]:
+            if request_ip in network:
+                app_log.warning(f"Blocking request from {request_ip} in {network}")
+                raise web.HTTPError(403, f"Requests from {request_ip} are not allowed")
 
     def get_current_user(self):
         if not self.settings['auth_enabled']:

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -9,7 +9,7 @@ from tornado.log import app_log
 from jupyterhub.services.auth import HubOAuthenticated, HubOAuth
 
 from . import __version__ as binder_version
-from .utils import ip_in_network_set
+from .utils import ip_in_networks
 
 
 class BaseHandler(HubOAuthenticated, web.RequestHandler):
@@ -33,13 +33,17 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
         if self.skip_check_request_ip or not ban_networks:
             return
         request_ip = self.request.remote_ip
-        if ip_in_network_set(
+        match = ip_in_networks(
             request_ip,
             ban_networks,
             min_prefix_len=self.settings["ban_networks_min_prefix_len"],
-        ):
-            app_log.warning(f"Blocking request from {request_ip} in ban_networks")
-            raise web.HTTPError(403, f"Requests from {request_ip} are not allowed")
+        )
+        if match:
+            network, message = match
+            app_log.warning(
+                f"Blocking request from {request_ip} matching banned network {network}: {message}"
+            )
+            raise web.HTTPError(403, f"Requests from {message} are not allowed")
 
     def get_current_user(self):
         if not self.settings['auth_enabled']:

--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -98,6 +98,11 @@ class HealthHandler(BaseHandler):
     # to avoid flooding logs with health checks
     log_success_debug = True
 
+    # Do not check request ip when getting health status
+    # we want to allow e.g. federation members to check each other's
+    # health, but not launch Binders
+    skip_check_request_ip = True
+
     def initialize(self, hub_url=None):
         self.hub_url = hub_url
 

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -335,3 +335,8 @@ def always_build(app, request):
         patch = patch_provider(Provider)
         patch.start()
         request.addfinalizer(patch.stop)
+
+
+# skip_remote mark for tests that require local binder
+# e.g. patching config
+skip_remote = pytest.mark.skipif(REMOTE_BINDER, reason="requires local binder")

--- a/binderhub/tests/test_auth.py
+++ b/binderhub/tests/test_auth.py
@@ -1,9 +1,12 @@
 """Test authentication"""
 
+import ipaddress
+from unittest import mock
 from urllib.parse import urlparse
 
 import pytest
 
+from .conftest import skip_remote
 from .utils import async_requests
 
 
@@ -41,3 +44,53 @@ async def test_auth(app, path, authenticated, use_session):
     assert r2.status_code == 200, f"{r2.status_code} {r.url}"
     # verify that we landed at the destination after auth
     assert r2.url == url
+
+
+@skip_remote
+@pytest.mark.parametrize(
+    "path, banned, prefixlen, status",
+    [
+        ("/", True, 32, 403),
+        ("/", False, 32, 200),
+        (
+            "/v2/gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd",
+            True,
+            24,
+            403,
+        ),
+        # ban_networks shouldn't affect health endpoint
+        ("/health", True, 32, (200, 503)),
+        ("/health", False, 24, (200, 503)),
+    ],
+)
+async def test_ban_networks(request, app, use_session, path, banned, prefixlen, status):
+    url = f"{app.url}{path}"
+    ban_networks = ["255.255.255.255/32", "1.0.0.0/8"]
+    local_net = str(ipaddress.ip_network("127.0.0.1").supernet(new_prefix=prefixlen))
+    if banned:
+        ban_networks.append(local_net)
+
+    # pass through trait validators on app
+    app.ban_networks = ban_networks
+
+    def reset():
+        app.ban_networks = []
+
+    request.addfinalizer(reset)
+    with mock.patch.dict(
+        app.tornado_app.settings,
+        {
+            "ban_networks": app.ban_networks,
+            "ban_networks_min_prefix_len": app.ban_networks_min_prefix_len,
+        },
+    ):
+        r = await async_requests.get(url)
+    if isinstance(status, int):
+        assert r.status_code == status
+    else:
+        # allow container of statuses
+        assert r.status_code in status
+
+    if status == 403:
+        # check error message on 403
+        assert "Requests from 127.0.0.1 are not allowed" in r.text

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -1,6 +1,7 @@
 """Miscellaneous utilities"""
 from collections import OrderedDict
 from hashlib import blake2b
+import ipaddress
 import time
 
 from traitlets import Integer, TraitError
@@ -162,6 +163,25 @@ def url_path_join(*pieces):
         result = "/"
 
     return result
+
+
+def ip_in_network_set(ip, network_set, min_prefix_len=1):
+    """Return whether `ip` is in the set of networks network_set
+
+    This is O(1) regardless of the size of network_set
+
+    Implementation based on netaddr.IPSet.__contains__
+    """
+    if min_prefix_len < 1:
+        raise ValueError(f"min_prefix_len must be >= 1, got {min_prefix_len}")
+    if not network_set:
+        return False
+    check_net = ipaddress.ip_network(ip)
+    while check_net.prefixlen >= min_prefix_len:
+        if check_net in network_set:
+            return True
+        check_net = check_net.supernet(1)
+    return False
 
 
 # FIXME: remove when instantiating a kubernetes client

--- a/binderhub/utils.py
+++ b/binderhub/utils.py
@@ -165,21 +165,31 @@ def url_path_join(*pieces):
     return result
 
 
-def ip_in_network_set(ip, network_set, min_prefix_len=1):
-    """Return whether `ip` is in the set of networks network_set
+def ip_in_networks(ip, networks, min_prefix_len=1):
+    """Return whether `ip` is in the dict of networks
 
-    This is O(1) regardless of the size of network_set
+    This is O(1) regardless of the size of networks
 
     Implementation based on netaddr.IPSet.__contains__
+
+    Repeatedly checks if ip/32; ip/31; ip/30; etc. is in networks
+    for all netmasks that match the given ip,
+    for a max of 32 dict key lookups for ipv4.
+
+    If all netmasks have a prefix length of e.g. 24 or greater,
+    min_prefix_len prevents checking wider network masks that can't possibly match.
+
+    Returns `(netmask, networks[netmask])` for matching netmask
+    in networks, if found; False, otherwise.
     """
     if min_prefix_len < 1:
         raise ValueError(f"min_prefix_len must be >= 1, got {min_prefix_len}")
-    if not network_set:
+    if not networks:
         return False
     check_net = ipaddress.ip_network(ip)
     while check_net.prefixlen >= min_prefix_len:
-        if check_net in network_set:
-            return True
+        if check_net in networks:
+            return check_net, networks[check_net]
         check_net = check_net.supernet(1)
     return False
 


### PR DESCRIPTION
to ban requests from certain sources, e.g. AWS

health endpoint is not included, for reasons covered in https://github.com/jupyterhub/mybinder.org-deploy/issues/1828

We could also block only builds/launches, rather everything but health check. That would save on cost.

see https://github.com/jupyterhub/mybinder.org-deploy/issues/1828 for reasoning about doing this at the application level instead of a NetworkPolicy

I'm still exploring the performance costs of this and possible optimizations using netaddr when we have thousands of networks to check.