### PR TITLE
Update the build image to jupyter/repo2docker:2021.01.0

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -411,7 +411,7 @@ class BinderHub(Application):
     )
 
     build_image = Unicode(
-        'jupyter/repo2docker:0.10.0',
+        'jupyter/repo2docker:2021.01.0',
         help="""
         The repo2docker image to be used for doing builds
         """,


### PR DESCRIPTION
Since the previous tag was getting a bit old, we can update the default build image to the latest as of today.