### PR TITLE
docker registry: handle subdirectories in custom registries

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -306,7 +306,7 @@ class BuildHandler(BaseHandler):
         if self.settings['use_registry']:
             for _ in range(3):
                 try:
-                    image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
+                    image_manifest = await self.registry.get_image_manifest(*image_name.split('/',1)[-1].split(':', 1))
                     image_found = bool(image_manifest)
                     break
                 except HTTPClientError:


### PR DESCRIPTION
Fixed image name splitting in manifest for this case:
"dockerhub.ebi.ac.uk/bioimagearchive/k8s-jupyterhub/binder-ebibiostudies-2dbiostudies-2dnotebooks-c728a8:7f8fe051826f19933283b7a4dfe975b62a1e17ba"

Tested on:

"registry.hub.docker.com/nvidia/cuda:11.2.1-devel-ubuntu20.04"
----
Background:

Binderhub can pull my images and push them to our gitlab docker registry, but it can't find manifest files, I think this patch fixes this and doesn't break every other container repo

closes #1267
