### PR TITLE
Revert "docker registry: handle subdirectories in custom registries"

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -310,7 +310,7 @@ class BuildHandler(BaseHandler):
         if self.settings['use_registry']:
             for _ in range(3):
                 try:
-                    image_manifest = await self.registry.get_image_manifest(*image_name.split('/',1)[-1].split(':', 1))
+                    image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
                     image_found = bool(image_manifest)
                     break
                 except HTTPClientError:


### PR DESCRIPTION
Reverts jupyterhub/binderhub#1269

Rolling this change back because of #1281 and I can't think of a quick fix.

I think we need to try again and find a solution that works for the new and the old case (and maybe add a test so we don't break them again after finding the solution :) )