### PR TITLE
Gitlab registry support

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -71,13 +71,13 @@ def _get_image_basename_and_tag(full_name):
         image_name = full_name
         tag = 'latest'
 
-    if re.fullmatch('[a-z0-9]{4,40}/[a-z0-9\._-]{2,255}', image_name):
+    if re.fullmatch('[a-z0-9]{4,40}/[a-z0-9._-]{2,255}', image_name):
         # if it looks like a Docker Hub image name, we're done
         return image_name, tag
-    else:
-        # if the image isn't implied to origin at Docker Hub, the first part has to be a registry
-        image_basename = '/'.join(image_name.split('/')[1:])
-        return image_basename, tag
+    # if the image isn't implied to origin at Docker Hub,
+    # the first part has to be a registry
+    image_basename = '/'.join(image_name.split('/')[1:])
+    return image_basename, tag
 
 
 def _generate_build_name(build_slug, ref, prefix='', limit=63, ref_length=6):

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -7,6 +7,7 @@ import hashlib
 from http.client import responses
 import json
 import string
+import re
 import time
 import escapism
 
@@ -53,6 +54,30 @@ LAUNCH_COUNT = Counter(
 )
 BUILDS_INPROGRESS = Gauge('binderhub_inprogress_builds', 'Builds currently in progress')
 LAUNCHES_INPROGRESS = Gauge('binderhub_inprogress_launches', 'Launches currently in progress')
+
+
+def _get_image_basename_and_tag(full_name):
+    """Get a supposed image name and tag without the registry part
+    :param full_name: full image specification, e.g. "gitlab.com/user/project:tag"
+    :return: tuple of image name and tag, e.g. ("user/project", "tag")
+    """
+    # the tag is either after the last (and only) colon, or not given at all,
+    # in which case "latest" is implied
+    tag_splits = full_name.rsplit(':', 1)
+    if len(tag_splits) == 2:
+        image_name = tag_splits[0]
+        tag = tag_splits[1]
+    else:
+        image_name = full_name
+        tag = 'latest'
+
+    if re.fullmatch('[a-z0-9]{4,40}/[a-z0-9\._-]{2,255}', image_name):
+        # if it looks like a Docker Hub image name, we're done
+        return image_name, tag
+    else:
+        # if the image isn't implied to origin at Docker Hub, the first part has to be a registry
+        image_basename = '/'.join(image_name.split('/')[1:])
+        return image_basename, tag
 
 
 def _generate_build_name(build_slug, ref, prefix='', limit=63, ref_length=6):
@@ -310,7 +335,7 @@ class BuildHandler(BaseHandler):
         if self.settings['use_registry']:
             for _ in range(3):
                 try:
-                    image_manifest = await self.registry.get_image_manifest(*'/'.join(image_name.split('/')[-2:]).split(':', 1))
+                    image_manifest = await self.registry.get_image_manifest(*_get_image_basename_and_tag(image_name))
                     image_found = bool(image_manifest)
                     break
                 except HTTPClientError:

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -191,7 +191,10 @@ class DockerRegistry(LoggingConfigurable):
         # first, get a token to perform the manifest request
         if self.token_url:
             auth_req = httpclient.HTTPRequest(
-                url_concat(self.token_url, {"scope": "repository:{}:pull".format(image)}),
+                url_concat(self.token_url, {
+                    "scope": "repository:{}:pull".format(image),
+                    "service": "container_registry"
+                }),
                 auth_username=self.username,
                 auth_password=self.password,
             )

--- a/binderhub/tests/test_builder.py
+++ b/binderhub/tests/test_builder.py
@@ -1,7 +1,21 @@
 import pytest
 
-from binderhub.builder import _generate_build_name
+from binderhub.builder import _generate_build_name, _get_image_basename_and_tag
 
+
+@pytest.mark.parametrize("fullname,basename,tag", [
+    ("jupyterhub/k8s-binderhub:0.2.0-a2079a5", "jupyterhub/k8s-binderhub", "0.2.0-a2079a5"),
+    ("jupyterhub/jupyterhub", "jupyterhub/jupyterhub", "latest"),
+    ("gcr.io/project/image:tag", "project/image", "tag"),
+    ("weirdregistry.com/image:tag", "image", "tag"),
+    ("gitlab-registry.example.com/group/project:some-tag", "group/project", "some-tag"),
+    ("gitlab-registry.example.com/group/project/image:latest", "group/project/image", "latest"),
+    ("gitlab-registry.example.com/group/project/my/image:rc1", "group/project/my/image", "rc1")
+])
+def test_image_basename_resolution(fullname, basename, tag):
+    result_basename, result_tag = _get_image_basename_and_tag(fullname)
+    assert result_basename == basename
+    assert result_tag == tag
 
 @pytest.mark.parametrize('ref,build_slug', [
     # a long ref, no special characters at critical positions


### PR DESCRIPTION
This PR provides support for GitLab image registry and possibly also further non-Docker Hub image registries, the latter not tested.
New code was tested against following image registries using minikube:

* Docker Hub
* Image registry of Gitab.com
* Image registry of a private GitLab instance

Besides parsing image names, we also append the query param `service=container_registry` when sending requests to read manifests. I have noticed that without, both Gitlab.com and my private instance, can't be accessed properly. See [Gitlab docs](https://docs.gitlab.com/ee/administration/packages/container_registry.html#enable-the-container-registry) for more context. I can tell that in case of Docker Hub, the extra param is no issue and i assume same applies for other Image registries.

Note that this is mostly not my own work, most of the code is based on [#986 ](https://github.com/jupyterhub/binderhub/pull/986).

For reference, the relevant parts of an example config using Gitlab.com image registry:
```
config:
  BinderHub:
    use_registry: true
    image_prefix: "registry.gitlab.com/<gitlab-user>/<repo>/"
  DockerRegistry:
    token_url: "https://gitlab.com/jwt/auth"
    url: "https://registry.gitlab.com"
    username: <deploy-token-username>
    password: <deploy-token-pw>
registry:
  url: https://registry.gitlab.com
  username: <deploy-token-username>
  password: <deploy-token-pw>
```
