### PR TITLE
Send filepath urls to JupyterLab instead of classic notebook

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -64,7 +64,7 @@ class ParameterizedMainHandler(BaseHandler):
         social_desc = f"{SPEC_NAMES[provider_prefix]}: {spec}"
         nbviewer_url = None
         if provider_prefix == "gh":
-            # we can only produce an nbviewer URL for github right now
+            # We can only produce an nbviewer URL for github right now
             nbviewer_url = 'https://nbviewer.jupyter.org/github'
             org, repo_name, ref = spec.split('/', 2)
             # NOTE: tornado unquotes query arguments too -> notebooks%2Findex.ipynb becomes notebooks/index.ipynb

--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -44,9 +44,8 @@ BinderImage.prototype.launch = function(url, token, path, pathType) {
     if (pathType === "file") {
       // trim trailing / on file paths
       path = path.replace(/(\/$)/g, "");
-      // /tree is safe because it allows redirect to files
-      // need more logic here if we support things other than notebooks
-      url = url + "/tree/" + encodeURI(path);
+      // /doc/tree is safe because it allows redirect to files
+      url = url + "/doc/tree/" + encodeURI(path);
     } else {
       // pathType === 'url'
       url = url + "/" + path;


### PR DESCRIPTION
Now that JupyterLab 3 has been out for some time, and most lab extensions have been updated to work well with that version, it might be a good time to make the switch from classic notebook to lab.

In this PR, I am changing the default redirect URL from `tree` to `doc/tree` to enable the JupyterLab "simple mode" that is the closest to the classic notebook user interface (doc).

- Obviously, it is still possible to opt out using the `urlpath` instead of a `filepath`.
- Also referencing the [poll about defaulting to JupyterLab in JupyterHub](https://discourse.jupyter.org/t/poll-should-zero-to-jupyterhub-switch-to-jupyterlab-as-the-default-user-interface/8001) on discourse.