### PR TITLE
ci: add github-token permissions for CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is the first time i see the CodeQL workflow fail if I recall correctly. I get notifications as I'm considered the "actor" of the scheduled CI job when it triggers - because i changed the file most recently.

As the JupyterHub org made the secrets.GITHUB_TOKEN readonly, we introduced failures like this one. By setting the permissions explicitly, we get things functional again.

Note that the permissions I set in this PR were not guessed, but I saw recent changes in the CodeQL repository and mirror those: https://github.com/github/codeql-action/commit/e305db89c2dc1e955b85c2834ce9248044bdfa32