### PR TITLE
Revert "build_docker_config added, enables augmentation of the build pod's docker config"

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -297,7 +297,7 @@ class BinderHub(Application):
     )
 
     push_secret = Unicode(
-        'binder-build-docker-config',
+        'binder-push-secret',
         allow_none=True,
         help="""
         A kubernetes secret object that provides credentials for pushing built images.
@@ -374,22 +374,6 @@ class BinderHub(Application):
         if parts.scheme != 'unix' or parts.netloc != '':
             raise TraitError("Only unix domain sockets on same node are supported for build_docker_host")
         return proposal.value
-
-    build_docker_config = Dict(
-        None,
-        allow_none=True,
-        help="""
-        A dict which will be merged into the .docker/config.json of the build container (repo2docker)
-        Here, you could for example pass proxy settings as described here:
-        https://docs.docker.com/network/proxy/#configure-the-docker-client
-
-        Note: if you provide your own push_secret, this values wont
-        have an effect, as the push_secrets will overwrite
-        .docker/config.json
-        In this case, make sure that you include your config in your push_secret
-        """,
-        config=True
-    )
 
     hub_api_token = Unicode(
         help="""API token for talking to the JupyterHub API""",
@@ -709,7 +693,6 @@ class BinderHub(Application):
                 "build_memory_limit": self.build_memory_limit,
                 "build_memory_request": self.build_memory_request,
                 "build_docker_host": self.build_docker_host,
-                "build_docker_config": self.build_docker_config,
                 "base_url": self.base_url,
                 "badge_base_url": self.badge_base_url,
                 "static_path": os.path.join(HERE, "static"),

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -248,9 +248,9 @@ class Build:
         )]
 
         if self.push_secret:
-            volume_mounts.append(client.V1VolumeMount(mount_path="/root/.docker", name='docker-config'))
+            volume_mounts.append(client.V1VolumeMount(mount_path="/root/.docker", name='docker-push-secret'))
             volumes.append(client.V1Volume(
-                name='docker-config',
+                name='docker-push-secret',
                 secret=client.V1SecretVolumeSource(secret_name=self.push_secret)
             ))
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -351,7 +351,7 @@ class BuildHandler(BaseHandler):
         # Prepare to build
         q = Queue()
 
-        if self.settings['use_registry'] or self.settings['build_docker_config']:
+        if self.settings['use_registry']:
             push_secret = self.settings['push_secret']
         else:
             push_secret = None

--- a/helm-chart/binderhub/templates/_helpers.tpl
+++ b/helm-chart/binderhub/templates/_helpers.tpl
@@ -16,9 +16,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Render docker config.json for the registry-publishing secret and other docker configuration.
+Render docker config.json for the registry-publishing secret.
 */}}
-{{- define "buildDockerConfig" -}}
+{{- define "registryDockerConfig" -}}
 
 {{- /* default auth url */ -}}
 {{- $url := (default "https://index.docker.io/v1" .Values.registry.url) }}
@@ -36,13 +36,11 @@ Render docker config.json for the registry-publishing secret and other docker co
 {{- end }}
 {{- $username := .Values.registry.username -}}
 
-{{- /* initialize a dict to represent a docker config with registry credentials */}}
-{{- $dockerConfig := dict "auths" (dict $url (dict "auth" (printf "%s:%s" $username .Values.registry.password | b64enc))) }}
-
-{{- /* augment our initialized docker config with buildDockerConfig */}}
-{{- if .Values.config.BinderHub.buildDockerConfig }}
-{{- $dockerConfig := merge $dockerConfig .Values.config.BinderHub.buildDockerConfig }}
-{{- end }}
-
-{{- $dockerConfig | toPrettyJson }}
+{
+  "auths": {
+    "{{ $url }}": {
+      "auth": "{{ printf "%s:%s" $username .Values.registry.password | b64enc }}"
+    }
+  }
+}
 {{- end }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -16,12 +16,12 @@ data:
   {{- end }}
   values.yaml: {{ $values | toYaml | b64enc | quote }}
 ---
-{{- if or .Values.config.BinderHub.use_registry .Values.config.BinderHub.buildDockerConfig }}
+{{- if .Values.config.BinderHub.use_registry }}
 kind: Secret
 apiVersion: v1
 metadata:
-  name: binder-build-docker-config
+  name: binder-push-secret
 type: Opaque
 data:
-  config.json: {{ include "buildDockerConfig" . | b64enc | quote }}
+  config.json: {{ include "registryDockerConfig" . | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
This proposes to revert jupyterhub/binderhub#1255. When we deployed this to mybinder.org today we ended up with all(?) build pods getting stuck in a pending state for about two hours. At which point we reverted the deploy.

<img width="1285" alt="Screenshot 2021-05-03 at 17 05 26" src="https://user-images.githubusercontent.com/1448859/116893912-c9908a00-ac31-11eb-89e2-ceca96823bd2.png">

The marker just before 15:30h is the deploy. The blue shaded graph shows the number of "running" build requests ("running" includes "container creating"). At 17:00h I deleted all build pods and reverted the deploy.

The summary of the original PR says that there is no breaking change and that maybe for a brief moment new build pods would be using the wrong secret/a secret that doesn't exist. Does someone involved in the PR have an idea what happened/went wrong when deploying this?