### PR TITLE
Add container lifecycle hooks support to chart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,13 @@ continue.
    (cd helm-chart && chartpress)
    ```
 
+1. Get the chart dependencies (for example JupyterHub)
+
+   ```bash
+   cd helm-chart/binderhub
+   helm dependency update
+   ```
+
 1. Validate, and then install the Helm chart defined in helm-chart/binderhub.
 
    This validation step is not making any modification to your Kubernetes
@@ -208,6 +215,8 @@ continue.
    ```
 
    If the validation succeeds, go ahead and upgrade/install the Helm chart.
+
+   Note that this will do the installation in the current namespace.
 
    ```bash
    helm upgrade --install binderhub-test helm-chart/binderhub \

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
         args:
           - --config
           - /etc/binderhub/config/binderhub_config.py
+        {{- with .Values.lifecycle }}
+        lifecycle:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /etc/binderhub/config/
             name: config

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -211,6 +211,7 @@ ingress:
     #     - chart-example.local
 
 initContainers: []
+lifecycle: {}
 extraVolumes: []
 extraVolumeMounts: []
 extraEnv: []


### PR DESCRIPTION
This merge request implements support for adding lifecycle hooks to the binder container.

One of the main use case here is to be able to add one (or more) custom CA to the system without having to rebuild the base image.

The combination of extraVolumes, extraVolumesMounts and lifecyle allows to do that in a simple manner.