### PR TITLE
Add config options to dind.deamonset: lifecycle, extraVolumes, extraVolumeMounts

### DIFF
--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -51,6 +51,10 @@ spec:
           mountPath: /var/lib/docker
         - name: rundind
           mountPath: {{ .Values.dind.hostSocketDir }}
+        {{- with .Values.dind.daemonset.extraVolumeMounts }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
+        {{- with .Values.dind.daemonset.lifecycle }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: dockerlib-dind
@@ -61,4 +65,7 @@ spec:
         hostPath:
           path: {{ .Values.dind.hostSocketDir }}
           type: DirectoryOrCreate
+      {{- with .Values.dind.daemonset.extraVolumes }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -55,6 +55,9 @@ spec:
         {{- . | toYaml | nindent 8 }}
         {{- end }}
         {{- with .Values.dind.daemonset.lifecycle }}
+        lifecycle:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: dockerlib-dind

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -166,6 +166,7 @@ dind:
       tag: 19.03.5-dind
     # Additional command line arguments to pass to dockerd
     extraArgs: []
+    lifecycle: {}
     extraVolumes: []
     extraVolumeMounts: []
   storageDriver: overlay2

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -166,6 +166,8 @@ dind:
       tag: 19.03.5-dind
     # Additional command line arguments to pass to dockerd
     extraArgs: []
+    extraVolumes: []
+    extraVolumeMounts: []
   storageDriver: overlay2
   resources: {}
   hostSocketDir: /var/run/dind


### PR DESCRIPTION
This is a followup merge request of #1301 that implements extra volumes, volumesMount and lifecycle hooks for the dind daemonset.

This will allow to install for example a custom CA and avoid using the insecure-registry docker daemon option when connecting to a registry that is behind a certificate signed by said custom CA.