### PR TITLE
Bump to JupyterHub 1.0.1

### DIFF
--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "1.0.0-beta.1"
+    version: "1.0.1"
     repository: "https://jupyterhub.github.io/helm-chart"

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
   - name: jupyterhub
-    version: "0.11.1"
+    version: "1.0.0-beta.1"
     repository: "https://jupyterhub.github.io/helm-chart"


### PR DESCRIPTION
I wanted to see what the tests concluded by bumping to z2jh 1.0.0-beta.1. I've already tested a bit manually all the way to mybinder.org-deploy and it looks promising.

JupyterHub 1.0.0 and 1.0.1 have been live for a while now without much hurdles. 1.0.1 relaxed some JSON schema specifications etc.