### PR TITLE
add build token, apply rate limit by request ip

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -7,6 +7,8 @@ import json
 import logging
 import os
 import re
+import secrets
+from binascii import a2b_hex
 from concurrent.futures import ThreadPoolExecutor
 from glob import glob
 from urllib.parse import urlparse
@@ -23,6 +25,7 @@ from tornado.log import app_log
 import tornado.web
 from traitlets import (
     Bool,
+    Bytes,
     Dict,
     Integer,
     TraitError,
@@ -43,6 +46,7 @@ from .config import ConfigHandler
 from .health import HealthHandler
 from .launcher import Launcher
 from .log import log_request
+from .ratelimit import RateLimiter
 from .repoproviders import RepoProvider
 from .registry import DockerRegistry
 from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
@@ -493,7 +497,7 @@ class BinderHub(Application):
         config=True,
         help="""The number of threads to use for blocking calls
 
-        Should generaly be a small number because we don't
+        Should generally be a small number because we don't
         care about high concurrency here, just not blocking the webserver.
         This executor is not used for long-running tasks (e.g. builds).
         """,
@@ -512,6 +516,41 @@ class BinderHub(Application):
         will be killed.
         """
     )
+
+    build_token_expires_seconds = Integer(
+        300,
+        config=True,
+        help="""Expiry (in seconds) of build tokens
+
+        These are generally only used to authenticate a single request
+        from a page, so should be short-lived.
+        """,
+    )
+    build_token_secret = Union(
+        [Unicode(), Bytes()],
+        config=True,
+        help="""Secret used to sign build tokens
+
+        Lightweight validation of same-origin requests
+        """,
+    )
+
+    @validate("build_token_secret")
+    def _validate_build_token_secret(self, proposal):
+        if isinstance(proposal.value, str):
+            # allow hex string for text-only input formats
+            return a2b_hex(proposal.value)
+        return proposal.value
+
+    @default("build_token_secret")
+    def _default_build_token_secret(self):
+        if os.environ.get("BINDERHUB_BUILD_TOKEN_SECRET"):
+            return a2b_hex(os.environ["BINDERHUB_BUILD_TOKEN_SECRET"])
+        app_log.warning(
+            "Generating random build token secret."
+            " Set BinderHub.build_token_secret to avoid this warning."
+        )
+        return secrets.token_bytes(32)
 
     # FIXME: Come up with a better name for it?
     builder_required = Bool(
@@ -691,12 +730,15 @@ class BinderHub(Application):
                 "build_image": self.build_image,
                 "build_node_selector": self.build_node_selector,
                 "build_pool": self.build_pool,
+                "build_token_secret": self.build_token_secret,
+                "build_token_expires_seconds": self.build_token_expires_seconds,
                 "sticky_builds": self.sticky_builds,
                 "log_tail_lines": self.log_tail_lines,
                 "pod_quota": self.pod_quota,
                 "per_repo_quota": self.per_repo_quota,
                 "per_repo_quota_higher": self.per_repo_quota_higher,
                 "repo_providers": self.repo_providers,
+                "rate_limiter": RateLimiter(parent=self),
                 "use_registry": self.use_registry,
                 "registry": registry,
                 "traitlets_config": self.config,

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -1,6 +1,6 @@
 {
     "$id": "binderhub.jupyter.org/launch",
-    "version": 4,
+    "version": 5,
     "title": "BinderHub Launch Events",
     "description": "BinderHub emits this event whenever a new repo is launched",
     "type": "object",
@@ -29,6 +29,10 @@
         "status": {
             "enum": ["success", "failure"],
             "description": "Success/Failure of the launch"
+        },
+        "build_token": {
+            "type": "boolean",
+            "description": "Whether a build token was used for the launch"
         },
         "origin": {
           "type": "string",

--- a/binderhub/ratelimit.py
+++ b/binderhub/ratelimit.py
@@ -1,0 +1,95 @@
+"""Rate limiting utilities"""
+
+import time
+from traitlets import Integer, Dict, Float, default
+from traitlets.config import LoggingConfigurable
+
+
+class RateLimitExceeded(Exception):
+    """Exception raised when rate limit is exceeded"""
+
+
+class RateLimiter(LoggingConfigurable):
+    """Class representing a collection of rate limits
+
+    Has one method: `.increment(key)` which should be called when
+    a given actor is attempting to consume a resource.
+    `key` can be any hashable (e.g. request ip address).
+    Each `key` has its own rate limit counter.
+
+    If the rate limit is exhausted, a RateLimitExceeded exception is raised,
+    otherwise a summary of the current rate limit remaining is returned.
+
+    Rate limits are reset to zero at the end of `period_seconds`,
+    not a sliding window,
+    so the entire rate limit can be consumed instantly
+    """
+
+    period_seconds = Integer(
+        3600,
+        config=True,
+        help="""The rate limit window""",
+    )
+
+    limit = Integer(
+        10,
+        config=True,
+        help="""The number of requests to allow within period_seconds""",
+    )
+
+    clean_seconds = Integer(
+        600,
+        config=True,
+        help="""Interval on which to clean out old limits.
+
+        Avoids memory growth of unused limits
+        """,
+    )
+
+    _limits = Dict()
+
+    _last_cleaned = Float()
+
+    @default("_last_cleaned")
+    def _default_last_cleaned(self):
+        return self.time()
+
+    def _clean_limits(self):
+        now = self.time()
+        self._last_cleaned = now
+        self._limits = {
+            key: limit for key, limit in self._limits.items() if limit["reset"] > now
+        }
+
+    @staticmethod
+    def time():
+        """Mostly here to enable override in tests"""
+        return time.time()
+
+    def increment(self, key):
+        """Check rate limit for a key
+
+        key: key for recording rate limit. Each key tracks a different rate limit.
+        Returns: {"remaining": int_remaining, "reset": int_timestamp}
+        Raises: RateLimitExceeded if the request would exceed the rate limit.
+        """
+        now = int(self.time())
+        if now - self._last_cleaned > self.clean_seconds:
+            self._clean_limits()
+
+        if key not in self._limits or self._limits[key]["reset"] < now:
+            # no limit recorded, or reset expired
+            self._limits[key] = {
+                "remaining": self.limit,
+                "reset": now + self.period_seconds,
+            }
+        limit = self._limits[key]
+        # keep decrementing, so we have a track of excess requests
+        # which indicate abuse
+        limit["remaining"] -= 1
+        if limit["remaining"] <= 0:
+            seconds_until_reset = int(limit["reset"] - now)
+            raise RateLimitExceeded(
+                f"Rate limit exceeded (by {-limit['remaining']}) for {key!r}, reset in {seconds_until_reset}s."
+            )
+        return limit

--- a/binderhub/ratelimit.py
+++ b/binderhub/ratelimit.py
@@ -87,7 +87,7 @@ class RateLimiter(LoggingConfigurable):
         # keep decrementing, so we have a track of excess requests
         # which indicate abuse
         limit["remaining"] -= 1
-        if limit["remaining"] <= 0:
+        if limit["remaining"] < 0:
             seconds_until_reset = int(limit["reset"] - now)
             raise RateLimitExceeded(
                 f"Rate limit exceeded (by {-limit['remaining']}) for {key!r}, reset in {seconds_until_reset}s."

--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -1,4 +1,5 @@
 var BASE_URL = $("#base-url").data().url;
+var BUILD_TOKEN = $("#build-token").data().token;
 
 export default function BinderImage(providerSpec) {
   this.providerSpec = providerSpec;
@@ -8,6 +9,10 @@ export default function BinderImage(providerSpec) {
 
 BinderImage.prototype.fetch = function() {
   var apiUrl = BASE_URL + "build/" + this.providerSpec;
+  if (BUILD_TOKEN) {
+      apiUrl = apiUrl + `?build_token=${BUILD_TOKEN}`;
+  }
+
   this.eventSource = new EventSource(apiUrl);
   var that = this;
   this.eventSource.onerror = function(err) {

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -3,6 +3,7 @@
 {% block head %}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
+<meta id="build-token" data-token="{{ build_token }}">
 <!-- Other OG information in page.html -->
 <meta property="og:title" content="{{social_desc}}">
 <meta property="og:image" content="https://mybinder.org/static/images/logo_square.png">

--- a/binderhub/tests/test_ratelimit.py
+++ b/binderhub/tests/test_ratelimit.py
@@ -1,0 +1,81 @@
+import time
+from unittest import mock
+
+import pytest
+
+from binderhub.ratelimit import RateLimiter, RateLimitExceeded
+
+
+def test_rate_limit():
+    r = RateLimiter(limit=10, period_seconds=60)
+    assert r._limits == {}
+    now = r.time()
+    reset = int(now) + 60
+    with mock.patch.object(r, "time", lambda: now):
+        limit = r.increment("1.2.3.4")
+    assert limit == {
+        "remaining": 9,
+        "reset": reset,
+    }
+    assert r._limits == {
+        "1.2.3.4": limit,
+    }
+    for i in range(1, 9):
+        limit = r.increment("1.2.3.4")
+        assert limit == {
+            "remaining": 9 - i,
+            "reset": reset,
+        }
+
+    for i in range(5):
+        with pytest.raises(RateLimitExceeded):
+            r.increment("1.2.3.4")
+
+    assert r._limits["1.2.3.4"]["remaining"] == -4
+
+
+def test_rate_limit_expires():
+    r = RateLimiter(limit=10, period_seconds=60)
+    assert r._limits == {}
+    now = r.time()
+    reset = int(now) + 60
+
+    for i in range(5):
+        limit = r.increment("1.2.3.4")
+
+    # now expire period, should get fresh limit
+    with mock.patch.object(r, "time", lambda: now + 65):
+        limit = r.increment("1.2.3.4")
+    assert limit == {
+        "remaining": 9,
+        "reset": int(now) + 65 + 60,
+    }
+
+
+def test_rate_limit_clean():
+    r = RateLimiter(limit=10, period_seconds=60)
+    assert r._limits == {}
+    now = r.time()
+
+    limit = r.increment("1.2.3.4")
+
+    with mock.patch.object(r, "time", lambda: now + 30):
+        limit2 = r.increment("4.3.2.1")
+
+    # force clean, shouldn't expire
+    r._last_cleaned = now - r.clean_seconds
+    with mock.patch.object(r, "time", lambda: now + 35):
+        limit2 = r.increment("4.3.2.1")
+
+    assert "1.2.3.4" in r._limits
+
+    # force clean again, should expire
+    r._last_cleaned = now - r.clean_seconds
+    with mock.patch.object(r, "time", lambda: now + 65):
+        limit2 = r.increment("4.3.2.1")
+
+    assert r._last_cleaned == now + 65
+    assert "1.2.3.4" not in r._limits
+    assert "4.3.2.1" in r._limits
+    # 4.3.2.1 hasn't expired, still consuming rate limit
+    assert limit2["remaining"] == 7

--- a/binderhub/tests/test_ratelimit.py
+++ b/binderhub/tests/test_ratelimit.py
@@ -31,7 +31,7 @@ def test_rate_limit():
         with pytest.raises(RateLimitExceeded):
             r.increment("1.2.3.4")
 
-    assert r._limits["1.2.3.4"]["remaining"] == -4
+    assert r._limits["1.2.3.4"]["remaining"] == -5
 
 
 def test_rate_limit_expires():

--- a/binderhub/tests/test_ratelimit.py
+++ b/binderhub/tests/test_ratelimit.py
@@ -20,7 +20,7 @@ def test_rate_limit():
     assert r._limits == {
         "1.2.3.4": limit,
     }
-    for i in range(1, 9):
+    for i in range(1, 10):
         limit = r.increment("1.2.3.4")
         assert limit == {
             "remaining": 9 - i,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ prometheus_client
 python-json-logger
 tornado>=5.1
 traitlets
+pyjwt>=2


### PR DESCRIPTION
build token is a signed JWT, used to validate requests originating from our pages.

A build token is only valid for a short time, and only valid for a single build spec and request origin. The token is issued by the request for the html page served at `/v2/:spec` and added in the javascript via url param to `/build/v2/:spec?build_token=...`.

Similar to an xsrf token, but actually allows cross-site requests within the federation as long as federation members share a signing key (can be improved to only distributing public keys with RS256 for signing instead of HS256).

rate limit is calculated by remote ip address and only applied on requests made *without* a build token, i.e. via raw requests to the event stream API.

Default rate limit is 10 per hour.

Most abuse occurs via floods of requests to the api from single ips, but we don't want to limit traffic from e.g. a single-room workshop as aggressively, which might also originate from a single IP. Hence the need to distinguish 'regular human' page requests from API requests or cross-origin requests.

This is *not* a robust security measure, as dedicated abuser can still request valid build tokens (I won't say how, but it's not hard). Indeed, it's *less* robust than a standard XSRF token approach, but those prohibit the way our federation works, hence the jwt. xsrf is also trivially circumventable by scripts, it only protects against malicious websites visited by valid users (not a problem we have, I believe). But at least it's more tedious, and they'll need to keep requesting tokens as they are only valid for one spec at a time.

If we find that these requests are still getting abused, we can use a similar rate limit mechanism to put a captcha in front of the request for the build token itself if we start seeing lots of traffic from an ip. Properly implemented, that should be a genuinely robust marker for requests by humans, which is what we are really after.

I added a boolean `build_token` field to the event schema, so we'll be able to see how many builds are issues with a token vs without, as a proxy measure for whether it's via the API or a regular browser request.