### PR TITLE
unpin autodoc-traits

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -9,7 +9,7 @@
 # environment, which it is on ReadTheDocs.
 
 # Documentation specific packages
-https://github.com/jupyterhub/autodoc-traits/archive/75885ee24636efbfebfceed1043459715049cd84.zip
+https://github.com/jupyterhub/autodoc-traits/archive/HEAD.zip
 myst-parser
 pydata-sphinx-theme
 sphinx-copybutton


### PR DESCRIPTION
we don't pin any other doc dependencies, and the bug preventing build has already been fixed

closes #1308 