### PR TITLE
Normalise the value of Host and Origin headers

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -99,9 +99,7 @@ class ParameterizedMainHandler(BaseHandler):
             {
                 "exp": int(time.time()) + self.settings["build_token_expires_seconds"],
                 "aud": provider_spec,
-                "origin": self.request.headers.get(
-                    "origin", self.request.headers.get("host", "")
-                ),
+                "origin": self.token_origin(),
             },
             key=self.settings["build_token_secret"],
             algorithm="HS256",


### PR DESCRIPTION
A follow up to #1309 

The origin header can contain the scheme (eg `https://mybinder.org`) and not just `hostname:port` like the host header.

Noticed this when looking at the requests sent to launch `binder-examples/requirements`. I directly visited `https://mybinder.org/v2/gh/binder-examples/requirements/HEAD` which sends only a `Host` header with value `mybinder.org`. I think with #1309 the response from this request would contain the build token (with a origin of `mybinder.org`).

Next `https://mybinder.org/build/gh/binder-examples/requirements/HEAD` is fetched which also only has a `host: mybinder.org` header. It returns a status 307 pointing to `https://ovh.mybinder.org/build/gh/binder-examples/requirements/HEAD`. The request to this URL contains a `Host: ovh.mybinder.org` and `Origin: https://mybinder.org` header.

We give preference to the origin header, but because that contains the scheme we end up with a build token that has `mybinder.org` in it and a origin of `https://mybinder.org`. In this PR I add a bit of code that parses the origin and returns the `netloc` (hostname + port) which should be in the same format as the `Host` header.