### PR TITLE
Make build class configurable

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -31,6 +31,7 @@ from traitlets import (
     TraitError,
     Unicode,
     Union,
+    Type,
     default,
     observe,
     validate,
@@ -245,6 +246,16 @@ class BinderHub(Application):
 
         Set to false to use only local docker images. Useful when running
         in a single node.
+        """,
+        config=True
+    )
+
+    build_class = Type(
+        Build,
+        help="""
+        The class used to build repo2docker images.
+        
+        Must inherit from binderhub.build.Build
         """,
         config=True
     )
@@ -740,6 +751,7 @@ class BinderHub(Application):
                 "repo_providers": self.repo_providers,
                 "rate_limiter": RateLimiter(parent=self),
                 "use_registry": self.use_registry,
+                "build_class": self.build_class,
                 "registry": registry,
                 "traitlets_config": self.config,
                 "google_analytics_code": self.google_analytics_code,

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -21,7 +21,6 @@ from tornado.log import app_log
 from prometheus_client import Counter, Histogram, Gauge
 
 from .base import BaseHandler
-from .build import Build, FakeBuild
 from .utils import KUBE_REQUEST_TIMEOUT
 
 # Separate buckets for builds and launches.
@@ -368,7 +367,7 @@ class BuildHandler(BaseHandler):
         else:
             push_secret = None
 
-        BuildClass = FakeBuild if self.settings.get('fake_build') else Build
+        BuildClass = self.settings.get('build_class')
 
         appendix = self.settings['appendix'].format(
             binder_url=self.binder_launch_host + self.binder_request,

--- a/testing/local-binder-mocked-hub/binderhub_config.py
+++ b/testing/local-binder-mocked-hub/binderhub_config.py
@@ -7,12 +7,13 @@
 # - JupyterHub: mocked
 
 from binderhub.repoproviders import FakeProvider
+from binderhub.build import FakeBuild
 
 c.BinderHub.debug = True
 c.BinderHub.use_registry = False
 c.BinderHub.builder_required = False
 c.BinderHub.repo_providers = {'gh': FakeProvider}
-c.BinderHub.tornado_settings.update({'fake_build': True})
+c.BinderHub.build_class = FakeBuild
 
 c.BinderHub.about_message = "<blink>Hello world.</blink>"
 c.BinderHub.banner_message = 'This is headline <a href="#">news.</a>'


### PR DESCRIPTION
This will enable to replace binderhub.build.Build by a custom class.
One usecase would be to configure custom options for the repo2docker
command.

See: https://discourse.jupyter.org/t/make-target-repo-dir-configurable-in-binder/9617