### PR TITLE
Retrieve baseUrl & build token just before they are needed

### DIFF
--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -1,6 +1,3 @@
-var BASE_URL = $("#base-url").data().url;
-var BUILD_TOKEN = $("#build-token").data().token;
-
 export default function BinderImage(providerSpec) {
   this.providerSpec = providerSpec;
   this.callbacks = {};
@@ -8,9 +5,11 @@ export default function BinderImage(providerSpec) {
 }
 
 BinderImage.prototype.fetch = function() {
-  var apiUrl = BASE_URL + "build/" + this.providerSpec;
-  if (BUILD_TOKEN) {
-      apiUrl = apiUrl + `?build_token=${BUILD_TOKEN}`;
+  var baseUrl = $("#base-url").data('url');
+  var apiUrl = baseUrl + "build/" + this.providerSpec;
+  var buildToken = $("#build-token").data('token');
+  if (buildToken) {
+      apiUrl = apiUrl + `?build_token=${buildToken}`;
   }
 
   this.eventSource = new EventSource(apiUrl);


### PR DESCRIPTION
The bundle is included in the <head>, so code in top level
might be executed before the DOM is loaded. I think this was
happening, causing errors of form `$(...).data() is undefined`.

Since they are used in only one place, we instead retrieve just
before they are used. The `indexMain` entrypoint is called from
the footer, so this code will execute after the DOM has
loaded.

We can also pass parameter name to `.data()`, which will return
undefined if it doesn't exist in the element. Easier than checking
if the output of `.data()` is undefined.