### PR TITLE
Add required 'labels' property to FakeProvider

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -188,6 +188,12 @@ class RepoProvider(LoggingConfigurable):
 class FakeProvider(RepoProvider):
     """Fake provider for local testing of the UI
     """
+    labels = {
+        "text": "Fake Provider",
+        "tag_text": "Fake Ref",
+        "ref_prop_disabled": True,
+        "label_prop_disabled": True,
+    }
 
     async def get_resolved_ref(self):
         return "1a2b3c4d5e6f"


### PR DESCRIPTION
Without this, following `CONTRIBUTING.md` for setup
without a kubernetes cluster fails with the following
error message:

```
  File "/Users/yuvipanda/code/binderhub/binderhub/templates/index.html", line 42, in block 'form'
    <label for="repository">{{(repo_providers.values() | list | first).labels.text}}</label>
  File "/Users/yuvipanda/.local/share/virtualenvs/binderhub/lib/python3.9/site-packages/jinja2/environment.py", line 474, in getattr
    return getattr(obj, attribute)
jinja2.exceptions.UndefinedError: 'traitlets.traitlets.MetaHasTraits object' has no attribute 'labels'
```