### PR TITLE
Allow running dev setup without kubernetes

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -333,9 +333,6 @@ class BuildHandler(BaseHandler):
             else:
                 image_found = True
 
-        # Launch a notebook server if the image already is built
-        kube = self.settings['kubernetes_client']
-
         if image_found:
             await self.emit({
                 'phase': 'built',
@@ -343,7 +340,7 @@ class BuildHandler(BaseHandler):
                 'message': 'Found built image, launching...\n'
             })
             with LAUNCHES_INPROGRESS.track_inprogress():
-                await self.launch(kube, provider)
+                await self.launch(provider)
             self.event_log.emit(
                 "binderhub.jupyter.org/launch",
                 5,
@@ -379,7 +376,8 @@ class BuildHandler(BaseHandler):
 
         self.build = build = BuildClass(
             q=q,
-            api=kube,
+            # api object can be None if we are using FakeBuild
+            api=self.settings.get("kubernetes_client"),
             name=build_name,
             namespace=self.settings["build_namespace"],
             repo_url=repo_url,
@@ -458,7 +456,7 @@ class BuildHandler(BaseHandler):
             BUILD_TIME.labels(status='success').observe(time.perf_counter() - build_starttime)
             BUILD_COUNT.labels(status='success', **self.repo_metric_labels).inc()
             with LAUNCHES_INPROGRESS.track_inprogress():
-                await self.launch(kube, provider)
+                await self.launch(provider)
             self.event_log.emit(
                 "binderhub.jupyter.org/launch",
                 5,
@@ -484,7 +482,7 @@ class BuildHandler(BaseHandler):
         # well-behaved clients will close connections after they receive the launch event.
         await gen.sleep(60)
 
-    async def launch(self, kube, provider):
+    async def launch(self, provider):
         """Ask JupyterHub to launch the image."""
         # Load the spec-specific configuration if it has been overridden
         repo_config = provider.repo_config(self.settings)
@@ -494,45 +492,46 @@ class BuildHandler(BaseHandler):
         # if we added annotations/labels with the repo name via KubeSpawner
         # we could do this better
         image_no_tag = self.image_name.rsplit(':', 1)[0]
-        matching_pods = 0
-        total_pods = 0
-
-        # TODO: run a watch to keep this up to date in the background
-        pool = self.settings['executor']
-        f = pool.submit(
-            kube.list_namespaced_pod,
-            self.settings["build_namespace"],
-            label_selector='app=jupyterhub,component=singleuser-server',
-            _request_timeout=KUBE_REQUEST_TIMEOUT,
-            _preload_content=False,
-        )
-        resp = await asyncio.wrap_future(f)
-        pods = json.loads(resp.read())
-        for pod in pods["items"]:
-            total_pods += 1
-            for container in pod["spec"]["containers"]:
-                # is the container running the same image as us?
-                # if so, count one for the current repo.
-                image = container["image"].rsplit(":", 1)[0]
-                if image == image_no_tag:
-                    matching_pods += 1
-                    break
 
         # TODO: put busy users in a queue rather than fail?
         # That would be hard to do without in-memory state.
         quota = repo_config.get('quota')
-        if quota and matching_pods >= quota:
-            app_log.error("%s has exceeded quota: %s/%s (%s total)",
-                self.repo_url, matching_pods, quota, total_pods)
-            await self.fail("Too many users running %s! Try again soon." % self.repo_url)
-            return
+        if quota:
+            # Fetch info on currently running users *only* if quotas are set
+            matching_pods = 0
+            total_pods = 0
 
-        if quota and matching_pods >= 0.5 * quota:
-            log = app_log.warning
-        else:
-            log = app_log.info
-        log("Launching pod for %s: %s other pods running this repo (%s total)",
-            self.repo_url, matching_pods, total_pods)
+            # TODO: run a watch to keep this up to date in the background
+            f = self.settings['executor'].submit(
+                self.settings['kubernetes_client'].list_namespaced_pod,
+                self.settings['build_namespace'],
+                label_selector='app=jupyterhub,component=singleuser-server',
+                _request_timeout=KUBE_REQUEST_TIMEOUT,
+                _preload_content=False,
+            )
+            resp = await asyncio.wrap_future(f)
+            pods = json.loads(resp.read())
+            for pod in pods["items"]:
+                total_pods += 1
+                for container in pod["spec"]["containers"]:
+                    # is the container running the same image as us?
+                    # if so, count one for the current repo.
+                    image = container["image"].rsplit(":", 1)[0]
+                    if image == image_no_tag:
+                        matching_pods += 1
+                        break
+            if matching_pods >= quota:
+                app_log.error("%s has exceeded quota: %s/%s (%s total)",
+                    self.repo_url, matching_pods, quota, total_pods)
+                await self.fail("Too many users running %s! Try again soon." % self.repo_url)
+                return
+
+            if matching_pods >= 0.5 * quota:
+                log = app_log.warning
+            else:
+                log = app_log.info
+            log("Launching pod for %s: %s other pods running this repo (%s total)",
+                self.repo_url, matching_pods, total_pods)
 
         await self.emit({
             'phase': 'launching',


### PR DESCRIPTION
- Talk to kubernetes to get list of running user pods only
  if quotas are set. This saves a network call, and allows
  running locally without a kubernetes setup (for frontend dev).
  This does meean we lose the log value of number of other
  pods currently running a given repo, though.
- Optionally make `kube` parameter to `Build` `None` - this works
  fine for FakeClient. We should abstract this out better so
  `Build` is abstract and `KubeBuild` is kubernetes specific, but
  that can come later