### PR TITLE
more debug information when build token origin mismatches

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -517,6 +517,15 @@ class BinderHub(Application):
         """
     )
 
+    build_token_check_origin = Bool(
+        True,
+        config=True,
+        help="""Whether to validate build token origin.
+
+        False disables the origin check.
+        """
+    )
+
     build_token_expires_seconds = Integer(
         300,
         config=True,
@@ -526,6 +535,7 @@ class BinderHub(Application):
         from a page, so should be short-lived.
         """,
     )
+
     build_token_secret = Union(
         [Unicode(), Bytes()],
         config=True,
@@ -730,6 +740,7 @@ class BinderHub(Application):
                 "build_image": self.build_image,
                 "build_node_selector": self.build_node_selector,
                 "build_pool": self.build_pool,
+                "build_token_check_origin": self.build_token_check_origin,
                 "build_token_secret": self.build_token_secret,
                 "build_token_expires_seconds": self.build_token_expires_seconds,
                 "sticky_builds": self.sticky_builds,

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -88,8 +88,12 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
 
         origin = self.token_origin()
         if decoded["origin"] != origin:
-            app_log.error(f"Rejecting build token from mismatched origin {decoded}")
-            raise web.HTTPError(403, "Invalid build token")
+            app_log.error(
+                f"Build token from mismatched origin != {origin}: {decoded};"
+                f" Host={self.request.headers.get('host')}, Origin={self.request.headers.get('origin')}"
+            )
+            if self.settings["build_token_check_origin"]:
+                raise web.HTTPError(403, "Invalid build token")
         app_log.debug(f"Accepting build token for {provider_spec}")
         self._have_build_token = True
         return decoded


### PR DESCRIPTION
and add opt-out config for checking origin, so we can demote these to warnings while we figure it out

This will help debug issues with build tokens when the origin check fails