### PR TITLE
typo in build token attribute

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -352,7 +352,7 @@ class BuildHandler(BaseHandler):
                     "spec": spec,
                     "ref": ref,
                     "status": "success",
-                    "build_token": self._has_build_token,
+                    "build_token": self._have_build_token,
                     "origin": self.settings["normalized_origin"]
                     if self.settings["normalized_origin"]
                     else self.request.host,
@@ -467,7 +467,7 @@ class BuildHandler(BaseHandler):
                     "spec": spec,
                     "ref": ref,
                     "status": "success",
-                    "build_token": self._has_build_token,
+                    "build_token": self._have_build_token,
                     "origin": self.settings["normalized_origin"]
                     if self.settings["normalized_origin"]
                     else self.request.host,


### PR DESCRIPTION
it's have, not has

This typo prevents publishing events at the end of build. It doesn't get detected because these are emitted after the event stream is finished.