### PR TITLE
Bump Chart.yaml apiVersion (embeds requirements.yaml content into Chart.yaml)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,7 +365,7 @@ These are tasks that BinderHub maintainers perform.
 
 The BinderHub Helm chart depends on the [JupyterHub Helm
 chart](https://jupyterhub.github.io/helm-chart/), and its version is pinned
-within `helm-chart/binderhub/requirements.yaml`. It is straightforward to update
+within `helm-chart/binderhub/Chart.yaml`. It is straightforward to update
 it with another version from the [JupyterHub Helm chart
 repository](https://jupyterhub.github.io/helm-chart/).
 

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -55,8 +55,7 @@ The BinderHub serving mybinder.org is deployed as a dependency of a local chart 
       hub:
         ...
 
-Such kinds of "nested" chart dependencies are managed by a special file called ``requirements.yaml``.
-More info on using such a file can be found in the `related Helm docs <https://helm.sh/docs/developing_charts/#managing-dependencies-with-requirements-yaml>`_.
+Such kinds of "nested" chart dependencies are managed via the dependencies field in ``Chart.yaml``.
 
 Ok so now that we've ascertained that indentation errors are the most likely cause of undesirable behaviour, how can we prevent them?
 

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -2,7 +2,15 @@
 apiVersion: v2
 name: binderhub
 version: 0.2.0-set.by.chartpress
-description: A Helm chart to install BinderHub
+dependencies:
+  # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
+  - name: jupyterhub
+    version: "1.0.1"
+    repository: "https://jupyterhub.github.io/helm-chart"
+description: |-
+  BinderHub is like a JupyterHub that automatically builds environments for the
+  users based on repo2docker. A BinderHub is by default not configured to
+  authenticate users or provide storage for them.
 keywords: [jupyter, jupyterhub, binderhub]
 home: https://binderhub.readthedocs.io/en/latest/
 sources: [https://github.com/jupyterhub/binderhub]

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -1,4 +1,17 @@
-apiVersion: v1
-description: A helm chart to install Binder
+# Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
+apiVersion: v2
 name: binderhub
-version: 0.2.0
+version: 0.2.0-set.by.chartpress
+description: A Helm chart to install BinderHub
+keywords: [jupyter, jupyterhub, binderhub]
+home: https://binderhub.readthedocs.io/en/latest/
+sources: [https://github.com/jupyterhub/binderhub]
+icon: https://jupyter.org/assets/hublogo.svg
+kubeVersion: ">=1.17.0-0"
+maintainers:
+  # Since it is a requirement of Artifact Hub to have specific maintainers
+  # listed, we have added some below, but in practice the entire JupyterHub team
+  # contributes to the maintenance of this Helm chart. Please go ahead and add
+  # yourself!
+  - name: Erik Sundell
+    email: erik@sundellopensource.se

--- a/helm-chart/binderhub/requirements.yaml
+++ b/helm-chart/binderhub/requirements.yaml
@@ -1,5 +1,0 @@
-dependencies:
-  # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
-  - name: jupyterhub
-    version: "1.0.1"
-    repository: "https://jupyterhub.github.io/helm-chart"

--- a/testing/local-binder-k8s-hub/install-jupyterhub-chart
+++ b/testing/local-binder-k8s-hub/install-jupyterhub-chart
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Makes a standalone installation of the JupyterHub Helm chart of the version
-specified in the BinderHub Helm chart requirements.yaml file, and use the
+specified in the BinderHub Helm chart's Chart.yaml file, and use the
 configuration for the JupyterHub Helm chart nested in the BinderHub helm chart's
 configuration.
 """
@@ -19,17 +19,17 @@ helm_chart = os.path.join(here, os.pardir, os.pardir, 'helm-chart')
 def _get_jupyterhub_dependency_version():
     """
     Extract JupyterHub Helm chart version from the BinderHub chart's
-    requirements.yaml
+    Chart.yaml file that lists its chart dependencies.
     """
-    requirements_yaml = os.path.join(helm_chart, 'binderhub', 'requirements.yaml')
+    chart_yaml = os.path.join(helm_chart, 'binderhub', 'Chart.yaml')
 
-    with open(requirements_yaml) as f:
-        requirements = yaml.safe_load(f)
-    for dep in requirements['dependencies']:
+    with open(chart_yaml) as f:
+        dependecies = yaml.safe_load(f)
+    for dep in dependecies['dependencies']:
         if dep['name'] == 'jupyterhub':
             return dep['version']
     else:
-        raise ValueError(f"JupyterHub as a Helm chart dependency not found in {requirements_yaml}:\n{requirements}")
+        raise ValueError(f"JupyterHub as a Helm chart dependency not found in {chart_yaml}:\n{dependecies}")
 
 
 with NamedTemporaryFile(mode="w") as tmp:


### PR DESCRIPTION
In this PR I migrate Chart.yaml's apiVersion: 1 -> 2. The purpose is just general maintenance to make life easier in the end by keeping things somewhat updated.

I'm not sure if a henchbot or similar creates PRs to mybinder.org will be influenced by this, but if it is, I think it is a concern somewhat out of scope for consideration when reviewing this PR.