### PR TITLE
Add schema.yaml for helm3 compliant chart validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,4 +80,5 @@ jobs:
         env:
           GITHUB_REPOSITORY: "${{ github.repository }}"
         run: |
+          ./tools/generate-json-schema.py
           ./ci/publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,17 @@ jobs:
             (cd helm-chart && chartpress)
             git --no-pager diff --color=always
 
+      - name: Generate values.schema.json from schema.yaml
+        if: matrix.test == 'helm'
+        run: |
+          tools/generate-json-schema.py
+
+      - name: "Helm template --validate (with lint-and-validate-values.yaml)"
+        if: matrix.test == 'helm'
+        run: |
+          helm template --validate binderhub-test helm-chart/binderhub \
+              --values tools/templates/lint-and-validate-values.yaml
+
       - name: Validate the chart against the k8s API
         if: matrix.test == 'helm'
         run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ chartpress==1.0.*
 click
 codecov
 html5lib
+jsonschema
 jupyterhub
 pytest
 pytest-asyncio

--- a/helm-chart/.gitignore
+++ b/helm-chart/.gitignore
@@ -1,3 +1,5 @@
+binderhub/values.schema.json
+
 ### macOS ###
 *.DS_Store
 .AppleDouble

--- a/helm-chart/binderhub/.helmignore
+++ b/helm-chart/binderhub/.helmignore
@@ -1,3 +1,13 @@
+# Anything within the root folder of the Helm chart, where Chart.yaml resides,
+# will be embedded into the packaged Helm chart. This is reasonable since only
+# when the templates render after the chart has been packaged and distributed,
+# will the templates logic evaluate that determines if other files were
+# referenced, such as our our files/hub/jupyterhub_config.py.
+#
+# Here are files that we intentionally ignore to avoid them being packaged,
+# because we don't want to reference them from our templates anyhow.
+schema.yaml
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -1,0 +1,523 @@
+# This schema (a jsonschema in YAML format) is used to generate
+# values.schema.json which is packaged with the Helm chart for client side
+# validation by Helm of values before template rendering.
+#
+# This schema is also used by our documentation system to build the
+# configuration reference section based on the description fields. See
+# doc/source/conf.py for that logic!
+#
+# We look to document everything we have default values for in values.yaml, but
+# we don't look to enforce the perfect validation logic within this file.
+#
+# ref: https://json-schema.org/learn/getting-started-step-by-step.html
+#
+$schema": http://json-schema.org/draft-07/schema#
+type: object
+additionalProperties: false
+required:
+  - pdb
+  - replicas
+  - resources
+  - rbac
+  - nodeSelector
+  - image
+  - registry
+  - service
+  - config
+  - extraConfig
+  - cors
+  - jupyterhub
+  - deployment
+  - dind
+  - imageCleaner
+  - ingress
+  - initContainers
+  - lifecycle
+  - extraVolumes
+  - extraVolumeMounts
+  - extraEnv
+  - podAnnotations
+properties:
+
+  pdb: &pdb-spec
+    type: object
+    additionalProperties: false
+    description: |
+      Configure a PodDisruptionBudget for this Deployment.
+
+      See [the Kubernetes
+      documentation](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
+      for more details.
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Decides if a PodDisruptionBudget is created targeting the
+          Deployment's pods.
+      maxUnavailable:
+        type: [integer, "null"]
+        description: |
+          The maximum number of pods that can be unavailable during voluntary
+          disruptions.
+      minAvailable:
+        type: [integer, "null"]
+        description: |
+          The minimum number of pods required to be available during voluntary
+          disruptions.
+
+  replicas:
+    type: integer
+    description: |
+      You can have multiple binder pods to share the workload or improve
+      availability on node failure.
+
+  resources: &resources-spec
+    type: object
+    additionalProperties: true
+    description: |
+      A k8s native specification of resources, see [the
+      documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core).
+
+  rbac:
+    type: object
+    additionalProperties: false
+    required: [enabled]
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Decides if RBAC resources are to be created and referenced by the the
+          Helm chart's workloads.
+
+  nodeSelector: &nodeSelector-spec
+    type: object
+    additionalProperties: true
+    description: |
+      An object with key value pairs representing labels. K8s Nodes are required
+      to have match all these labels for this Pod to scheduled on them.
+
+      ```yaml
+      disktype: ssd
+      nodetype: awesome
+      ```
+
+      See [the Kubernetes
+      documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+      for more details.
+
+  image: &image-spec
+    type: object
+    additionalProperties: false
+    required: [name, tag]
+    properties:
+      name:
+        type: string
+        description: |
+          The name of the image, without the tag.
+      tag:
+        type: string
+        description: |
+          The tag of the image to pull. This is the value following `:` in
+          complete image specifications.
+      pullPolicy:
+        enum: [null, "", IfNotPresent, Always, Never]
+        description: |
+          Configures the Pod's `spec.imagePullPolicy`.
+
+          See the [Kubernetes
+          docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+          for more info.
+      pullSecrets:
+        type: array
+        description: |
+          A list of references to existing Kubernetes Secrets with credentials
+          to pull the image.
+
+  registry:
+    type: object
+    additionalProperties: false
+    description: |
+      TODO
+    properties:
+      url:
+        type: [string, "null"]
+        description: |
+          TODO
+      username:
+        type: [string, "null"]
+        description: |
+          TODO
+      password:
+        type: [string, "null"]
+        description: |
+          TODO
+
+  service:
+    type: object
+    additionalProperties: false
+    description: |
+      Configuration of the Kubernetes Service resource exposing the BinderHub
+      web server.
+    properties:
+      type:
+        enum: [ClusterIP, NodePort, LoadBalancer, ExternalName]
+        description: |
+          The Kubernetes ServiceType to be used.
+
+          The default type is `ClusterIP`.
+          See the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+          to learn more about service types.
+      labels:
+        type: object
+        additionalProperties: false
+        patternProperties: &labels-and-annotations-patternProperties
+          ".*":
+            type: string
+        description: |
+          Labels to add to the binder Service.
+      annotations:
+        type: object
+        additionalProperties: false
+        patternProperties: *labels-and-annotations-patternProperties
+        description: |
+          Annotations to add to the binder Service.
+      nodePort:
+        type: [integer, "null"]
+        description: |
+          See [the Kubernetes
+          documentation](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
+          for more details about NodePorts.
+
+  config:
+    type: object
+    additionalProperties: true
+    description: |
+      BinderHub and its components are Python classes that expose its
+      configuration through
+      [_traitlets_](https://traitlets.readthedocs.io/en/stable/). With this Helm
+      chart configuration you can directly configure the Python classes through
+      _static_ YAML values. To _dynamically_ set values, you need to use
+      `extraConfig` instead.
+
+      __Example__
+
+      If you inspect documentation or some `binderhub_config.py` to contain the
+      following section:
+
+      ```python
+      c.binderhub.some_config_option = True
+      ```
+
+      Then, you would be able to represent it with this configuration like:
+
+      ```yaml
+      config:
+        BinderHub:
+          some_config_option: true
+      ```
+
+      ```{admonition} YAML limitations
+      :class: tip
+      You can't represent Python `Bytes` or `Set` objects in YAML directly.
+      ```
+
+      ```{admonition} Helm value merging
+      :class: tip
+      `helm` merges a Helm chart's default values with values passed with the
+      `--values` or `-f` flag. During merging, lists are replaced while
+      dictionaries are updated.
+      ```
+
+  extraConfig:
+    type: object
+    additionalProperties: true
+    description: |
+      Arbitrary extra python based configuration that should be in `binderhub_config.py`.
+
+      This is the *escape hatch* - if you want to configure BinderHub to do something specific
+      that is not present here as an option, you can write the raw Python to do it here.
+
+      extraConfig is a *dict*, so there can be multiple configuration snippets
+      under different names.
+      The configuration sections are run in alphabetical order.
+
+      Since this is usually a multi-line string, you want to format it using YAML's
+      [| operator](https://yaml.org/spec/1.2/spec.html#id2795688).
+
+      For example:
+        ```yaml
+        extraConfig:
+          my_binderhub_config.py: |
+            c.BinderHub.something = 'something'
+        ```
+
+      No validation of this python is performed! If you make a mistake here, it will probably
+      manifest as either the binder pod going into `Error` or `CrashLoopBackoff` states, or in
+      some special cases, the binder pod running but... just doing very random things. Be careful!
+
+  cors: &cors-spec
+    type: object
+    additionalProperties: false
+    description: |
+      TODO
+    properties:
+      allowOrigin:
+        type: [string, "null"]
+        description: |
+          TODO
+
+  jupyterhub:
+    type: object
+    additionalProperties: true
+    description: |
+      Configuration for the JupyterHub Helm chart that is a dependency of the
+      BinderHub Helm chart.
+    properties:
+      custom:
+        type: object
+        additionalProperties: true
+        properties:
+          cors: *cors-spec
+          binderauth_enabled:
+            type: boolean
+            description: |
+              TODO
+      binder:
+        type: object
+        additionalProperties: true
+        properties:
+          apiToken:
+            type: [string, "null"]
+            description: |
+              TODO
+
+  deployment:
+    type: object
+    additionalProperties: false
+    properties:
+      readinessProbe: &probe-spec
+        type: object
+        additionalProperties: true
+        description: |
+          This config option is exactly like the k8s native specification of a
+          container probe, except that it also supports an `enabled` boolean
+          flag.
+
+          See [the k8s
+          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#probe-v1-core)
+          for more details.
+        required: [enabled]
+        properties:
+          enabled:
+            type: [boolean]
+      livenessProbe: *probe-spec
+      labels:
+        type: object
+        additionalProperties: false
+        patternProperties: *labels-and-annotations-patternProperties
+        description: |
+          Extra labels to add to the binder pod.
+
+          See the [Kubernetes docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+          to learn more about labels.
+
+  dind:
+    type: object
+    additionalProperties: false
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          TODO
+      initContainers: &initContainers-spec
+        type: array
+        description: |
+          List of additional initContainers.
+          
+          See the [Kubernetes
+          docs](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
+          for more info.
+      daemonset:
+        type: object
+        additionalProperties: false
+        properties:
+          image: *image-spec
+          extraArgs:
+            type: array
+            description: |
+              TODO
+          lifecycle: &lifecycle-spec
+            type: object
+            additionalProperties: false
+            description: |
+              A k8s native specification of lifecycle hooks on the container, see [the
+              documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#lifecycle-v1-core).
+            properties:
+              postStart:
+                type: object
+                additionalProperties: true
+              preStop:
+                type: object
+                additionalProperties: true
+          extraVolumes: &extraVolumes-spec
+            type: array
+            description: |
+              Additional volumes for the Pod. Use a k8s native syntax.
+          extraVolumeMounts: &extraVolumeMounts-spec
+            type: array
+            description: |
+              Additional volume mounts for the Container. Use a k8s native syntax.
+      storageDriver:
+        type: string
+        description: |
+          TODO
+      resources: *resources-spec
+      hostSocketDir:
+        type: string
+        description: |
+          TODO
+      hostLibDir:
+        type: string
+        description: |
+          TODO
+
+  imageCleaner:
+    type: object
+    additionalProperties: false
+    required: [enabled]
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          TODO
+      image: *image-spec
+      delay:
+        type: integer
+        description: |
+          TODO
+      imageGCThresholdType:
+        type: string
+        description: |
+          TODO
+      imageGCThresholdHigh:
+        type: integer
+        description: |
+          TODO
+      imageGCThresholdLow:
+        type: integer
+        description: |
+          TODO
+      host:
+        type: object
+        additionalProperties: false
+        required: [enabled, dockerSocket, dockerLibDir]
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              TODO
+          dockerSocket:
+            type: string
+            description: |
+              TODO
+          dockerLibDir:
+            type: string
+            description: |
+              TODO
+
+  ingress:
+    type: object
+    additionalProperties: false
+    required: [enabled]
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Enable the creation of a Kubernetes Ingress referencing incoming
+          network network traffic to the binder k8s Service.
+      https:
+        type: object
+        additionalProperties: false
+        description: |
+          TODO
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              TODO
+          type:
+            type: string
+            description: |
+              TODO
+      annotations:
+        type: object
+        additionalProperties: false
+        patternProperties: *labels-and-annotations-patternProperties
+        description: |
+          Annotations to apply to the Ingress resource.
+
+          See [the Kubernetes
+          documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+          for more details about annotations.
+      hosts:
+        type: array
+        description: |
+          List of hosts to route requests to the proxy.
+      pathSuffix:
+        type: [string, "null"]
+        description: |
+          Suffix added to Ingress's routing path pattern.
+
+          Specify `*` if your ingress matches path by glob pattern.
+      tls:
+        type: array
+        description: |
+          TLS configurations for Ingress.
+
+          See [the Kubernetes
+          documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
+          for more details about annotations.
+
+  initContainers: *initContainers-spec
+  lifecycle: *lifecycle-spec
+  extraVolumes: *extraVolumes-spec
+  extraVolumeMounts: *extraVolumeMounts-spec
+  extraEnv:
+    type: [object, array]
+    additionalProperties: true
+    description: |
+      Environment variables to add to the binder pods.
+
+      String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
+      is a part of Kubernetes.
+
+      ```yaml
+      extraEnv:
+        # basic notation (for literal values only)
+        MY_ENV_VARS_NAME1: "my env var value 1"
+
+        # explicit notation (the "name" field takes precedence)
+        CHP_NAMESPACE:
+          name: CHP_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
+        # implicit notation (the "name" field is implied)
+        PREFIXED_CHP_NAMESPACE:
+          value: "my-prefix-$(CHP_NAMESPACE)"
+        SECRET_VALUE:
+          valueFrom:
+            secretKeyRef:
+              name: my-k8s-secret
+              key: password
+      ```
+
+      For more information, see the [Kubernetes EnvVar
+      specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+  podAnnotations:
+    type: object
+    additionalProperties: false
+    patternProperties: *labels-and-annotations-patternProperties
+    description: |
+      Annotations to add to the binder Pods.

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -286,17 +286,14 @@ properties:
       hub:
         type: object
         additionalProperties: true
-        required: [services]
         properties:
           services:
             type: object
             additionalProperties: true
-            required: [binder]
             properties:
               binder:
                 type: object
                 additionalProperties: true
-                required: [apiToken]
                 properties:
                   apiToken:
                     type: [string, "null"]
@@ -533,3 +530,24 @@ properties:
     patternProperties: *labels-and-annotations-patternProperties
     description: |
       Annotations to add to the binder Pods.
+
+  global:
+    type: object
+    additionalProperties: true
+
+  hpa:
+    type: object
+    additionalProperties: true
+    description: |
+      This is not a supported configuration yet by this Helm chart, but may be
+      in the future. This schema entry was added because
+      jupyterhub/mybinder.org-deploy configured a HorizontalPodAutoscaler
+      resource here.
+
+  networkPolicy:
+    type: object
+    additionalProperties: true
+    description: |
+      This is not a supported configuration yet by this Helm chart, but may be
+      in the future. This schema entry was added because
+      jupyterhub/mybinder.org-deploy configured a Networkpolicy resource here.

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -272,6 +272,7 @@ properties:
     description: |
       Configuration for the JupyterHub Helm chart that is a dependency of the
       BinderHub Helm chart.
+    required: [hub]
     properties:
       custom:
         type: object
@@ -282,14 +283,25 @@ properties:
             type: boolean
             description: |
               TODO
-      binder:
+      hub:
         type: object
         additionalProperties: true
+        required: [services]
         properties:
-          apiToken:
-            type: [string, "null"]
-            description: |
-              TODO
+          services:
+            type: object
+            additionalProperties: true
+            required: [binder]
+            properties:
+              binder:
+                type: object
+                additionalProperties: true
+                required: [apiToken]
+                properties:
+                  apiToken:
+                    type: [string, "null"]
+                    description: |
+                      TODO
 
   deployment:
     type: object

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -492,38 +492,9 @@ properties:
   extraVolumes: *extraVolumes-spec
   extraVolumeMounts: *extraVolumeMounts-spec
   extraEnv:
-    type: [object, array]
-    additionalProperties: true
+    type: array
     description: |
-      Environment variables to add to the binder pods.
-
-      String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
-      is a part of Kubernetes.
-
-      ```yaml
-      extraEnv:
-        # basic notation (for literal values only)
-        MY_ENV_VARS_NAME1: "my env var value 1"
-
-        # explicit notation (the "name" field takes precedence)
-        CHP_NAMESPACE:
-          name: CHP_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-
-        # implicit notation (the "name" field is implied)
-        PREFIXED_CHP_NAMESPACE:
-          value: "my-prefix-$(CHP_NAMESPACE)"
-        SECRET_VALUE:
-          valueFrom:
-            secretKeyRef:
-              name: my-k8s-secret
-              key: password
-      ```
-
-      For more information, see the [Kubernetes EnvVar
-      specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+      Env to add to the binder Pods.
   podAnnotations:
     type: object
     additionalProperties: false

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -117,7 +117,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- with .Values.extraEnv }}
-        {{- include "jupyterhub.extraEnv" . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
         ports:
           - containerPort: 8585

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -24,10 +24,7 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         {{- with .Values.deployment.labels }}
-        # Because toYaml + indent is super flaky
-        {{- range $key, $value := .Values.deployment.labels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
         # This lets us autorestart when the configmap changes!
@@ -120,7 +117,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- with .Values.extraEnv }}
-        {{- . | toYaml | nindent 8 }}
+        {{- include "jupyterhub.extraEnv" . | nindent 8 }}
         {{- end }}
         ports:
           - containerPort: 8585

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -6,7 +6,7 @@ type: Opaque
 data:
   {{- $values :=  dict "config" dict }}
   {{- $cfg := .Values.config }}
-  binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | b64enc | quote }}
+  binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | required "jupyterhub.hub.services.binder.apiToken must be explicitly set!" | b64enc | quote }}
   {{- /* every 'pick' here should be matched with a corresponding 'omit' in secret.yaml */ -}}
   {{- if $cfg.GitHubRepoProvider }}
   {{- $_ := set $values.config "GitHubRepoProvider" (pick $cfg.GitHubRepoProvider "client_id" "client_secret" "access_token") }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -216,5 +216,5 @@ initContainers: []
 lifecycle: {}
 extraVolumes: []
 extraVolumeMounts: []
-extraEnv: {}
+extraEnv: []
 podAnnotations: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -179,7 +179,6 @@ imageCleaner:
   image:
     name: jupyterhub/k8s-image-cleaner
     tag: 'local'
-    repository: jupyterhub/k8s-image-cleaner
   # delete an image at most every 5 seconds
   delay: 5
   # Interpret threshold values as percentage or bytes

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -216,5 +216,5 @@ initContainers: []
 lifecycle: {}
 extraVolumes: []
 extraVolumeMounts: []
-extraEnv: []
+extraEnv: {}
 podAnnotations: {}

--- a/tools/generate-json-schema.py
+++ b/tools/generate-json-schema.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+This script reads schema.yaml and generates a values.schema.json that we can
+package with the Helm chart, allowing helm the CLI to perform validation.
+
+While we can directly generate a values.schema.json from schema.yaml, it
+contains a lot of description text we use to generate our configuration
+reference that isn't helpful to ship along the validation schema. Due to that,
+we trim away everything that isn't needed.
+"""
+
+import json
+import os
+import sys
+
+from collections.abc import MutableMapping
+
+import yaml
+
+here_dir = os.path.abspath(os.path.dirname(__file__))
+schema_yaml = os.path.join(
+    here_dir, os.pardir, "helm-chart/binderhub", "schema.yaml"
+)
+values_schema_json = os.path.join(
+    here_dir, os.pardir, "helm-chart/binderhub", "values.schema.json"
+)
+
+
+def clean_jsonschema(d, parent_key=""):
+    """
+    Modifies a dictionary representing a jsonschema in place to not contain
+    jsonschema keys not relevant for a values.schema.json file solely for use by
+    the helm CLI.
+    """
+    JSONSCHEMA_KEYS_TO_REMOVE = {"description"}
+
+    # start by cleaning up the current level
+    for k in set.intersection(JSONSCHEMA_KEYS_TO_REMOVE, set(d.keys())):
+        del d[k]
+
+    # Recursively cleanup nested levels, bypassing one level where there could
+    # be a valid Helm chart configuration named just like the jsonschema
+    # specific key to remove.
+    if "properties" in d:
+        for k, v in d["properties"].items():
+            if isinstance(v, MutableMapping):
+                clean_jsonschema(v, k)
+
+
+def run():
+    # Using these sets, we can validate further manually by printing the results
+    # of set operations.
+    with open(schema_yaml) as f:
+        schema = yaml.safe_load(f)
+
+    # Drop what isn't relevant for a values.schema.json file packaged with the
+    # Helm chart, such as the description keys only relevant for our
+    # configuration reference.
+    clean_jsonschema(schema)
+
+    # dump schema to values.schema.json
+    with open(values_schema_json, "w") as f:
+        json.dump(schema, f)
+
+    print("binderhub/values.schema.json created")
+
+
+run()

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -70,7 +70,7 @@ jupyterhub:
     services:
       binder:
         admin: true
-        apiToken:
+        apiToken: dummy-binder-secret-token
   singleuser:
     cmd: jupyter-notebook
     events: false

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -147,9 +147,8 @@ lifecycle: *lifecycle
 extraVolumes: []
 extraVolumeMounts: []
 extraEnv: &extraEnv
-  IGNORED_KEY_NAME:
-    name: MOCK_ENV_VAR_NAME1
+  - name: MOCK_ENV_VAR_NAME1
     value: MOCK_ENV_VAR_VALUE1
-  MOCK_ENV_VAR_NAME2:
+  - name: MOCK_ENV_VAR_NAME2
     value: MOCK_ENV_VAR_VALUE2
 podAnnotations: *annotations

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -1,0 +1,155 @@
+pdb:
+  enabled: true
+  maxUnavailable: 1
+  minAvailable: null
+
+replicas: 1
+
+resources: &resources
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: 200m
+    memory: 1Gi
+
+rbac:
+  enabled: true
+
+nodeSelector: &nodeSelector
+  node-type: mock
+
+image: &image
+  name: dummy-name
+  tag: dummy-tag
+  pullPolicy: Always
+  pullSecrets: [c]
+
+registry:
+  url: mock-url
+  username: mock-username
+  password: mock-password
+
+service:
+  type: ClusterIP
+  labels: &labels
+    mock-label1-key: mock-label1-value
+    mock-label2-key: mock-label2-value
+  annotations: &annotations
+    mock-annotation1-key: mock-annotation1-value
+    mock-annotation2-key: mock-annotation2-value
+  nodePort: 1234
+
+config:
+  BinderHub:
+    some_dummy_config: true
+
+extraConfig:
+  binder-test-config: |-
+    dummy binderhub python code ...
+
+cors: &cors
+  allowOrigin:
+
+jupyterhub:
+  cull:
+    enabled: true
+    users: true
+  custom:
+    cors: *cors
+    binderauth_enabled: false
+  rbac:
+    enabled: true
+  hub:
+    config:
+      JupyterHub:
+        authenticator_class: nullauthenticator.NullAuthenticator
+    extraConfig:
+      hub-test-config: |
+        dummy jupyterhub python code...
+    services:
+      binder:
+        admin: true
+        apiToken:
+  singleuser:
+    cmd: jupyter-notebook
+    events: false
+    storage:
+      type: none
+    memory:
+      guarantee:
+  prePuller:
+    hook:
+      enabled: false
+    continuous:
+      enabled: false
+
+deployment:
+  readinessProbe: &probe
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    failureThreshold: 1000
+    timeoutSeconds: 3
+  livenessProbe: *probe
+  labels: *labels
+
+dind:
+  enabled: false
+  initContainers: &initContainers
+    - name: mock-init-container-name
+      image: mock-init-container-image
+  daemonset:
+    image: *image
+    extraArgs: []
+    lifecycle: &lifecycle
+      postStart:
+        exec:
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "echo Hello from the postStart handler >> /usr/share/message"
+    extraVolumes: []
+    extraVolumeMounts: []
+  storageDriver: overlay2
+  resources: *resources
+  hostSocketDir: /var/run/dind
+  hostLibDir: /var/lib/dind
+
+imageCleaner:
+  enabled: true
+  image: *image
+  delay: 5
+  imageGCThresholdType: "relative"
+  imageGCThresholdHigh: 2
+  imageGCThresholdLow: 1
+  host:
+    enabled: true
+    dockerSocket: /var/run/docker.sock
+    dockerLibDir: /var/lib/docker
+
+ingress:
+  enabled: true
+  https:
+    enabled: false
+    type: kube-lego
+  hosts: [domain.com]
+  annotations: *annotations
+  pathSuffix: dummy-pathSuffix
+  tls:
+    - secretName: binderhub-tls
+      hosts:
+        - mocked1.domain.name
+        - mocked2.domain.name
+
+initContainers: *initContainers
+lifecycle: *lifecycle
+extraVolumes: []
+extraVolumeMounts: []
+extraEnv: &extraEnv
+  IGNORED_KEY_NAME:
+    name: MOCK_ENV_VAR_NAME1
+    value: MOCK_ENV_VAR_VALUE1
+  MOCK_ENV_VAR_NAME2:
+    value: MOCK_ENV_VAR_VALUE2
+podAnnotations: *annotations

--- a/tools/validate-against-schema.py
+++ b/tools/validate-against-schema.py
@@ -13,6 +13,9 @@ values_yaml = os.path.join(
 lint_and_validate_values_yaml = os.path.join(
     here_dir, "templates", "lint-and-validate-values.yaml"
 )
+binderhub_chart_config_yaml = os.path.join(
+    here_dir, os.pardir, "testing/k8s-binder-k8s-hub", "binderhub-chart-config.yaml"
+)
 
 with open(schema_yaml) as f:
     schema = yaml.safe_load(f)
@@ -20,6 +23,8 @@ with open(values_yaml) as f:
     values = yaml.safe_load(f)
 with open(lint_and_validate_values_yaml) as f:
     lint_and_validate_values = yaml.safe_load(f)
+with open(binderhub_chart_config_yaml) as f:
+    binderhub_chart_config_yaml = yaml.safe_load(f)
 
 # Validate values.yaml against schema
 print("Validating values.yaml against schema.yaml...")
@@ -29,5 +34,11 @@ print()
 
 # Validate lint-and-validate-values.yaml against schema
 print("Validating lint-and-validate-values.yaml against schema.yaml...")
+jsonschema.validate(lint_and_validate_values, schema)
+print("OK!")
+print()
+
+# Validate lint-and-validate-values.yaml against schema
+print("Validating binderhub-chart-config.yaml against schema.yaml...")
 jsonschema.validate(lint_and_validate_values, schema)
 print("OK!")

--- a/tools/validate-against-schema.py
+++ b/tools/validate-against-schema.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import jsonschema
+import os
+import yaml
+
+here_dir = os.path.abspath(os.path.dirname(__file__))
+schema_yaml = os.path.join(
+    here_dir, os.pardir, "helm-chart/binderhub", "schema.yaml"
+)
+values_yaml = os.path.join(
+    here_dir, os.pardir, "helm-chart/binderhub", "values.yaml"
+)
+lint_and_validate_values_yaml = os.path.join(
+    here_dir, "templates", "lint-and-validate-values.yaml"
+)
+
+with open(schema_yaml) as f:
+    schema = yaml.safe_load(f)
+with open(values_yaml) as f:
+    values = yaml.safe_load(f)
+with open(lint_and_validate_values_yaml) as f:
+    lint_and_validate_values = yaml.safe_load(f)
+
+# Validate values.yaml against schema
+print("Validating values.yaml against schema.yaml...")
+jsonschema.validate(values, schema)
+print("OK!")
+print()
+
+# Validate lint-and-validate-values.yaml against schema
+print("Validating lint-and-validate-values.yaml against schema.yaml...")
+jsonschema.validate(lint_and_validate_values, schema)
+print("OK!")


### PR DESCRIPTION
Closes #1329 by mimicing https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2033 that converts a schema.yaml file into values.schema.json before publishing and package it with the Helm chart so `helm` automatically can perform validation logic whenever `helm template`, `helm install` or `helm upgrade` is run.

My process to create the schema.yaml file was to look in values.yaml and add schema entries for everything there. I copied various schema.yaml entries from z2jh's schema.yaml file to save me some work, but a lot of descriptions is still just having a TODO note. I consider it out of scope for this PR to also write descriptions for everything in the schema.yaml. The descriptions are currently not used anyhow, but they can be used to generate a configuration reference in the future.

I've tried this schema against mybinder.org's Helm chart, adjusted the schema by adding `hpa` and `networkPolicy` to not break mybinder.org-deploy and because these configuration options may very well be upstreamed to BinderHub itself.
