### PR TITLE
helm-chart: enhance extraEnv like in z2jh with jupyterhub.extraEnv helper

### DIFF
--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -492,9 +492,38 @@ properties:
   extraVolumes: *extraVolumes-spec
   extraVolumeMounts: *extraVolumeMounts-spec
   extraEnv:
-    type: array
+    type: [object, array]
+    additionalProperties: true
     description: |
-      Env to add to the binder Pods.
+      Environment variables to add to the binder pods.
+
+      String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
+      is a part of Kubernetes.
+
+      ```yaml
+      extraEnv:
+        # basic notation (for literal values only)
+        MY_ENV_VARS_NAME1: "my env var value 1"
+
+        # explicit notation (the "name" field takes precedence)
+        CHP_NAMESPACE:
+          name: CHP_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
+        # implicit notation (the "name" field is implied)
+        PREFIXED_CHP_NAMESPACE:
+          value: "my-prefix-$(CHP_NAMESPACE)"
+        SECRET_VALUE:
+          valueFrom:
+            secretKeyRef:
+              name: my-k8s-secret
+              key: password
+      ```
+
+      For more information, see the [Kubernetes EnvVar
+      specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
   podAnnotations:
     type: object
     additionalProperties: false

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -506,15 +506,15 @@ properties:
         MY_ENV_VARS_NAME1: "my env var value 1"
 
         # explicit notation (the "name" field takes precedence)
-        CHP_NAMESPACE:
-          name: CHP_NAMESPACE
+        BINDER_NAMESPACE:
+          name: BINDER_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
 
         # implicit notation (the "name" field is implied)
-        PREFIXED_CHP_NAMESPACE:
-          value: "my-prefix-$(CHP_NAMESPACE)"
+        PREFIXED_BINDER_NAMESPACE:
+          value: "my-prefix-$(BINDER_NAMESPACE)"
         SECRET_VALUE:
           valueFrom:
             secretKeyRef:

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -117,7 +117,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- with .Values.extraEnv }}
-        {{- . | toYaml | nindent 8 }}
+        {{- include "jupyterhub.extraEnv" . | nindent 8 }}
         {{- end }}
         ports:
           - containerPort: 8585

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -216,5 +216,5 @@ initContainers: []
 lifecycle: {}
 extraVolumes: []
 extraVolumeMounts: []
-extraEnv: []
+extraEnv: {}
 podAnnotations: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -147,8 +147,9 @@ lifecycle: *lifecycle
 extraVolumes: []
 extraVolumeMounts: []
 extraEnv: &extraEnv
-  - name: MOCK_ENV_VAR_NAME1
+  IGNORED_KEY_NAME:
+    name: MOCK_ENV_VAR_NAME1
     value: MOCK_ENV_VAR_VALUE1
-  - name: MOCK_ENV_VAR_NAME2
+  MOCK_ENV_VAR_NAME2:
     value: MOCK_ENV_VAR_VALUE2
 podAnnotations: *annotations


### PR DESCRIPTION
### Feature summary

extraEnv can now not only be a list, but also an object. The implementation reuse a z2jh named template that transforms a extraEnv entry into a list to be augmented in a containers `env` specification.

Key outcomes are to:
- allow extraEnv config to be a dictionary so it can merge instead and be overridden as a list would be
- allow extraEnv in dictionary format to contain advanced env entries as well (not just `name: value`, see https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1757)
- reuse jupyterhub Helm chart logic, both in schema.yaml by copy paste and in the logic to render by reference to the named template.

### Notes about implementation

BinderHub the Helm chart depends on Z2JH. This PR reuse logic in the Z2JH Helm chart by referencing a globally accessible named Helm template defined in Z2JH. It is a named Helm template that takes either a list or mapping and emits a YAML formatted list.

To reference certain named template in Z2JH is currently an explicitly recommended practice in Z2JH ([see fullnameOverride docs](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#fullnameoverride)). If we want to refresh the BinderHub helm chart I think a relevant PR is to make BinderHub to stop referencing Z2JH resource names as hardcoded, but instead references the names in z2jh via the globally accessible named templates that evaluates to the actual name.

![image](https://user-images.githubusercontent.com/3837114/124752888-b39c8f80-df28-11eb-8c66-37ac108a395d.png)