### PR TITLE
Update DOCKER_REGISTRY_URL to the recommended one

### DIFF
--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -128,7 +128,7 @@ class DockerRegistry(LoggingConfigurable):
         url = urlparse(self.url)
         if ("." + url.hostname).endswith(".gcr.io"):
             return "https://{0}/v2/token?service={0}".format(url.hostname)
-        elif self.url.endswith(".docker.com"):
+        elif self.url.endswith(".docker.io"):
             return "https://auth.docker.io/token?service=registry.docker.io"
         else:
             # is gcr.io's token url common? If so, it might be worth defaulting

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -11,7 +11,7 @@ from tornado.httputil import url_concat
 from traitlets.config import LoggingConfigurable
 from traitlets import Dict, Unicode, default
 
-DEFAULT_DOCKER_REGISTRY_URL = "https://registry.hub.docker.com"
+DEFAULT_DOCKER_REGISTRY_URL = "https://registry-1.docker.io"
 DEFAULT_DOCKER_AUTH_URL = "https://index.docker.io/v1"
 
 

--- a/binderhub/tests/test_registry.py
+++ b/binderhub/tests/test_registry.py
@@ -12,7 +12,7 @@ from binderhub.registry import DockerRegistry
 
 def test_registry_defaults(tmpdir):
     registry = DockerRegistry(docker_config_path=str(tmpdir.join("doesntexist.json")))
-    assert registry.url == "https://registry.hub.docker.com"
+    assert registry.url == "https://registry-1.docker.io"
     assert registry.auth_config_url == "https://index.docker.io/v1"
     assert (
         registry.token_url == "https://auth.docker.io/token?service=registry.docker.io"
@@ -37,7 +37,7 @@ def test_registry_username_password(tmpdir):
     registry = DockerRegistry(docker_config_path=str(config_json))
     assert registry.username == "user"
     assert registry.password == "pass"
-    assert registry.url == "https://registry.hub.docker.com"
+    assert registry.url == "https://registry-1.docker.io"
 
 
 def test_registry_gcr_defaults(tmpdir):

--- a/doc/zero-to-binderhub/setup-binderhub.rst
+++ b/doc/zero-to-binderhub/setup-binderhub.rst
@@ -281,7 +281,7 @@ If you setup your own local registry using
           url: "https://index.docker.io/v1"
         config:
           DockerRegistry:
-            url: "https://registry.hub.docker.com" # the actual v2 registry url
+            url: "https://registry-1.docker.io" # the recommended registry URL
             auth_config_url: "https://index.docker.io/v1" # must match above!
             token_url: "https://auth.docker.io/token?service=registry.docker.io"
 


### PR DESCRIPTION
The recommended hostname ( https://github.com/docker/hub-feedback/issues/2113#issuecomment-866298153 ) for docker registry is `https://registry-1.docker.io`.

This was fixed on mybinder deployment https://github.com/jupyterhub/mybinder.org-deploy/pull/1937, updating the URL here so people depending on dockerhub in their own binderhub deployments don't hit this issue.