### PR TITLE
Add button to view raw logs during a build

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -165,7 +165,7 @@ function build(providerSpec, log, path, pathType) {
 
   image.onStateChange('*', function(oldState, newState, data) {
     if (data.message !== undefined) {
-      log.write(data.message);
+      log.writeAndStore(data.message);
       log.fit();
     } else {
       console.log(data);
@@ -225,6 +225,7 @@ function setUpLog() {
     convertEol: true,
     disableStdin: true
   });
+  var logMessages = [];
 
   log.open(document.getElementById('log'), false);
   log.fit();
@@ -235,12 +236,12 @@ function setUpLog() {
 
   var $panelBody = $("div.panel-body");
   log.show = function () {
-    $('#toggle-logs button').text('hide');
+    $('#toggle-logs button.toggle').text('hide');
     $panelBody.removeClass('hidden');
   };
 
   log.hide = function () {
-    $('#toggle-logs button').text('show');
+    $('#toggle-logs button.toggle').text('show');
     $panelBody.addClass('hidden');
   };
 
@@ -252,7 +253,20 @@ function setUpLog() {
     }
   };
 
+  $('#view-raw-logs').on('click', function(ev) {
+    const blob = new Blob([logMessages.join('')], { type: 'text/plain' });
+    this.href = window.URL.createObjectURL(blob);
+    // Prevent the toggle action from firing
+    ev.stopPropagation();
+  });
+
   $('#toggle-logs').click(log.toggle);
+
+  log.writeAndStore = function (msg) {
+    logMessages.push(msg);
+    log.write(msg);
+  }
+
   return log;
 }
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -148,7 +148,8 @@
         <div id="log-container" class="panel panel-default on-build hidden row">
           <div id="toggle-logs" class="panel-heading">
             Build logs
-            <button type="button" class="btn btn-link btn-xs pull-right">show</button>
+            <button type="button" class="btn btn-link btn-xs pull-right toggle">show</button>
+            <a id="view-raw-logs" class="btn btn-link btn-xs pull-right" target="_blank">view raw</a>
           </div>
           <div class="panel-body hidden">
             <div id="log"></div>

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -31,7 +31,8 @@
 <div id="log-container" class="panel panel-default on-build hidden row">
   <div id="toggle-logs" class="panel-heading">
     Build logs
-    <button class="btn btn-link btn-xs pull-right">show</button>
+    <button type="button" class="btn btn-link btn-xs pull-right toggle">show</button>
+    <a id="view-raw-logs" class="btn btn-link btn-xs pull-right" target="_blank">view raw</a>
   </div>
   <div class="panel-body hidden">
     <div id="log"></div>


### PR DESCRIPTION
Adds a `view raw` button to view the current build logs as plain text. Suggested by @bollwyvl in https://discourse.jupyter.org/t/binder-fails-to-compile-pygraphviz/9912/5 (at the end of the post).

This works by storing all log messages in an array, and creating a URL Blob object containing the logs when `view raw` is clicked. Note this won't update with new logs. You have to click `view logs` again.

Using `FakeBuild`:
![image](https://user-images.githubusercontent.com/1644105/125174240-c975b300-e1bb-11eb-9e52-95f611962cf4.png)

Clicking on `view raw` opens a new tab:
![image](https://user-images.githubusercontent.com/1644105/125174245-d397b180-e1bb-11eb-9dec-82021f4d5f11.png)

I've also tested this in Chrome.