### PR TITLE
Let z2jh seed jupyterhub.hub.services.binder.apiToken

### DIFF
--- a/doc/zero-to-binderhub/setup-binderhub.rst
+++ b/doc/zero-to-binderhub/setup-binderhub.rst
@@ -27,30 +27,11 @@ the container registry. For more information on getting a registry password, see
 :ref:`setup-registry`. We'll copy/paste the contents of this file in the steps
 below.
 
-Create two random tokens by running the following commands then copying the
-outputs.::
-
-    openssl rand -hex 32
-    openssl rand -hex 32
-
-.. note::
-
-   This command is run **twice** because we need two different tokens.
-
 Create ``secret.yaml`` file
 ---------------------------
 
-Create a file called ``secret.yaml`` and add the following::
-
-  jupyterhub:
-    hub:
-      services:
-        binder:
-          apiToken: "<output of FIRST `openssl rand -hex 32` command>"
-    proxy:
-      secretToken: "<output of SECOND `openssl rand -hex 32` command>"
-
-Next, we'll configure this file to connect with our registry.
+Create a file called ``secret.yaml``, we'll set sensitive values to pass to our
+Helm chart in this file.
 
 If you are using ``gcr.io``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zero-to-binderhub/setup-binderhub.rst
+++ b/doc/zero-to-binderhub/setup-binderhub.rst
@@ -48,24 +48,17 @@ need to insert. Note that the first line is not indented at all::
     # paste the content after `password: |` below
     password: |
       {
-      "type": "<REPLACE>",
-      "project_id": "<REPLACE>",
-      "private_key_id": "<REPLACE>",
-      "private_key": "<REPLACE>",
-      "client_email": "<REPLACE>",
-      "client_id": "<REPLACE>",
-      "auth_uri": "<REPLACE>",
-      "token_uri": "<REPLACE>",
-      "auth_provider_x509_cert_url": "<REPLACE>",
-      "client_x509_cert_url": "<REPLACE>"
+        "type": "<REPLACE>",
+        "project_id": "<REPLACE>",
+        "private_key_id": "<REPLACE>",
+        "private_key": "<REPLACE>",
+        "client_email": "<REPLACE>",
+        "client_id": "<REPLACE>",
+        "auth_uri": "<REPLACE>",
+        "token_uri": "<REPLACE>",
+        "auth_provider_x509_cert_url": "<REPLACE>",
+        "client_x509_cert_url": "<REPLACE>"
       }
-
-
-.. tip::
-
-   * The content you put just after ``password: |`` must all line up at the same
-     tab level.
-   * Don't forget the ``|`` after the ``password:`` label.
 
 If you are using Docker Hub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -98,8 +98,8 @@ spec:
         - name: JUPYTERHUB_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: binder-secret
-              key: "binder.hub-token"
+              name: "{{ include "jupyterhub.hub.fullname" . }}"
+              key: hub.services.binder.apiToken
         {{- if .Values.config.BinderHub.auth_enabled }}
         - name: JUPYTERHUB_API_URL
           value: {{ (print (.Values.config.BinderHub.hub_url_local | default .Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}

--- a/helm-chart/binderhub/templates/secret.yaml
+++ b/helm-chart/binderhub/templates/secret.yaml
@@ -6,7 +6,6 @@ type: Opaque
 data:
   {{- $values :=  dict "config" dict }}
   {{- $cfg := .Values.config }}
-  binder.hub-token: {{ .Values.jupyterhub.hub.services.binder.apiToken | required "jupyterhub.hub.services.binder.apiToken must be explicitly set!" | b64enc | quote }}
   {{- /* every 'pick' here should be matched with a corresponding 'omit' in secret.yaml */ -}}
   {{- if $cfg.GitHubRepoProvider }}
   {{- $_ := set $values.config "GitHubRepoProvider" (pick $cfg.GitHubRepoProvider "client_id" "client_secret" "access_token") }}

--- a/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
+++ b/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
@@ -28,16 +28,10 @@ jupyterhub:
       allowOrigin: "*"
 
   hub:
-    # cookieSecret must be a hex encoded even length string
-    cookieSecret: "cccccccccc"
     db:
       type: "sqlite-memory"
-    services:
-      binder:
-        apiToken: "dummy-binder-secret-token"
 
   proxy:
-    secretToken: "dummy-proxy-secret-token"
     service:
       type: NodePort
       nodePorts:

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config.yaml
@@ -12,16 +12,15 @@ custom:
     allowOrigin: "*"
 
 hub:
-  # cookieSecret must be a hex encoded even length string
-  cookieSecret: "cccccccccc"
   db:
     type: "sqlite-memory"
   services:
     binder:
+      # apiToken is also configured in
+      # testing/local-binder-k8s-hub/binderhub_config.py
       apiToken: "dummy-binder-secret-token"
 
 proxy:
-  secretToken: "dummy-proxy-secret-token"
   service:
     type: NodePort
     nodePorts:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -70,7 +70,6 @@ jupyterhub:
     services:
       binder:
         admin: true
-        apiToken: dummy-binder-secret-token
   singleuser:
     cmd: jupyter-notebook
     events: false


### PR DESCRIPTION
This feature helps user not need to specify a randomly generated token. This token is needed still, but can now be generated and stored in a k8s automatically by z2jh 1.1.0+ (bumped in #1340) that includes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2312.

The actual change to make this work is below and to simply stop passing an api token explicitly. So, when mybinder.org-deploy for example starts using this version, or at a later time, they can simply delete the apiToken from the git config.

```diff
         - name: JUPYTERHUB_API_TOKEN
           valueFrom:
             secretKeyRef:
-              name: binder-secret
-              key: "binder.hub-token"
+              name: "{{ include "jupyterhub.hub.fullname" . }}"
+              key: hub.services.binder.apiToken
```

### Why not to worry about the one test failure

The helm diff test fails because it use the same config to render templates before and after this PR, but before this PR you were required to pass an api token explicitly. In the future, the before and after comparison will succeed as both the "before" and "after" will accept omitting the api token.