### PR TITLE
ci: fix publish workflow by adding missing dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,13 +30,7 @@ jobs:
         run: |
           . ./ci/common
           setup_helm v3.5.4
-          # FIXME: six is required by docker 5.0.0 but isn't explicitly required
-          #        any more.
-          #
-          #        Upstream issue:  https://github.com/docker/docker-py/issues/2807
-          #        Breaking commit: https://github.com/docker/docker-py/commit/c8fba210a222d4f7fde90da8f48db1e7faa637ec
-          #
-          pip install --no-cache-dir chartpress==1.0.* six pyyaml
+          pip install --no-cache-dir chartpress>=1.2 pyyaml
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           #        Upstream issue:  https://github.com/docker/docker-py/issues/2807
           #        Breaking commit: https://github.com/docker/docker-py/commit/c8fba210a222d4f7fde90da8f48db1e7faa637ec
           #
-          pip install --no-cache-dir chartpress==1.0.* six
+          pip install --no-cache-dir chartpress==1.0.* six pyyaml
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-chartpress==1.0.*
+chartpress>=1.2
 click
 codecov
 html5lib
@@ -14,8 +14,3 @@ pytest-cov
 pyyaml
 requests
 ruamel.yaml>=0.15
-# FIXME: six is required by docker 5.0.0 but isn't explicitly required any more.
-#        Upstream issue:  https://github.com/docker/docker-py/issues/2807
-#        Breaking commit: https://github.com/docker/docker-py/commit/c8fba210a222d4f7fde90da8f48db1e7faa637ec
-#
-six

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,10 @@ jupyterhub
 pytest
 pytest-asyncio
 pytest-cov
+# pyyaml is used by the scripts in tools/ and could absolutely be replaced by
+# using ruamel.yaml. ruamel.yaml is more powerful than pyyaml, and that is
+# relevant when writing YAML files back after having loaded them from disk.
+pyyaml
 requests
 ruamel.yaml>=0.15
 # FIXME: six is required by docker 5.0.0 but isn't explicitly required any more.


### PR DESCRIPTION
This PR fixes the broken publishing workflow as observed by @betatim by adding `pyyaml` as a dependency.

I also bumped chartpress which help us remove a workaround here as it is now done in chartpress itself instead.