### PR TITLE
Bump JupyterHub helm chart to 1.1.1

### DIFF
--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -3,9 +3,16 @@ apiVersion: v2
 name: binderhub
 version: 0.2.0-set.by.chartpress
 dependencies:
-  # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
+  # Source code:    https://github.com/jupyterhub/zero-to-jupyterhub-k8s
+  # Latest version: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
+  # App changelog:  https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tree/HEAD/CHANGELOG.md
+  #
+  # Important: Whenever you bump the jupyterhub Helm chart version, also inspect
+  #            the helm-chart/images/binderhub pinned version in requirements.in
+  #            and run "./dependencies freeze --upgrade".
+  #
   - name: jupyterhub
-    version: "1.0.1"
+    version: "1.1.1"
     repository: "https://jupyterhub.github.io/helm-chart"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -10,5 +10,5 @@ google-cloud-logging==1.*
 
 # jupyterhub and kubernetes is pinned to match the JupyterHub Helm chart's
 # version of jupyterhub
-jupyterhub==1.2.*
+jupyterhub==1.4.*
 kubernetes==9.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,76 +4,92 @@
 #
 #    ./dependencies freeze --upgrade
 #
-alembic==1.5.4
+alembic==1.6.5
     # via jupyterhub
 async-generator==1.10
     # via jupyterhub
-attrs==20.3.0
+attrs==21.2.0
     # via jsonschema
-cachetools==4.2.1
+cachetools==4.2.2
     # via google-auth
-certifi==2020.12.5
+certifi==2021.5.30
     # via
     #   kubernetes
     #   requests
 certipy==0.1.3
     # via jupyterhub
-cffi==1.14.4
+cffi==1.14.6
     # via cryptography
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via requests
-cryptography==3.4.4
+cryptography==3.4.7
     # via pyopenssl
+docker==5.0.0
+    # via -r binderhub.in
 entrypoints==0.3
     # via jupyterhub
-google-api-core[grpc]==1.26.0
+escapism==1.0.1
+    # via -r binderhub.in
+google-api-core[grpc]==1.31.0
     # via
     #   google-cloud-core
     #   google-cloud-logging
-google-auth==1.25.0
+google-auth==1.33.1
     # via
     #   google-api-core
     #   google-cloud-core
     #   kubernetes
-google-cloud-core==1.6.0
+google-cloud-core==1.7.1
     # via google-cloud-logging
 google-cloud-logging==1.15.1
     # via -r requirements.in
-googleapis-common-protos==1.52.0
+googleapis-common-protos==1.53.0
     # via google-api-core
-grpcio==1.35.0
+greenlet==1.1.0
+    # via sqlalchemy
+grpcio==1.39.0
     # via google-api-core
-idna==2.10
+idna==3.2
     # via requests
 ipython-genutils==0.2.0
     # via traitlets
-jinja2==2.11.3
-    # via jupyterhub
+jinja2==3.0.1
+    # via
+    #   -r binderhub.in
+    #   jupyterhub
 jsonschema==3.2.0
-    # via jupyter-telemetry
+    # via
+    #   -r binderhub.in
+    #   jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==1.2.2
-    # via -r requirements.in
+jupyterhub==1.4.2
+    # via
+    #   -r binderhub.in
+    #   -r requirements.in
 kubernetes==9.0.1
-    # via -r requirements.in
+    # via
+    #   -r binderhub.in
+    #   -r requirements.in
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
-oauthlib==3.1.0
+oauthlib==3.1.1
     # via
     #   jupyterhub
     #   requests-oauthlib
-packaging==20.9
+packaging==21.0
     # via google-api-core
 pamela==1.0.0
     # via jupyterhub
-prometheus-client==0.9.0
-    # via jupyterhub
-protobuf==3.14.0
+prometheus-client==0.11.0
+    # via
+    #   -r binderhub.in
+    #   jupyterhub
+protobuf==3.17.3
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -85,13 +101,15 @@ pyasn1==0.4.8
     #   rsa
 pycparser==2.20
     # via cffi
+pyjwt==2.1.0
+    # via -r binderhub.in
 pyopenssl==20.0.1
     # via certipy
 pyparsing==2.4.7
     # via packaging
-pyrsistent==0.17.3
+pyrsistent==0.18.0
     # via jsonschema
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   alembic
     #   jupyterhub
@@ -99,24 +117,29 @@ python-dateutil==2.8.1
 python-editor==1.0.4
     # via alembic
 python-json-logger==2.0.1
-    # via jupyter-telemetry
+    # via
+    #   -r binderhub.in
+    #   jupyter-telemetry
 pytz==2021.1
     # via google-api-core
 pyyaml==5.4.1
     # via kubernetes
 requests-oauthlib==1.3.0
     # via kubernetes
-requests==2.25.1
+requests==2.26.0
     # via
+    #   docker
     #   google-api-core
     #   jupyterhub
     #   kubernetes
     #   requests-oauthlib
-rsa==4.7
+rsa==4.7.2
     # via google-auth
-ruamel.yaml==0.16.12
+ruamel.yaml.clib==0.2.6
+    # via ruamel.yaml
+ruamel.yaml==0.17.10
     # via jupyter-telemetry
-six==1.15.0
+six==1.16.0
     # via
     #   google-api-core
     #   google-auth
@@ -127,23 +150,27 @@ six==1.15.0
     #   protobuf
     #   pyopenssl
     #   python-dateutil
-    #   websocket-client
-sqlalchemy==1.3.23
+sqlalchemy==1.4.22
     # via
     #   alembic
     #   jupyterhub
 tornado==6.1
-    # via jupyterhub
+    # via
+    #   -r binderhub.in
+    #   jupyterhub
 traitlets==5.0.5
     # via
+    #   -r binderhub.in
     #   jupyter-telemetry
     #   jupyterhub
-urllib3==1.26.5
+urllib3==1.26.6
     # via
     #   kubernetes
     #   requests
-websocket-client==0.57.0
-    # via kubernetes
+websocket-client==1.1.0
+    # via
+    #   docker
+    #   kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Please see the [CHANGELOG.md](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md) for details, we are already on 1.0.1 - this should be a non-breaking change for us.

Merging this unblocks #1337 that relies on a feature in 1.1.0.