### PR TITLE
bump JupyterHub helm chart to 1.1.2

### DIFF
--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   #            and run "./dependencies freeze --upgrade".
   #
   - name: jupyterhub
-    version: "1.1.1"
+    version: "1.1.2"
     repository: "https://jupyterhub.github.io/helm-chart"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -20,7 +20,7 @@ certipy==0.1.3
     # via jupyterhub
 cffi==1.14.6
     # via cryptography
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 cryptography==3.4.7
     # via pyopenssl
@@ -30,22 +30,22 @@ entrypoints==0.3
     # via jupyterhub
 escapism==1.0.1
     # via -r binderhub.in
-google-api-core[grpc]==1.31.0
+google-api-core[grpc]==1.31.1
     # via
     #   google-cloud-core
     #   google-cloud-logging
-google-auth==1.33.1
+google-auth==1.34.0
     # via
     #   google-api-core
     #   google-cloud-core
     #   kubernetes
-google-cloud-core==1.7.1
+google-cloud-core==1.7.2
     # via google-cloud-logging
 google-cloud-logging==1.15.1
     # via -r requirements.in
 googleapis-common-protos==1.53.0
     # via google-api-core
-greenlet==1.1.0
+greenlet==1.1.1
     # via sqlalchemy
 grpcio==1.39.0
     # via google-api-core
@@ -116,7 +116,7 @@ python-dateutil==2.8.2
     #   kubernetes
 python-editor==1.0.4
     # via alembic
-python-json-logger==2.0.1
+python-json-logger==2.0.2
     # via
     #   -r binderhub.in
     #   jupyter-telemetry
@@ -167,7 +167,7 @@ urllib3==1.26.6
     # via
     #   kubernetes
     #   requests
-websocket-client==1.1.0
+websocket-client==1.1.1
     # via
     #   docker
     #   kubernetes


### PR DESCRIPTION
z2jh 1.1.2 fixes a small bug in the jupyterhub helm chart ([CHANGELOG.md](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md#112---2021-08-05)). Shouldn't be a breaking change.