### PR TITLE
Update repo2docker container image 2021.08.0

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -455,7 +455,7 @@ class BinderHub(Application):
     )
 
     build_image = Unicode(
-        'jupyter/repo2docker:2021.01.0',
+        'quay.io/jupyterhub/repo2docker:2021.08.0',
         help="""
         The repo2docker image to be used for doing builds
         """,


### PR DESCRIPTION
Update to the new `quay.io/jupyterhub/repo2docker:2021.08.0` release