### PR TITLE
Remove unnecessary env var pass-throughs in binderhub_config.py

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -445,7 +445,6 @@ class BinderHub(Application):
         return proposal.value
 
     build_namespace = Unicode(
-        'default',
         help="""
         Kubernetes namespace to spawn build pods in.
 
@@ -453,6 +452,9 @@ class BinderHub(Application):
         """,
         config=True
     )
+    @default('build_namespace')
+    def _default_build_namespace(self):
+        return os.environ.get('BUILD_NAMESPACE', 'default')
 
     build_image = Unicode(
         'quay.io/jupyterhub/repo2docker:2021.08.0',

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -78,9 +78,6 @@ if allow_origin:
         }
     })
 
-if os.getenv('BUILD_NAMESPACE'):
-    c.BinderHub.build_namespace = os.environ['BUILD_NAMESPACE']
-
 if c.BinderHub.auth_enabled:
     hub_url = urlparse(c.BinderHub.hub_url)
     c.HubOAuth.hub_host = '{}://{}'.format(hub_url.scheme, hub_url.netloc)

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -4,8 +4,6 @@ from functools import lru_cache
 from urllib.parse import urlparse
 import yaml
 
-c.BinderHub.hub_api_token = os.environ['JUPYTERHUB_API_TOKEN']
-
 
 def _merge_dictionaries(a, b):
     """Merge two dictionaries recursively.


### PR DESCRIPTION
- hub api token was already being picked up from the env var by traitlet
- build_namespace is now also picked up from the env var by traitlet