### PR TITLE
Move custom BinderSpawner config to traitlets

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -816,7 +816,7 @@ class BinderHub(Application):
         if self.auth_enabled:
             self.tornado_settings['cookie_secret'] = os.urandom(32)
         if self.cors_allow_origin:
-            self.tornado_app.setdefault('headers', {})['Access-Control-Allow-Origin'] = self.cors_allow_origin
+            self.tornado_settings.setdefault('headers', {})['Access-Control-Allow-Origin'] = self.cors_allow_origin
 
         handlers = [
             (r'/metrics', MetricsHandler),

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -193,6 +193,21 @@ class BinderHub(Application):
             proposal.value = proposal.value + '/'
         return proposal.value
 
+    cors_allow_origin = Unicode(
+        "",
+        help="""
+        Origins that can access the BinderHub API.
+
+        Sets the Access-Control-Allow-Origin header in the spawned
+        notebooks. Set to '*' to allow any origin to access spawned
+        notebook servers.
+
+        See also BinderSpawner.cors_allow_origin in the binderhub spawner
+        mixin for setting this property on the spawned notebooks.
+        """,
+        config=True
+    )
+
     auth_enabled = Bool(
         False,
         help="""If JupyterHub authentication enabled,
@@ -800,6 +815,8 @@ class BinderHub(Application):
         )
         if self.auth_enabled:
             self.tornado_settings['cookie_secret'] = os.urandom(32)
+        if self.cors_allow_origin:
+            self.tornado_app.setdefault('headers', {})['Access-Control-Allow-Origin'] = self.cors_allow_origin
 
         handlers = [
             (r'/metrics', MetricsHandler),

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -17,10 +17,11 @@ you need to add the following into ``config.yaml``:
       cull:
         # don't cull authenticated users
         users: False
-      custom:
-        binderauth_enabled: true
       hub:
         redirectToServer: false
+        config:
+          BinderSpawner:
+            auth_enabled: false
         services:
           binder:
             oauth_no_confirm: true

--- a/doc/cors.rst
+++ b/doc/cors.rst
@@ -1,53 +1,54 @@
 Enabling CORS
 =============
 
-Cross-Origin Resource Sharing (CORS) is a mechanism that gives a 
-web application running at one origin, access to resources from a 
-different origin. For security reasons, browsers restrict these 
+Cross-Origin Resource Sharing (CORS) is a mechanism that gives a
+web application running at one origin, access to resources from a
+different origin. For security reasons, browsers restrict these
 "cross-origin" requests by default.
 
 In the context of a BinderHub deployment, CORS is relevant when you
-wish to leverage binder as a computing backend for a web application 
-hosted at some other domain. For example, the amazing libraries 
-`Juniper <https://github.com/ines/juniper>`_ and 
-`Thebe <https://github.com/executablebooks/thebe>`_ leverage binder as 
-a computing backend to facilitate live, interactive coding, directly 
-within a static HTML webpage. For this functionality, CORS must be 
+wish to leverage binder as a computing backend for a web application
+hosted at some other domain. For example, the amazing libraries
+`Juniper <https://github.com/ines/juniper>`_ and
+`Thebe <https://github.com/executablebooks/thebe>`_ leverage binder as
+a computing backend to facilitate live, interactive coding, directly
+within a static HTML webpage. For this functionality, CORS must be
 enabled.
 
 Adjusting BinderHub config to enable CORS
 -----------------------------------------
 
-As mentioned above, for security reasons, CORS is not enabled by 
-default for BinderHub deployments. To enable CORS we need to add 
-additional HTTP headers to allow our BinderHub deployment to be 
-accessed from a different origin. This is as simple as adding the 
+As mentioned above, for security reasons, CORS is not enabled by
+default for BinderHub deployments. To enable CORS we need to add
+additional HTTP headers to allow our BinderHub deployment to be
+accessed from a different origin. This is as simple as adding the
 following to your ``config.yaml``:
 
 .. code:: yaml
-  
-    cors: &cors
-      allowOrigin: '*'
+
+    config:
+      BinderHub:
+        cors_allow_origin: '*'
 
     jupyterhub:
-      custom:
-        cors: *cors
+      config:
+        BinderSpawner:
+          cors_allow_origin: '*'
 
-For example, if you're following on from the previous section 
+For example, if you're following on from the previous section
 :doc:`../https`, your ``config.yaml`` might look like this:
 
 .. code:: yaml
-  
+
     config:
       BinderHub:
         hub_url: https://<jupyterhub-URL> # e.g. https://hub.binder.example.com
-    
-    cors: &cors
-      allowOrigin: '*'
+        cors_allow_origin: '*'
 
     jupyterhub:
-      custom:
-        cors: *cors
+      config:
+        BinderSpawner:
+          cors_allow_origin: '*'
       ingress:
         enabled: true
         hosts:
@@ -80,7 +81,7 @@ For example, if you're following on from the previous section
           hosts:
             - <binderhub-URL> # e.g. binder.example.com
 
-Once you've adjusted ``config.yaml`` to enable CORS, apply your changes 
+Once you've adjusted ``config.yaml`` to enable CORS, apply your changes
 with::
 
     helm upgrade <namespace> jupyterhub/binderhub --version=<version>  -f secret.yaml -f config.yaml

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -69,14 +69,6 @@ if get_value('dind.enabled', False) and get_value('dind.hostSocketDir'):
         get_value('dind.hostSocketDir')
     )
 
-cors = get_value('cors', {})
-allow_origin = cors.get('allowOrigin')
-if allow_origin:
-    c.BinderHub.tornado_settings.update({
-        'headers': {
-            'Access-Control-Allow-Origin': allow_origin,
-        }
-    })
 
 if c.BinderHub.auth_enabled:
     hub_url = urlparse(c.BinderHub.hub_url)

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -262,17 +262,15 @@ properties:
       BinderHub Helm chart.
     required: [hub]
     properties:
-      custom:
-        type: object
-        description: |
-          DEPRECATED
       hub:
         type: object
         additionalProperties: true
+        required: [services]
         properties:
           services:
             type: object
             additionalProperties: true
+            required: [binder]
             properties:
               binder:
                 type: object
@@ -538,6 +536,6 @@ properties:
   # Deprecated
   cors:
     type: object
-    additionalProperties: false
+    additionalProperties: true
     description: |
       DEPRECATED.

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -255,17 +255,6 @@ properties:
       manifest as either the binder pod going into `Error` or `CrashLoopBackoff` states, or in
       some special cases, the binder pod running but... just doing very random things. Be careful!
 
-  cors: &cors-spec
-    type: object
-    additionalProperties: false
-    description: |
-      TODO
-    properties:
-      allowOrigin:
-        type: [string, "null"]
-        description: |
-          TODO
-
   jupyterhub:
     type: object
     additionalProperties: true
@@ -274,11 +263,6 @@ properties:
       BinderHub Helm chart.
     required: [hub]
     properties:
-      custom:
-        type: object
-        additionalProperties: true
-        properties:
-          cors: *cors-spec
       hub:
         type: object
         additionalProperties: true

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -279,10 +279,6 @@ properties:
         additionalProperties: true
         properties:
           cors: *cors-spec
-          binderauth_enabled:
-            type: boolean
-            description: |
-              TODO
       hub:
         type: object
         additionalProperties: true

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -25,7 +25,6 @@ required:
   - service
   - config
   - extraConfig
-  - cors
   - jupyterhub
   - deployment
   - dind
@@ -263,6 +262,10 @@ properties:
       BinderHub Helm chart.
     required: [hub]
     properties:
+      custom:
+        type: object
+        description: |
+          DEPRECATED
       hub:
         type: object
         additionalProperties: true
@@ -322,7 +325,7 @@ properties:
         type: array
         description: |
           List of additional initContainers.
-          
+
           See the [Kubernetes
           docs](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
           for more info.
@@ -531,3 +534,10 @@ properties:
       This is not a supported configuration yet by this Helm chart, but may be
       in the future. This schema entry was added because
       jupyterhub/mybinder.org-deploy configured a Networkpolicy resource here.
+
+  # Deprecated
+  cors:
+    type: object
+    additionalProperties: false
+    description: |
+      DEPRECATED.

--- a/helm-chart/binderhub/templates/NOTES.txt
+++ b/helm-chart/binderhub/templates/NOTES.txt
@@ -163,3 +163,25 @@ config:
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
 {{- end }}
+
+{{- $breaking := "" }}
+{{- $breaking_title := "\n" }}
+{{- $breaking_title = print $breaking_title "\n#################################################################################" }}
+{{- $breaking_title = print $breaking_title "\n######   BREAKING: The config values passed contained no longer accepted    #####" }}
+{{- $breaking_title = print $breaking_title "\n######             options. See the messages below for more details.        #####" }}
+{{- $breaking_title = print $breaking_title "\n######                                                                      #####" }}
+{{- $breaking_title = print $breaking_title "\n######             To verify your updated config is accepted, you can use   #####" }}
+{{- $breaking_title = print $breaking_title "\n######             the `helm template` command.                             #####" }}
+{{- $breaking_title = print $breaking_title "\n#################################################################################" }}
+
+{{- if hasKey .Values.cors "allowedOrigin" }}
+{{- $breaking = print $breaking "\n\nRENAMED: cors.allowedOrigin has been renamed to config.BinderHub.cors_allow_origin" }}
+{{- end }}
+
+{{- if hasKey .Values.jupyterhub.custom.cors "allowedOrigin" }}
+{{- $breaking = print $breaking "\n\nRENAMED: jupyterhub.custom.cors.allowedOrigin has been renamed to jupyterhub.hub.config.BinderSpawner.cors_allow_origin" }}
+{{- end }}
+
+{{- if $breaking }}
+{{- fail (print $breaking_title $breaking) }}
+{{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -67,7 +67,7 @@ jupyterhub:
 
         # image & token are set via spawn options
         from kubespawner import KubeSpawner
-        from traitlet import Bool, Unicode
+        from traitlets import Bool, Unicode
 
         class BinderSpawner(KubeSpawner):
             auth_enabled = Bool(
@@ -110,7 +110,7 @@ jupyterhub:
                         args.append(f'--NotebookApp.default_url={self.default_url}')
 
                     if self.cors_allow_origin:
-                        args.append('--NotebookApp.allow_origin=' + cors_allow_origin)
+                        args.append('--NotebookApp.allow_origin=' + self.cors_allow_origin)
                     # allow_origin=* doesn't properly allow cross-origin requests to single files
                     # see https://github.com/jupyter/notebook/pull/5898
                     if self.cors_allow_origin == '*':
@@ -119,7 +119,7 @@ jupyterhub:
                 return args
 
             def start(self):
-                if not auth_enabled:
+                if not self.auth_enabled:
                     if 'token' not in self.user_options:
                         raise web.HTTPError(400, "token required")
                     if 'image' not in self.user_options:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -39,26 +39,16 @@ config:
 
 extraConfig: {}
 
-# have to set cors.allowOrigin twice:
-# once in top-level cors.allowOrigin,
-# and again in jupyterhub.hub.extraConfigMap.cors.allowOrigin
-
-# Using YAML anchors, `&cors` for the first appearance and `*cors` for subsequent
-# appearances, allows us to remove redundancy in this (BinderHub) `values.yaml`.
-# The anchors do not extend beyond this file.
-# As such, users must set `cors` separately for their own user `values.yaml` for notebooks.
-# `cors` will be set separately in the user `values.yaml` and binderhub`values.yaml`.
-# The same anchor pattern (`&cors`, `*cors`) can be used in the user `values.yaml`.
-
-cors: &cors
-  allowOrigin:
+# Two bits of config need to be set to fully enable cors.
+# config.BinderHub.cors_allow_origin controls the allowed origins for the
+# binderhub api, and jupyterhub.hub.config.BinderSpawner.cors_allow_origin
+# controls the allowed origins for the spawned user notebooks. You most
+# likely want to set both of those to the same value.
 
 jupyterhub:
   cull:
     enabled: true
     users: true
-  custom:
-    cors: *cors
   rbac:
     enabled: true
   hub:
@@ -77,7 +67,7 @@ jupyterhub:
 
         # image & token are set via spawn options
         from kubespawner import KubeSpawner
-        from traitlet import Bool
+        from traitlet import Bool, Unicode
 
         class BinderSpawner(KubeSpawner):
             auth_enabled = Bool(
@@ -87,6 +77,21 @@ jupyterhub:
 
                 Requires `jupyterhub-singleuser` to be available inside the repositories
                 being built.
+                """,
+                config=True
+            )
+
+            cors_allow_origin = Unicode(
+                "",
+                help="""
+                Origins that can access the spawned notebooks.
+
+                Sets the Access-Control-Allow-Origin header in the spawned
+                notebooks. Set to '*' to allow any origin to access spawned
+                notebook servers.
+
+                See also BinderHub.cors_allow_origin in binderhub config
+                for controlling CORS policy for the BinderHub API endpoint.
                 """,
                 config=True
             )
@@ -104,12 +109,11 @@ jupyterhub:
                     if self.default_url:
                         args.append(f'--NotebookApp.default_url={self.default_url}')
 
-                    allow_origin = cors.get('allowOrigin')
-                    if allow_origin:
-                        args.append('--NotebookApp.allow_origin=' + allow_origin)
+                    if self.cors_allow_origin:
+                        args.append('--NotebookApp.allow_origin=' + cors_allow_origin)
                     # allow_origin=* doesn't properly allow cross-origin requests to single files
                     # see https://github.com/jupyter/notebook/pull/5898
-                    if allow_origin == '*':
+                    if self.cors_allow_origin == '*':
                         args.append('--NotebookApp.allow_origin_pat=.*')
                     args += self.args
                 return args

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -59,13 +59,14 @@ jupyterhub:
     users: true
   custom:
     cors: *cors
-    binderauth_enabled: false
   rbac:
     enabled: true
   hub:
     config:
       JupyterHub:
         authenticator_class: nullauthenticator.NullAuthenticator
+      BinderSpawner:
+        auth_enabled: false
     extraConfig:
       00-binder: |
         from tornado import web
@@ -73,14 +74,24 @@ jupyterhub:
         # get custom config from values.custom
         import z2jh
         cors = z2jh.get_config('custom.cors', {})
-        auth_enabled = z2jh.get_config('custom.binderauth_enabled', False)
 
         # image & token are set via spawn options
         from kubespawner import KubeSpawner
+        from traitlet import Bool
 
         class BinderSpawner(KubeSpawner):
+            auth_enabled = Bool(
+                False,
+                help="""
+                Enable authenticated binderhub setup.
+
+                Requires `jupyterhub-singleuser` to be available inside the repositories
+                being built.
+                """,
+                config=True
+            )
             def get_args(self):
-                if auth_enabled:
+                if self.auth_enabled:
                     args = super().get_args()
                 else:
                     args = [

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -61,10 +61,6 @@ jupyterhub:
       00-binder: |
         from tornado import web
 
-        # get custom config from values.custom
-        import z2jh
-        cors = z2jh.get_config('custom.cors', {})
-
         # image & token are set via spawn options
         from kubespawner import KubeSpawner
         from traitlet import Bool, Unicode

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -4,6 +4,7 @@ pdb:
 
 replicas: 1
 
+
 resources:
   requests:
     cpu: 0.2
@@ -46,6 +47,9 @@ extraConfig: {}
 # likely want to set both of those to the same value.
 
 jupyterhub:
+  # Deprecated values, kept here so we can provide useful error messages
+  custom:
+    cors: {}
   cull:
     enabled: true
     users: true
@@ -234,3 +238,7 @@ extraVolumes: []
 extraVolumeMounts: []
 extraEnv: {}
 podAnnotations: {}
+
+# Deprecated values, kept here so we can provide useful error messages
+cors: {}
+

--- a/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
+++ b/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
@@ -21,11 +21,10 @@ jupyterhub:
   debug:
     enabled: true
 
-  config:
-    BinderSpawner:
-      cors_allow_origin: "*"
-
   hub:
+    config:
+      BinderSpawner:
+        cors_allow_origin: "*"
     db:
       type: "sqlite-memory"
 

--- a/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
+++ b/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
@@ -1,8 +1,5 @@
 # This config is used when both BinderHub and the JupyterHub it uses are
 # deployed to a kubernetes cluster.
-cors:
-  allowOrigin: '*'
-
 service:
   type: NodePort
   nodePort: 30901
@@ -15,6 +12,7 @@ config:
     hub_url_local: http://proxy-public
     use_registry: false
     log_level: 10
+    cors_allow_origin: '*'
 
 # NOTE: This is a mirror of the jupyterhub section in
 #       jupyterhub-chart-config.yaml in testing/local-binder-k8s-hub, keep these
@@ -23,9 +21,9 @@ jupyterhub:
   debug:
     enabled: true
 
-  custom:
-    cors:
-      allowOrigin: "*"
+  config:
+    BinderSpawner:
+      cors_allow_origin: "*"
 
   hub:
     db:

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
@@ -1,9 +1,6 @@
 # A JupyterHub Helm chart config containing only auth relevant config, and is
 # meant to be used alongside another configuration.
 
-custom:
-  binderauth_enabled: true
-
 hub:
   services:
     binder:
@@ -15,3 +12,5 @@ hub:
       authenticator_class: "dummy"
     DummyAuthenticator:
       password: "dummy"
+    BinderSpawner:
+      auth_enabled: true

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config.yaml
@@ -7,11 +7,11 @@
 debug:
   enabled: true
 
-custom:
-  cors:
-    allowOrigin: "*"
 
 hub:
+  config:
+    BinderSpawner:
+      cors_allow_origin: '*'
   db:
     type: "sqlite-memory"
   services:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -57,7 +57,6 @@ jupyterhub:
     users: true
   custom:
     cors: *cors
-    binderauth_enabled: false
   rbac:
     enabled: true
   hub:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -48,15 +48,10 @@ extraConfig:
   binder-test-config: |-
     dummy binderhub python code ...
 
-cors: &cors
-  allowOrigin:
-
 jupyterhub:
   cull:
     enabled: true
     users: true
-  custom:
-    cors: *cors
   rbac:
     enabled: true
   hub:


### PR DESCRIPTION
Currently, we have two config variables that are specified in `jupyterhub.custom`
so they can be read by code in the JupyterHub custom config. However, we can
do this in a much more structured way by using actual traitlets. Better validation,
documentation and 'cleaner'. 

This also helps move config away from z2jh specific things (`z2jh.get_config`) 
towards the more generic traitlets.