### PR TITLE
Make registry class configurable, add FakeRegistry

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -49,7 +49,7 @@ from .launcher import Launcher
 from .log import log_request
 from .ratelimit import RateLimiter
 from .repoproviders import RepoProvider
-from .registry import DockerRegistry
+from .registry import DockerRegistry, FakeRegistry
 from .main import MainHandler, ParameterizedMainHandler, LegacyRedirectHandler
 from .repoproviders import (GitHubRepoProvider, GitRepoProvider,
                             GitLabRepoProvider, GistRepoProvider,
@@ -256,6 +256,16 @@ class BinderHub(Application):
         The class used to build repo2docker images.
         
         Must inherit from binderhub.build.Build
+        """,
+        config=True
+    )
+
+    registry_class = Type(
+        DockerRegistry,
+        help="""
+        The class used to Query a Docker registry.
+
+        Must inherit from binderhub.registry.DockerRegistry
         """,
         config=True
     )
@@ -718,8 +728,8 @@ class BinderHub(Application):
             FileSystemLoader(template_paths)
         ])
         jinja_env = Environment(loader=loader, **jinja_options)
-        if self.use_registry and self.builder_required:
-            registry = DockerRegistry(parent=self)
+        if self.use_registry:
+            registry = self.registry_class(parent=self)
         else:
             registry = None
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -535,7 +535,7 @@ class FakeBuild(Build):
     Fake Building process to be able to work on the UI without a running Minikube.
     """
     def submit(self):
-        self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, 'Running')
+        self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.RUNNING)
         return
 
     def stream_logs(self):
@@ -562,7 +562,7 @@ class FakeBuild(Build):
                     'message': f"Step {i+1}/10\n",
                 })
             )
-        self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, 'Succeeded')
+        self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.COMPLETED)
         self.progress('log', json.dumps({
                 'phase': 'Deleted',
                 'message': f"Deleted...\n",

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -226,3 +226,11 @@ class DockerRegistry(LoggingConfigurable):
                 raise
         else:
             return json.loads(resp.body.decode("utf-8"))
+
+class FakeRegistry(DockerRegistry):
+    """
+    Fake registry that contains no images
+    """
+
+    async def get_image_manifest(self, image, tag):
+        return None

--- a/testing/local-binder-mocked-hub/binderhub_config.py
+++ b/testing/local-binder-mocked-hub/binderhub_config.py
@@ -7,10 +7,12 @@
 # - JupyterHub: mocked
 
 from binderhub.repoproviders import FakeProvider
+from binderhub.registry import FakeRegistry
 from binderhub.build import FakeBuild
 
 c.BinderHub.debug = True
-c.BinderHub.use_registry = False
+c.BinderHub.use_registry = True
+c.BinderHub.registry_class = FakeRegistry
 c.BinderHub.builder_required = False
 c.BinderHub.repo_providers = {'gh': FakeProvider}
 c.BinderHub.build_class = FakeBuild


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/binderhub/pull/1323#issuecomment-877692252

This lets you run the UI only without a working Docker daemon, following the instructions in https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md#develop-user-interface

Without this Binderhub tries to query the local Docker Daemon for the image and therefore fails if you don't have Docker running:
https://github.com/jupyterhub/binderhub/blob/d8e7128b684140db80d533a3b794ebca786c40f7/binderhub/builder.py#L352-L354

This also includes some fixes for the FakeBuild class since the strings do not match the expected enum values (follow-up to https://github.com/jupyterhub/binderhub/pull/1325)