### PR TITLE
use jupyterlab for default UI

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -129,8 +129,10 @@ jupyterhub:
         admin: true
         apiToken:
   singleuser:
-    # start jupyter notebook
+    # start jupyter notebook for the server
     cmd: jupyter-notebook
+    # use jupyterlab for the default UI
+    defaultUrl: /lab
     events: false
     storage:
       type: none


### PR DESCRIPTION
matches filepath behavior (#1288). https://github.com/jupyterhub/repo2docker/pull/1035 changed the default repo2docker behavior, but binderhub overrides the default command, so both the default and filepath urls need to be set here.