### PR TITLE
JUPYTERHUB_API_URL needs to end in /

### DIFF
--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -86,6 +86,8 @@ class Launcher(LoggingConfigurable):
         headers = kwargs.setdefault('headers', {})
         headers.update({'Authorization': 'token %s' % self.hub_api_token})
         hub_api_url = os.getenv('JUPYTERHUB_API_URL', '') or self.hub_url_local + 'hub/api/'
+        if not hub_api_url.endswith('/'):
+            hub_api_url += '/'
         request_url = hub_api_url + url
         req = HTTPRequest(request_url, *args, **kwargs)
         retry_delay = self.retry_delay


### PR DESCRIPTION
When running BinderHub as a [JupyterHub managed service](https://jupyterhub.readthedocs.io/en/stable/reference/services.html#launching-a-hub-managed-service) `JUPYTERHUB_API_URL` does not end in a `/`.

Related to https://github.com/jupyterhub/binderhub/pull/1353