### PR TITLE
Build class for running repo2docker locally

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -173,10 +173,9 @@ class Build:
 
         self._component_label = "binderhub-build"
 
-    def get_cmd(self):
-        """Get the cmd to run to build the image"""
-        cmd = [
-            'jupyter-repo2docker',
+    def get_r2d_cmd_options(self):
+        """Get options/flags for repo2docker"""
+        r2d_options = [
             '--ref', self.ref,
             '--image', self.image_name,
             '--no-clean', '--no-run', '--json-logs',
@@ -184,14 +183,22 @@ class Build:
             '--user-id', '1000',
         ]
         if self.appendix:
-            cmd.extend(['--appendix', self.appendix])
+            r2d_options.extend(['--appendix', self.appendix])
 
         if self.push_secret:
-            cmd.append('--push')
+            r2d_options.append('--push')
 
         if self.memory_limit:
-            cmd.append('--build-memory-limit')
-            cmd.append(str(self.memory_limit))
+            r2d_options.append('--build-memory-limit')
+            r2d_options.append(str(self.memory_limit))
+
+        return r2d_options
+
+    def get_cmd(self):
+        """Get the cmd to run to build the image"""
+        cmd = [
+            'jupyter-repo2docker',
+        ] + self.get_r2d_cmd_options()
 
         # repo_url comes at the end, since otherwise our arguments
         # might be mistook for commands to run.

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -218,4 +218,4 @@ class LocalRepo2dockerBuild(Build):
         pass
 
     def stop(self):
-        pass
+        raise NotImplementedError()

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -1,0 +1,227 @@
+"""
+Contains build of a docker image from a git repository.
+"""
+
+import asyncio
+from collections import defaultdict
+import datetime
+from functools import partial
+import json
+import os
+import threading
+from urllib.parse import urlparse
+import subprocess
+import warnings
+from tornado import ioloop
+
+from tornado.ioloop import IOLoop
+from tornado.log import app_log
+
+from .utils import rendezvous_rank, KUBE_REQUEST_TIMEOUT
+from .build import ProgressEvent, Build
+
+
+# https://github.com/jupyterhub/repo2docker/blob/2021.08.0/repo2docker/utils.py#L13-L58
+def _execute_cmd(cmd, capture=False, **kwargs):
+    """
+    Call given command, yielding output line by line if capture=True.
+
+    Must be yielded from.
+    """
+    if capture:
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.STDOUT
+
+    proc = subprocess.Popen(cmd, **kwargs)
+
+    if not capture:
+        # not capturing output, let subprocesses talk directly to terminal
+        ret = proc.wait()
+        if ret != 0:
+            raise subprocess.CalledProcessError(ret, cmd)
+        return
+
+    # Capture output for logging.
+    # Each line will be yielded as text.
+    # This should behave the same as .readline(), but splits on `\r` OR `\n`,
+    # not just `\n`.
+    buf = []
+
+    def flush():
+        """Flush next line of the buffer"""
+        line = b"".join(buf).decode("utf8", "replace")
+        buf[:] = []
+        return line
+
+    c_last = ""
+    try:
+        for c in iter(partial(proc.stdout.read, 1), b""):
+            if c_last == b"\r" and buf and c != b"\n":
+                yield flush()
+            buf.append(c)
+            if c == b"\n":
+                yield flush()
+            c_last = c
+        if buf:
+            yield flush()
+    finally:
+        ret = proc.wait()
+        if ret != 0:
+            raise subprocess.CalledProcessError(ret, cmd)
+
+
+class LocalRepo2dockerBuild(Build):
+    """Represents a build of a git repository into a docker image.
+
+    This runs a build using the repo2docker command line tool.
+    """
+
+    def __init__(
+        self,
+        q,
+        api,
+        name,
+        *,
+        namespace,
+        repo_url,
+        ref,
+        build_image,
+        docker_host,
+        image_name,
+        git_credentials=None,
+        push_secret=None,
+        memory_limit=0,
+        memory_request=0,
+        node_selector=None,
+        appendix="",
+        log_tail_lines=100,
+        sticky_builds=False,
+    ):
+        """
+        Parameters
+        ----------
+
+        q : tornado.queues.Queue
+            Queue that receives progress events after the build has been submitted
+        api : ignored
+        name : str
+            A unique name for the thing (repo, ref) being built. Used to coalesce
+            builds, make sure they are not being unnecessarily repeated
+        namespace : ignored
+        repo_url : str
+            URL of repository to build.
+            Passed through to repo2docker.
+        ref : str
+            Ref of repository to build
+            Passed through to repo2docker.
+        build_image : str
+            Docker image containing repo2docker that is used to spawn the build
+            pods.
+        docker_host : ignored
+        image_name : str
+            Full name of the image to build. Includes the tag.
+            Passed through to repo2docker.
+        git_credentials : str
+            Git credentials to use to clone private repositories. Passed
+            through to repo2docker via the GIT_CREDENTIAL_ENV environment
+            variable. Can be anything that will be accepted by git as
+            a valid output from a git-credential helper. See
+            https://git-scm.com/docs/gitcredentials for more information.
+        push_secret : ignored
+        memory_limit
+            Memory limit for the docker build process. Can be an integer in
+            bytes, or a byte specification (like 6M).
+            Passed through to repo2docker.
+        memory_request
+            Memory request of the build pod. The actual building happens in the
+            docker daemon, but setting request in the build pod makes sure that
+            memory is reserved for the docker build in the node by the kubernetes
+            scheduler.
+        node_selector : ignored
+        appendix : str
+            Appendix to be added at the end of the Dockerfile used by repo2docker.
+            Passed through to repo2docker.
+        log_tail_lines : int
+            Number of log lines to fetch from a currently running build.
+            If a build with the same name is already running when submitted,
+            only the last `log_tail_lines` number of lines will be fetched and
+            displayed to the end user. If not, all log lines will be streamed.
+        sticky_builds : ignored
+        """
+        self.q = q
+        self.repo_url = repo_url
+        self.ref = ref
+        self.name = name
+        self.image_name = image_name
+        self.push_secret = push_secret
+        self.build_image = build_image
+        self.main_loop = IOLoop.current()
+        self.memory_limit = memory_limit
+        self.memory_request = memory_request
+        self.appendix = appendix
+        self.log_tail_lines = log_tail_lines
+
+        self.git_credentials = git_credentials
+
+    @classmethod
+    def cleanup_builds(cls, kube, namespace, max_age):
+        app_log.debug("Not implemented")
+
+    def progress(self, kind: ProgressEvent.Kind, payload: str):
+        """
+        Put current progress info into the queue on the main thread
+        """
+        self.main_loop.add_callback(self.q.put, ProgressEvent(kind, payload))
+
+    def get_affinity(self):
+        raise NotImplementedError()
+
+    def submit(self):
+        """
+        Run a build to create the image for the repository.
+
+        Progress of the build can be monitored by listening for items in
+        the Queue passed to the constructor as `q`.
+        """
+        env = os.environ.copy()
+        if self.git_credentials:
+            env['GIT_CREDENTIAL_ENV'] = self.git_credentials
+
+        cmd = self.get_cmd()
+        app_log.info("Starting build: %s", " ".join(cmd))
+
+        try:
+            self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.RUNNING)
+            for line in _execute_cmd(cmd, capture=True, env=env):
+                self._handle_log(line)
+            self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.COMPLETED)
+        except subprocess.CalledProcessError as e:
+            self.progress(ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.FAILED)
+        except Exception as e:
+            app_log.exception("Error in watch stream for %s", self.name)
+            raise
+
+    def _handle_log(self, line):
+        try:
+            json.loads(line)
+        except ValueError:
+            # log event wasn't JSON.
+            # use the line itself as the message with unknown phase.
+            # We don't know what the right phase is, use 'unknown'.
+            # If it was a fatal error, presumably a 'failure'
+            # message will arrive shortly.
+            app_log.error("log event not json: %r", line)
+            line = json.dumps({
+                'phase': 'unknown',
+                'message': line,
+            })
+        self.progress(ProgressEvent.Kind.LOG_MESSAGE, line)
+
+    def stream_logs(self):
+        pass
+
+    def cleanup(self):
+        raise NotImplementedError()
+
+    def stop(self):
+        pass

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -8,16 +8,11 @@ import datetime
 from functools import partial
 import json
 import os
-import threading
-from urllib.parse import urlparse
 import subprocess
-import warnings
-from tornado import ioloop
 
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
 
-from .utils import rendezvous_rank, KUBE_REQUEST_TIMEOUT
 from .build import ProgressEvent, Build
 
 
@@ -114,9 +109,7 @@ class LocalRepo2dockerBuild(Build):
         ref : str
             Ref of repository to build
             Passed through to repo2docker.
-        build_image : str
-            Docker image containing repo2docker that is used to spawn the build
-            pods.
+        build_image : ignored
         docker_host : ignored
         image_name : str
             Full name of the image to build. Includes the tag.
@@ -154,7 +147,6 @@ class LocalRepo2dockerBuild(Build):
         self.name = name
         self.image_name = image_name
         self.push_secret = push_secret
-        self.build_image = build_image
         self.main_loop = IOLoop.current()
         self.memory_limit = memory_limit
         self.memory_request = memory_request

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -215,7 +215,7 @@ class LocalRepo2dockerBuild(Build):
         pass
 
     def cleanup(self):
-        raise NotImplementedError()
+        pass
 
     def stop(self):
         pass

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -69,6 +69,8 @@ class LocalRepo2dockerBuild(Build):
     """Represents a build of a git repository into a docker image.
 
     This runs a build using the repo2docker command line tool.
+
+    WARNING: This is still under development. Breaking changes may be made at any time.
     """
 
     def __init__(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,6 @@ pytest-cov
 # using ruamel.yaml. ruamel.yaml is more powerful than pyyaml, and that is
 # relevant when writing YAML files back after having loaded them from disk.
 pyyaml
-jupyter-repo2docker
+jupyter-repo2docker>=2021.08.0
 requests
 ruamel.yaml>=0.15

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,5 +12,6 @@ pytest-cov
 # using ruamel.yaml. ruamel.yaml is more powerful than pyyaml, and that is
 # relevant when writing YAML files back after having loaded them from disk.
 pyyaml
+jupyter-repo2docker
 requests
 ruamel.yaml>=0.15

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    ./dependencies freeze --upgrade
 #
-alembic==1.6.5
+alembic==1.7.1
     # via jupyterhub
 async-generator==1.10
     # via jupyterhub
@@ -22,19 +22,19 @@ cffi==1.14.6
     # via cryptography
 charset-normalizer==2.0.4
     # via requests
-cryptography==3.4.7
+cryptography==3.4.8
     # via pyopenssl
-docker==5.0.0
+docker==5.0.2
     # via -r binderhub.in
 entrypoints==0.3
     # via jupyterhub
 escapism==1.0.1
     # via -r binderhub.in
-google-api-core[grpc]==1.31.1
+google-api-core[grpc]==1.31.2
     # via
     #   google-cloud-core
     #   google-cloud-logging
-google-auth==1.34.0
+google-auth==1.35.0
     # via
     #   google-api-core
     #   google-cloud-core
@@ -47,12 +47,12 @@ googleapis-common-protos==1.53.0
     # via google-api-core
 greenlet==1.1.1
     # via sqlalchemy
-grpcio==1.39.0
+grpcio==1.40.0
     # via google-api-core
 idna==3.2
     # via requests
-ipython-genutils==0.2.0
-    # via traitlets
+importlib-resources==5.2.2
+    # via alembic
 jinja2==3.0.1
     # via
     #   -r binderhub.in
@@ -71,7 +71,7 @@ kubernetes==9.0.1
     # via
     #   -r binderhub.in
     #   -r requirements.in
-mako==1.1.4
+mako==1.1.5
     # via alembic
 markupsafe==2.0.1
     # via
@@ -111,11 +111,8 @@ pyrsistent==0.18.0
     # via jsonschema
 python-dateutil==2.8.2
     # via
-    #   alembic
     #   jupyterhub
     #   kubernetes
-python-editor==1.0.4
-    # via alembic
 python-json-logger==2.0.2
     # via
     #   -r binderhub.in
@@ -137,7 +134,7 @@ rsa==4.7.2
     # via google-auth
 ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
-ruamel.yaml==0.17.10
+ruamel.yaml==0.17.16
     # via jupyter-telemetry
 six==1.16.0
     # via
@@ -150,7 +147,7 @@ six==1.16.0
     #   protobuf
     #   pyopenssl
     #   python-dateutil
-sqlalchemy==1.4.22
+sqlalchemy==1.4.23
     # via
     #   alembic
     #   jupyterhub
@@ -158,7 +155,7 @@ tornado==6.1
     # via
     #   -r binderhub.in
     #   jupyterhub
-traitlets==5.0.5
+traitlets==5.1.0
     # via
     #   -r binderhub.in
     #   jupyter-telemetry
@@ -167,10 +164,12 @@ urllib3==1.26.6
     # via
     #   kubernetes
     #   requests
-websocket-client==1.1.1
+websocket-client==1.2.1
     # via
     #   docker
     #   kubernetes
+zipp==3.5.0
+    # via importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Adds a new Build class that runs repo2docker as a local process instead of a container. This allows you to run BinderHub without Kubernetes, and instead rely on JupyterHub with a local container spawner such as DockerSpawner.

This also enables the repo2docker options to be easily augmented in a subclass, for example
```py
class LocalRepo2dockerPodmanBuild(LocalRepo2dockerBuild):
    def get_r2d_cmd_options(self):
        return super().get_r2d_cmd_options() + [
            '--engine', 'podman',
        ]
```

Related to https://github.com/jupyterhub/binderhub/pull/1353