### PR TITLE
Upgrade webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "0.1.0",
   "description": "`BinderHub`",
   "devDependencies": {
+    "css-loader": "^6.2.0",
+    "event-source-polyfill": "^0.0.12",
+    "mini-css-extract-plugin": "^2.3.0",
+    "webpack": "^5.52.1",
+    "webpack-cli": "^4.8.0"
+  },
+  "dependencies": {
     "bootstrap": "^3.4.0",
     "clipboard": "^1.7.1",
-    "css-loader": "^0.28.7",
-    "event-source-polyfill": "^0.0.12",
-    "extract-text-webpack-plugin": "^3.0.2",
-    "file-loader": "^1.1.6",
     "jquery": "^3.2.1",
-    "style-loader": "^0.19.1",
-    "webpack": "^3.10.0",
+    "null-loader": "^4.0.1",
     "xterm": "^2.9.2"
   },
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,39 +1,54 @@
 const webpack = require('webpack');
-const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const path = require('path');
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
-    context: __dirname + "/binderhub/static/",
+    mode: 'production',
+    context: path.resolve(__dirname, 'binderhub/static'),
     entry: "./js/index.js",
     output: {
-        path: __dirname + "/binderhub/static/dist/",
+        path: path.resolve(__dirname, 'binderhub/static/dist/'),
         filename: "bundle.js",
         publicPath: '/static/dist/'
     },
-    module: {
-        rules: [
-            {
-                test: /\.css$/,
-                use: ExtractTextPlugin.extract({
-                    fallback: "style-loader",
-                    use: "css-loader",
-                    // Set publicPath as relative path ("./").
-                    // By default it uses the `output.publicPath` ("/static/dist/"), when it rewrites the URLs in styles.css.
-                    // And it causes these files unavailabe if BinderHub has a different base_url than "/".
-                    publicPath: "./"
-                })
-            },
-            {
-                test: /\.(eot|woff|ttf|woff2|svg)$/,
-                loader: "file-loader"
-            }
-        ]
-    },
-    devtool: 'source-map',
     plugins: [
         new webpack.ProvidePlugin({
             $: 'jquery',
             jQuery: 'jquery',
         }),
-        new ExtractTextPlugin("styles.css"),
-    ]
+        new MiniCssExtractPlugin({
+            filename: 'styles.css'
+        }),
+    ],
+    module: {
+        rules: [
+            {
+                test: /\.css$/i,
+                use: [
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            // Set publicPath as relative path ("./").
+                            // By default it uses the `output.publicPath` ("/static/dist/"), when it rewrites the URLs in styles.css.
+                            // And it causes these files unavailabe if BinderHub has a different base_url than "/".
+                            publicPath: "./",
+                        },
+                    },
+                    'css-loader'
+                ],
+            },
+            {
+                test: /\.(eot|woff|ttf|woff2|svg)$/,
+                type: 'asset/resource'
+            },
+            {
+                // Ignore errors caused by us using old version of xterm that ships with sourcemaps
+                // FIXME: Upgrade version of xterm so this can go away
+                test: /\.js\.map$/,
+                type: 'null-loader'
+            }
+        ]
+    },
+    devtool: 'source-map',
 }


### PR DESCRIPTION
Picks up *just* the webpack upgrade bits from
https://github.com/jupyterhub/binderhub/pull/1248, to make
testing and merging easier.

Co-authored-by: Kenan Erdogan <kenanerdogan@gmail.com>