### PR TITLE
Config fixes for local-binder-local-hub

### DIFF
--- a/testing/local-binder-local-hub/binderhub_config.py
+++ b/testing/local-binder-local-hub/binderhub_config.py
@@ -3,9 +3,9 @@
 #
 # If you are running BidnerHub manually (not via JupyterHub) run
 # `python -m binderhub -f binderhub_config.py`
-
-# Optionally override the external access URL for JupyterHub
-JUPYTERHUB_EXTERNAL_URL = None
+#
+# Override the external access URL for JupyterHub by setting the
+# environment variable JUPYTERHUB_EXTERNAL_URL
 
 # Host IP is needed in a few places
 import socket
@@ -36,4 +36,4 @@ assert os.getenv('JUPYTERHUB_API_TOKEN')
 c.BinderHub.base_url = os.getenv('JUPYTERHUB_SERVICE_PREFIX')
 # JUPYTERHUB_BASE_URL may not include the host
 # c.BinderHub.hub_url = os.getenv('JUPYTERHUB_BASE_URL')
-c.BinderHub.hub_url = JUPYTERHUB_EXTERNAL_URL or f'http://{hostip}:8000'
+c.BinderHub.hub_url = os.getenv('JUPYTERHUB_EXTERNAL_URL') or f'http://{hostip}:8000'

--- a/testing/local-binder-local-hub/jupyterhub_config.py
+++ b/testing/local-binder-local-hub/jupyterhub_config.py
@@ -24,7 +24,7 @@ c.DockerSpawner.remove = True
 c.LocalContainerSpawner.cmd = 'jupyter-notebook'
 
 c.Application.log_level = 'DEBUG'
-c.JupyterHub.Spawner.debug = True
+c.Spawner.debug = True
 c.JupyterHub.authenticator_class = "nullauthenticator.NullAuthenticator"
 
 c.JupyterHub.hub_ip = '0.0.0.0'

--- a/testing/local-binder-local-hub/jupyterhub_config.py
+++ b/testing/local-binder-local-hub/jupyterhub_config.py
@@ -37,5 +37,6 @@ c.JupyterHub.services = [{
     "admin": True,
     "command": ["python", "-mbinderhub", f"--config={binderhub_config}"],
     "url": f"http://localhost:8585",
+    "environment": {"JUPYTERHUB_EXTERNAL_URL": os.getenv("JUPYTERHUB_EXTERNAL_URL", "")}
 }]
 c.JupyterHub.default_url = f"/services/{binderhub_service_name}/"


### PR DESCRIPTION
A couple of fixes for https://github.com/jupyterhub/binderhub/pull/1364
- Fix `Spawner.debug = True`
- Make `JUPYTERHUB_EXTERNAL_URL` setable through an environment variable (requires explicit passthrough in the JupyterHub service config as most env-vars are removed)