### PR TITLE
Upgrade event-source-polyfill

### DIFF
--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -1,3 +1,7 @@
+import { NativeEventSource, EventSourcePolyfill } from 'event-source-polyfill';
+
+const EventSource = NativeEventSource || EventSourcePolyfill;
+
 export default function BinderImage(providerSpec) {
   this.providerSpec = providerSpec;
   this.callbacks = {};

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "`BinderHub`",
   "devDependencies": {
     "css-loader": "^6.2.0",
-    "event-source-polyfill": "^0.0.12",
     "mini-css-extract-plugin": "^2.3.0",
     "webpack": "^5.52.1",
     "webpack-cli": "^4.8.0"
   },
   "dependencies": {
+    "event-source-polyfill": "^1.0.25",
     "bootstrap": "^3.4.0",
     "clipboard": "^2.0.8",
     "jquery": "^3.2.1",


### PR DESCRIPTION
- Use the correct 'dependencies' field in package.json, as
  event-source-polyfill is a runtime dependency.

Split up from https://github.com/jupyterhub/binderhub/pull/1248

Co-authored-by: Kenan Erdogan <kenanerdogan@gmail.com>