### PR TITLE
Slightly cleanup 2 js files

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -17,7 +17,7 @@ import 'bootstrap';
 import 'event-source-polyfill';
 
 import BinderImage from './src/image';
-import { markdownBadge, rstBadge } from './src/badge';
+import { makeBadgeMarkup } from './src/badge';
 import { getPathType, updatePathText } from './src/path';
 import { nextHelpText } from './src/loading';
 
@@ -135,8 +135,12 @@ function updateUrls(formValues) {
     // update URLs and links (badges, etc.)
     $("#badge-link").attr('href', url);
     $('#basic-url-snippet').text(url);
-    $('#markdown-badge-snippet').text(markdownBadge(url));
-    $('#rst-badge-snippet').text(rstBadge(url));
+    $('#markdown-badge-snippet').text(
+      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, 'markdown')
+    );
+    $('#rst-badge-snippet').text(
+      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, 'rst')
+    );
   } else {
     ['#basic-url-snippet', '#markdown-badge-snippet', '#rst-badge-snippet' ].map(function(item){
       const el = $(item);

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -159,7 +159,8 @@ function build(providerSpec, log, fitAddon, path, pathType) {
 
   $('.on-build').removeClass('hidden');
 
-  const image = new BinderImage(providerSpec);
+  const buildToken = $("#build-token").data('token');
+  const image = new BinderImage(providerSpec, BASE_URL, buildToken);
 
   image.onStateChange('*', function(oldState, newState, data) {
     if (data.message !== undefined) {

--- a/binderhub/static/js/src/badge.js
+++ b/binderhub/static/js/src/badge.js
@@ -1,20 +1,16 @@
-const BASE_URL = $("#base-url").data().url;
-const BADGE_BASE_URL = $('#badge-base-url').data().url;
-let badge_url;
+export function makeBadgeMarkup(badgeBaseUrl, baseUrl, url, syntax) {
+  let badgeImageUrl;
 
-if (BADGE_BASE_URL) {
-  badge_url = BADGE_BASE_URL + "badge_logo.svg";
-}
-else {
-  badge_url = window.location.origin + BASE_URL + "badge_logo.svg";
-}
+  if (badgeBaseUrl) {
+    badgeImageUrl = badgeBaseUrl + "badge_logo.svg";
+  } else {
+    badgeImageUrl = window.location.origin + baseUrl + "badge_logo.svg";
+  }
 
-export function markdownBadge(url) {
-  // return markdown badge snippet
-  return "[![Binder](" + badge_url + ")](" + url + ")";
-}
+  if (syntax === 'markdown') {
+    return "[![Binder](" + badgeImageUrl + ")](" + url + ")";
+  } else if (syntax === 'rst') {
+    return ".. image:: " + badgeImageUrl + "\n :target: " + url;
 
-export function rstBadge(url) {
-  // return rst badge snippet
-  return ".. image:: " + badge_url + "\n :target: " + url;
+  }
 }

--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -2,104 +2,104 @@ import { NativeEventSource, EventSourcePolyfill } from 'event-source-polyfill';
 
 const EventSource = NativeEventSource || EventSourcePolyfill;
 
-export default function BinderImage(providerSpec) {
-  this.providerSpec = providerSpec;
-  this.callbacks = {};
-  this.state = null;
-}
-
-BinderImage.prototype.fetch = function() {
-  const baseUrl = $("#base-url").data('url');
-  let apiUrl = baseUrl + "build/" + this.providerSpec;
-  const buildToken = $("#build-token").data('token');
-  if (buildToken) {
-      apiUrl = apiUrl + `?build_token=${buildToken}`;
+export default class BinderImage {
+  constructor(providerSpec, baseUrl, buildToken) {
+    this.providerSpec = providerSpec;
+    this.baseUrl = baseUrl;
+    this.buildToken = buildToken;
+    this.callbacks = {};
+    this.state = null;
   }
 
-  this.eventSource = new EventSource(apiUrl);
-  const that = this;
-  this.eventSource.onerror = function(err) {
-    console.error("Failed to construct event stream", err);
-    that.changeState("failed", {
-      message: "Failed to connect to event stream\n"
+  fetch() {
+    let apiUrl = this.baseUrl + "build/" + this.providerSpec;
+    if (this.buildToken) {
+        apiUrl = apiUrl + `?build_token=${this.buildToken}`;
+    }
+
+    this.eventSource = new EventSource(apiUrl);
+    this.eventSource.onerror = (err) => {
+      console.error("Failed to construct event stream", err);
+      this.changeState("failed", {
+        message: "Failed to connect to event stream\n"
+      });
+    };
+    this.eventSource.addEventListener("message", (event) => {
+      const data = JSON.parse(event.data);
+      // FIXME: Rename 'phase' to 'state' upstream
+      // FIXME: fix case of phase/state upstream
+      let state = null;
+      if (data.phase) {
+        state = data.phase.toLowerCase();
+      }
+      this.changeState(state, data);
     });
-  };
-  this.eventSource.addEventListener("message", function(event) {
-    const data = JSON.parse(event.data);
-    // FIXME: Rename 'phase' to 'state' upstream
-    // FIXME: fix case of phase/state upstream
-    let state = null;
-    if (data.phase) {
-      state = data.phase.toLowerCase();
-    }
-    that.changeState(state, data);
-  });
-};
-
-BinderImage.prototype.close = function() {
-  if (this.eventSource !== undefined) {
-    this.eventSource.close();
   }
-};
 
-BinderImage.prototype.launch = function(url, token, path, pathType) {
-  // redirect a user to a running server with a token
-  if (path) {
-    // strip trailing /
-    url = url.replace(/\/$/, "");
-    // trim leading '/'
-    path = path.replace(/(^\/)/g, "");
-    if (pathType === "file") {
-      // trim trailing / on file paths
-      path = path.replace(/(\/$)/g, "");
-      // /doc/tree is safe because it allows redirect to files
-      url = url + "/doc/tree/" + encodeURI(path);
-    } else {
-      // pathType === 'url'
-      url = url + "/" + path;
+  close() {
+    if (this.eventSource !== undefined) {
+      this.eventSource.close();
     }
   }
-  const sep = url.indexOf("?") == -1 ? "?" : "&";
-  url = url + sep + $.param({ token: token });
-  window.location.href = url;
-};
 
-BinderImage.prototype.onStateChange = function(state, cb) {
-  if (this.callbacks[state] === undefined) {
-    this.callbacks[state] = [cb];
-  } else {
-    this.callbacks[state].push(cb);
-  }
-};
-
-BinderImage.prototype.validateStateTransition = function(oldState, newState) {
-  if (oldState === "start") {
-    return (
-      newState === "waiting" || newState === "built" || newState === "failed"
-    );
-  } else if (oldState === "waiting") {
-    return newState === "building" || newState === "failed";
-  } else if (oldState === "building") {
-    return newState === "pushing" || newState === "failed";
-  } else if (oldState === "pushing") {
-    return newState === "built" || newState === "failed";
-  } else {
-    return false;
-  }
-};
-
-BinderImage.prototype.changeState = function(state, data) {
-  const that = this;
-  [state, "*"].map(function(key) {
-    const callbacks = that.callbacks[key];
-    if (callbacks) {
-      for (let i = 0; i < callbacks.length; i++) {
-        callbacks[i](that.state, state || that.state, data);
+  launch(url, token, path, pathType) {
+    // redirect a user to a running server with a token
+    if (path) {
+      // strip trailing /
+      url = url.replace(/\/$/, "");
+      // trim leading '/'
+      path = path.replace(/(^\/)/g, "");
+      if (pathType === "file") {
+        // trim trailing / on file paths
+        path = path.replace(/(\/$)/g, "");
+        // /doc/tree is safe because it allows redirect to files
+        url = url + "/doc/tree/" + encodeURI(path);
+      } else {
+        // pathType === 'url'
+        url = url + "/" + path;
       }
     }
-  });
-
-  if (state && this.validateStateTransition(this.state, state)) {
-    this.state = state;
+    const sep = url.indexOf("?") == -1 ? "?" : "&";
+    url = url + sep + $.param({ token: token });
+    window.location.href = url;
   }
-};
+
+  onStateChange(state, cb) {
+    if (this.callbacks[state] === undefined) {
+      this.callbacks[state] = [cb];
+    } else {
+      this.callbacks[state].push(cb);
+    }
+  }
+
+  validateStateTransition(oldState, newState) {
+    if (oldState === "start") {
+      return (
+        newState === "waiting" || newState === "built" || newState === "failed"
+      );
+    } else if (oldState === "waiting") {
+      return newState === "building" || newState === "failed";
+    } else if (oldState === "building") {
+      return newState === "pushing" || newState === "failed";
+    } else if (oldState === "pushing") {
+      return newState === "built" || newState === "failed";
+    } else {
+      return false;
+    }
+  }
+
+  changeState(state, data) {
+    [state, "*"].map(key => {
+      const callbacks = this.callbacks[key];
+      if (callbacks) {
+        for (let i = 0; i < callbacks.length; i++) {
+          callbacks[i](this.state, state || this.state, data);
+        }
+      }
+    });
+
+    if (state && this.validateStateTransition(this.state, state)) {
+      this.state = state;
+    }
+  }
+}


### PR DESCRIPTION
For badge.js:

- Use ES6 classes
- Don't reach into the DOM to get build token and baseUrl.
  This will help with writing tests in the future
- Use => functions, so we can stop writing `const that = this`.
  See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions.
  Particularly, it does not rebind `this`, so we can continue
  to access the parent context's `this`.

For badge.js:
- Stop using global constants for config. 
- Use a single function that can switch on syntax type, rather than unique functions for
  each syntax. Helps reduce boilerplate.

Eventually this could be part of a binder-client JS package that
can be used by other projects (like thebe)

Ref https://github.com/jupyterhub/binderhub/issues/1373