### PR TITLE
lab default only if available, change `filepath` definition

### DIFF
--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -75,7 +75,7 @@ class ParameterizedMainHandler(BaseHandler):
                 filepath = self.get_argument('filepath', '').lstrip('/')
 
 
-            # Check if we have a JupyterLab + file path, if so then use it for the filepath
+            # Check the urlpath parameter for a file path, if so use it for the filepath
             urlpath = self.get_argument('urlpath', '').lstrip('/')
             if urlpath and "/tree/" in urlpath:
                 filepath = urlpath.split('tree/', 1)[-1]

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -70,11 +70,14 @@ class ParameterizedMainHandler(BaseHandler):
             nbviewer_url = 'https://nbviewer.jupyter.org/github'
             org, repo_name, ref = spec.split('/', 2)
             # NOTE: tornado unquotes query arguments too -> notebooks%2Findex.ipynb becomes notebooks/index.ipynb
-            filepath = self.get_argument('filepath', '').lstrip('/')
+            filepath = self.get_argument("labpath", "").lstrip("/")
+            if not filepath:
+                filepath = self.get_argument('filepath', '').lstrip('/')
+
 
             # Check if we have a JupyterLab + file path, if so then use it for the filepath
             urlpath = self.get_argument('urlpath', '').lstrip('/')
-            if urlpath.startswith("lab") and "/tree/" in urlpath:
+            if urlpath and "/tree/" in urlpath:
                 filepath = urlpath.split('tree/', 1)[-1]
 
             blob_or_tree = 'blob' if filepath else 'tree'

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -346,9 +346,14 @@ function loadingMain(providerSpec) {
   if (path) {
     pathType = 'url';
   } else {
-    path = params.get('filepath');
+    path = params.get('labpath');
     if (path) {
-      pathType = 'file';
+      pathType = 'lab';
+    } else {
+      path = params.get('filepath');
+      if (path) {
+        pathType = 'file';
+      }
     }
   }
   build(providerSpec, log, fitAddon, path, pathType);

--- a/binderhub/static/js/src/image.js
+++ b/binderhub/static/js/src/image.js
@@ -49,11 +49,16 @@ export default class BinderImage {
       url = url.replace(/\/$/, "");
       // trim leading '/'
       path = path.replace(/(^\/)/g, "");
-      if (pathType === "file") {
+      if (pathType === "lab") {
         // trim trailing / on file paths
         path = path.replace(/(\/$)/g, "");
         // /doc/tree is safe because it allows redirect to files
         url = url + "/doc/tree/" + encodeURI(path);
+      } else if (pathType === "file") {
+        // trim trailing / on file paths
+        path = path.replace(/(\/$)/g, "");
+        // /tree is safe because it allows redirect to files
+        url = url + "/tree/" + encodeURI(path);
       } else {
         // pathType === 'url'
         url = url + "/" + path;

--- a/binderhub/static/js/src/path.js
+++ b/binderhub/static/js/src/path.js
@@ -1,7 +1,14 @@
 export function getPathType() {
   // return path type. 'file' or 'url'
   const element = document.getElementById("url-or-file-selected");
-  return element.innerText.trim().toLowerCase();
+  let pathType = element.innerText.trim().toLowerCase();
+  if (pathType === "file") {
+    // selecting a 'file' in the form opens with jupyterlab
+    // avoids backward-incompatibility with old `filepath` urls,
+    // which still open old UI
+    pathType = "lab";
+  }
+  return pathType;
 }
 
 export function updatePathText() {

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -188,10 +188,29 @@ jupyterhub:
         admin: true
         apiToken:
   singleuser:
-    # start jupyter notebook for the server
-    cmd: jupyter-notebook
-    # use jupyterlab for the default UI
-    defaultUrl: /lab
+    # start notebook server with lab ui as default
+    # *if available*
+    cmd:
+      - python3
+      - "-c"
+      - |
+        import os
+        import sys
+
+        try:
+            import jupyterlab
+            major = int(jupyterlab.__version__.split(".", 1)[0])
+        except Exception:
+            have_lab = False
+        else:
+            have_lab = major >= 3
+
+        if have_lab and "NotebookApp.default_url" not in " ".join(sys.argv):
+            # if recent-enough lab is available, make it the default UI
+            sys.argv.insert(1, "--NotebookApp.default_url=/lab/")
+
+        # launch the notebook server
+        os.execvp("jupyter-notebook", sys.argv)
     events: false
     storage:
       type: none
@@ -282,4 +301,3 @@ podAnnotations: {}
 
 # Deprecated values, kept here so we can provide useful error messages
 cors: {}
-


### PR DESCRIPTION
Changes `?filepath` definition from "open with current UI" to "open with classic notebook" to match apparent user expectations.

two pieces of #1368 :

- opening a file with jupyterlab uses `?labpath` instead of `?filepath`. `filepath` is permanently frozen to mean `/tree/...` with the classic UI
- selecting 'open a file' in the form behavior is unchanged, in that it produces a `?labpath` url, not a `filepath` url
- move default url choice down one level into `singleuser.cmd` so that we can set lab as the default url if jupyterlab 3 is available

If no filepath is specified, and lab 3 is available, lab is still the default UI, leaving it the only link with changed behavior.

@betatim proposed reserving lab-by-default to `/v3/` to make the UI change fully explicit and opt-in. I think that if we go all the way to defining a `v3` url, we should also change the server launch command to `jupyter lab` instead of `jupyter notebook`, because we know that change will be significantly more disruptive, and is also going to happen eventually. It's also a lot simpler to say "v3 starts jupyterlab" than the UI is changed, but the server is not.

We specifically chose this 'only switch default ui' to avoid breaking existing links, so if we are making new links, I think we should update the server command to the current standard, too, rather than having to do this all over again in a few months.

I think we can also communicate a lot better (and take some steps) to address the fact that UI customizations (extensions and such) are very often broken by repo2docker updates, because repo2docker sets the UI versions, not the user. The user may pin down UI, but this can break things, too. There is no good answer for now for stable links with extensions that don't need upkeep by the user.