### PR TITLE
Emit launch events

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -588,7 +588,7 @@ class BuildHandler(BaseHandler):
                     await self.emit(
                         {
                             "phase": "launching",
-                            "message": "{}\n".format(message),
+                            "message": message + "\n",
                         }
                     )
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -585,9 +585,6 @@ class BuildHandler(BaseHandler):
 
                 async def handle_progress_event(event):
                     message = event["message"]
-                    if message.startswith("20"):
-                        # remove timestamp and type info from message
-                        message = message.split("] ", 1)[-1]
                     await self.emit(
                         {
                             "phase": "launching",

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -582,17 +582,33 @@ class BuildHandler(BaseHandler):
                 username = launcher.unique_name_from_repo(self.repo_url)
                 server_name = ''
             try:
+
+                async def handle_progress_event(event):
+                    message = event["message"]
+                    if message.startswith("20"):
+                        # remove timestamp and type info from message
+                        message = message.split("] ", 1)[-1]
+                    await self.emit(
+                        {
+                            "phase": "launching",
+                            "message": "{}\n".format(message),
+                        }
+                    )
+
                 extra_args = {
                     'binder_ref_url': self.ref_url,
                     'binder_launch_host': self.binder_launch_host,
                     'binder_request': self.binder_request,
                     'binder_persistent_request': self.binder_persistent_request,
                 }
-                server_info = await launcher.launch(image=self.image_name,
-                                                    username=username,
-                                                    server_name=server_name,
-                                                    repo_url=self.repo_url,
-                                                    extra_args=extra_args)
+                server_info = await launcher.launch(
+                    image=self.image_name,
+                    username=username,
+                    server_name=server_name,
+                    repo_url=self.repo_url,
+                    extra_args=extra_args,
+                    event_callback=handle_progress_event,
+                )
             except Exception as e:
                 duration = time.perf_counter() - launch_starttime
                 if i + 1 == launcher.retries:

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -287,7 +287,9 @@ class Launcher(LoggingConfigurable):
             self.log.debug("Requesting progress for {username}: {progress_api_url}")
             resp_future = self.api_request(
                 progress_api_url,
-                streaming_callback=handle_chunk,
+                streaming_callback=lambda chunk: asyncio.ensure_future(
+                    handle_chunk(chunk)
+                ),
                 request_timeout=self.launch_timeout,
             )
             try:

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -87,8 +87,8 @@ class Launcher(LoggingConfigurable):
         600,
         config=True,
         help="""
-         Wait this many seconds until server is ready, raise TimeoutError otherwise.
-         """,
+        Wait this many seconds until server is ready, raise TimeoutError otherwise.
+        """,
     )
 
     async def api_request(self, url, *args, **kwargs):
@@ -241,7 +241,7 @@ class Launcher(LoggingConfigurable):
             )
             if resp.code == 202:
                 # Server hasn't actually started yet
-                # listen pending spawn (launch) events until server is ready
+                # listen for pending spawn (launch) events until server is ready
                 ready_event_container = []
                 buffer_list = []
 
@@ -280,14 +280,13 @@ class Launcher(LoggingConfigurable):
                 except (gen.TimeoutError, TimeoutError):
                     raise web.HTTPError(
                         500,
-                        "Image %s for user %s took too long to launch"
-                        % (image, username),
+                        f"Image {image} for user {username} took too long to launch",
                     )
 
                 # verify that the server is running!
                 if not ready_event_container:
                     raise web.HTTPError(
-                        500, "Image %s for user %s failed to launch" % (image, username)
+                        500, f"Image {image} for user {username} failed to launch"
                     )
 
         except HTTPError as e:

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -269,13 +269,15 @@ class Launcher(LoggingConfigurable):
                     url_parts.extend(["server/progress"])
                 progress_api_url = url_path_join(*url_parts)
                 resp_future = self.api_request(
-                    progress_api_url, streaming_callback=handle_chunk
+                    progress_api_url,
+                    streaming_callback=handle_chunk,
+                    request_timeout=self.launch_timeout,
                 )
                 try:
                     await gen.with_timeout(
                         timedelta(seconds=self.launch_timeout), resp_future
                     )
-                except gen.TimeoutError:
+                except (gen.TimeoutError, TimeoutError):
                     raise web.HTTPError(
                         500,
                         "Image %s for user %s took too long to launch"

--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -9,6 +9,7 @@ import string
 from urllib.parse import urlparse, quote
 import uuid
 import os
+from datetime import timedelta
 
 from tornado.log import app_log
 from tornado import web, gen
@@ -17,6 +18,8 @@ from traitlets.config import LoggingConfigurable
 from traitlets import Integer, Unicode, Bool, default
 from jupyterhub.traitlets import Callable
 from jupyterhub.utils import maybe_future
+
+from .utils import url_path_join
 
 # pattern for checking if it's an ssh repo and not a URL
 # used only after verifying that `://` is not present
@@ -79,6 +82,13 @@ class Launcher(LoggingConfigurable):
 
         Receives 5 parameters: launcher, image, username, server_name, repo_url
         """
+    )
+    launch_timeout = Integer(
+        600,
+        config=True,
+        help="""
+         Wait this many seconds until server is ready, raise TimeoutError otherwise.
+         """,
     )
 
     async def api_request(self, url, *args, **kwargs):
@@ -148,7 +158,15 @@ class Launcher(LoggingConfigurable):
         # add a random suffix to avoid collisions for users on the same image
         return '{}-{}'.format(prefix, ''.join(random.choices(SUFFIX_CHARS, k=SUFFIX_LENGTH)))
 
-    async def launch(self, image, username, server_name='', repo_url='', extra_args=None):
+    async def launch(
+        self,
+        image,
+        username,
+        server_name="",
+        repo_url="",
+        extra_args=None,
+        event_callback=None,
+    ):
         """Launch a server for a given image
 
         - creates a temporary user on the Hub if authentication is not enabled
@@ -223,20 +241,52 @@ class Launcher(LoggingConfigurable):
             )
             if resp.code == 202:
                 # Server hasn't actually started yet
-                # We wait for it!
-                # NOTE: This ends up being about ten minutes
-                for i in range(64):
-                    user_data = await self.get_user_data(escaped_username)
-                    if user_data['servers'][server_name]['ready']:
-                        break
-                    if not user_data['servers'][server_name]['pending']:
-                        raise web.HTTPError(500, "Image %s for user %s failed to launch" % (image, username))
-                    # FIXME: make this configurable
-                    # FIXME: Measure how long it takes for servers to start
-                    # and tune this appropriately
-                    await gen.sleep(min(1.4 ** i, 10))
+                # listen pending spawn (launch) events until server is ready
+                ready_event_container = []
+                buffer_list = []
+
+                async def handle_chunk(chunk):
+                    lines = b"".join(buffer_list + [chunk]).split(b"\n\n")
+                    # the last item in the list is usually an empty line ('')
+                    # but it can be the partial line after the last `\n\n`,
+                    # so put it back on the buffer to handle with the next chunk
+                    buffer_list[:] = [lines[-1]]
+                    for line in lines[:-1]:
+                        if line:
+                            line = line.decode("utf8", "replace")
+                        if line and line.startswith("data:"):
+                            event = json.loads(line.split(":", 1)[1])
+                            if event_callback:
+                                await event_callback(event)
+                            if event.get("ready", False):
+                                # stream ends when server is ready
+                                ready_event_container.append(event)
+
+                url_parts = ["users", username]
+                if server_name:
+                    url_parts.extend(["servers", server_name, "progress"])
                 else:
-                    raise web.HTTPError(500, f"Image {image} for user {username} took too long to launch")
+                    url_parts.extend(["server/progress"])
+                progress_api_url = url_path_join(*url_parts)
+                resp_future = self.api_request(
+                    progress_api_url, streaming_callback=handle_chunk
+                )
+                try:
+                    await gen.with_timeout(
+                        timedelta(seconds=self.launch_timeout), resp_future
+                    )
+                except gen.TimeoutError:
+                    raise web.HTTPError(
+                        500,
+                        "Image %s for user %s took too long to launch"
+                        % (image, username),
+                    )
+
+                # verify that the server is running!
+                if not ready_event_container:
+                    raise web.HTTPError(
+                        500, "Image %s for user %s failed to launch" % (image, username)
+                    )
 
         except HTTPError as e:
             if e.response:
@@ -248,5 +298,7 @@ class Launcher(LoggingConfigurable):
                           format(_server_name, username, e, body))
             raise web.HTTPError(500, f"Failed to launch image {image}")
 
-        data['url'] = self.hub_url + 'user/%s/%s' % (escaped_username, server_name)
+        data["url"] = url_path_join(
+            self.hub_url, f"user/{escaped_username}/{server_name}"
+        )
         return data

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -55,7 +55,7 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
             event = json.loads(line.split(':', 1)[1])
             events.append(event)
             assert 'message' in event
-            sys.stdout.write(event['message'])
+            sys.stdout.write(f"{event.get('phase', '')}: {event['message']}")
             # this is the signal that everything is ready, pod is launched
             # and server is up inside the pod. Break out of the loop now
             # because BinderHub keeps the connection open for many seconds
@@ -63,10 +63,8 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
             if event.get('phase') == 'ready':
                 r.close()
                 break
-            if (
-                event.get("phase") == "launching"
-                and not event["message"].startswith("Launching server...")
-                and not event["message"].startswith("Launch attempt ")
+            if event.get("phase") == "launching" and not event["message"].startswith(
+                ("Launching server...", "Launch attempt ")
             ):
                 # skip standard launching events of builder
                 # we are interested in launching events from spawner

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -48,6 +48,7 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
     r = await async_requests.get(build_url, stream=True)
     r.raise_for_status()
     events = []
+    launch_events = 0
     async for line in async_requests.iter_lines(r):
         line = line.decode('utf8', 'replace')
         if line.startswith('data:'):
@@ -62,7 +63,16 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
             if event.get('phase') == 'ready':
                 r.close()
                 break
+            if (
+                event.get("phase") == "launching"
+                and not event["message"].startswith("Launching server...")
+                and not event["message"].startswith("Launch attempt ")
+            ):
+                # skip standard launching events of builder
+                # we are interested in launching events from spawner
+                launch_events += 1
 
+    assert launch_events > 0
     final = events[-1]
     assert 'phase' in final
     assert final['phase'] == 'ready'

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -211,6 +211,7 @@ jupyterhub:
 
         # launch the notebook server
         os.execvp("jupyter-notebook", sys.argv)
+    events: true
     storage:
       type: none
     memory:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -211,7 +211,6 @@ jupyterhub:
 
         # launch the notebook server
         os.execvp("jupyter-notebook", sys.argv)
-    events: false
     storage:
       type: none
     memory:

--- a/testing/local-binder-local-hub/jupyterhub_config.py
+++ b/testing/local-binder-local-hub/jupyterhub_config.py
@@ -44,3 +44,9 @@ c.JupyterHub.services = [{
     "environment": {"JUPYTERHUB_EXTERNAL_URL": os.getenv("JUPYTERHUB_EXTERNAL_URL", "")}
 }]
 c.JupyterHub.default_url = f"/services/{binderhub_service_name}/"
+
+c.JupyterHub.tornado_settings = {
+    "slow_spawn_timeout": 0,
+}
+
+c.KubeSpawner.events_enabled = True


### PR DESCRIPTION
Rebase of #950 (I don't have permission to push updates there)

squashed #950 to make conflict resolution easier, and fixed a couple small issues, but this works well in my own tests.

Much better feedback when launch fails: in my tests, launch failed because I hadn't set up image push/pull correctly:

<img width="1351" alt="Screen Shot 2021-09-24 at 12 04 09" src="https://user-images.githubusercontent.com/151929/134657664-5679007b-17a9-4782-831f-4dd92b82ee4e.png">


And when launch succeeds, you get more incremental feedback about progress:

https://user-images.githubusercontent.com/151929/134658127-c2406be2-a108-4a9f-9502-77fd35e7ae9f.mov


The original PR stripped k8s timestamp/log-level prefixes from messages, but I reverted that to make it simpler. I think if we want to do that, it should be a KubeSpawner option, not something we do in BinderHub.

EDIT by @consideRatio: closes #950.
EDIT by @manics: closes https://github.com/jupyterhub/binderhub/issues/886