### PR TITLE
Include JS for *just* the bootstrap components we use

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -13,7 +13,6 @@
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import ClipboardJS from 'clipboard';
-import 'bootstrap';
 import 'event-source-polyfill';
 
 import BinderImage from './src/image';
@@ -22,8 +21,12 @@ import { getPathType, updatePathText } from './src/path';
 import { nextHelpText } from './src/loading';
 
 import 'xterm/css/xterm.css';
+
+// Include just the bootstrap components we use
+import 'bootstrap/js/dropdown';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap/dist/css/bootstrap-theme.min.css';
+
 import '../index.css';
 
 const BASE_URL = $('#base-url').data().url;


### PR DESCRIPTION
This reduces our bundle size from 488 KB to 452 KB with barely
any effort on our part

Ref https://github.com/jupyterhub/binderhub/issues/1373