### PR TITLE
Jupyter packaging, fix sdist, PEP518 build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
 name: Publish helm chart and docker images
 
-# Trigger the workflow on tags or commits to the main or master branch.
 on:
+  pull_request:
   push:
-    branches: [main, master]
-    tags: ["**"]
 
 
 jobs:
@@ -17,6 +15,7 @@ jobs:
   #
   Publish:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -76,3 +75,24 @@ jobs:
         run: |
           ./tools/generate-json-schema.py
           ./ci/publish
+
+  PyPI-testbuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Versioneer requires past tags
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install pypa/build
+        run: python -mpip install build
+      - name: Build a sdist, and a binary wheel from the sdist
+        run: python -mbuild .
+      # ref: https://github.com/actions/upload-artifact#readme
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pypi-dist
+          path: "dist/*"
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -383,9 +383,8 @@ to prepare for breaking changes associated with the version bump.
 
 * update/close the `CHANGES.md` for this release (see below)
 * create a git tag for the release
-* `pip install twine`
-* `python setup.py sdist`
-* `python setup.py bdist_wheel`
+* `pip install build twine`
+* `python -mbuild .`
 * `twine check dist/*` to check the README parses on PyPI
 * edit `$HOME/.pypirc` to use the binder team account
 * `twine upload dist/*`
@@ -399,7 +398,7 @@ PyPI](https://packaging.python.org/guides/distributing-packages-using-setuptools
 
 As BinderHub does not have a typical semver release schedule, we try to
 update the changelog in `CHANGES.md` every three months. A useful tool
-for this [can be found here](https://github.com/choldgraf/github-activity).
+for this [can be found here](https://github.com/executablebooks/github-activity).
 If you choose to use this tool, the command that generated current sections
 in the changelog is below:
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,8 @@ recursive-include binderhub/event-schemas *
 graft testing
 graft doc
 include LICENSE
+include package.json
+include requirements.txt
 include versioneer.py
+include webpack.config.js
 include binderhub/_version.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ click
 codecov
 html5lib
 jsonschema
+jupyter_packaging>=0.10.4,<2
 jupyterhub
 pytest
 pytest-asyncio

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /tmp/binderhub
 
 # Build the binderhub python library into a wheel and save it to the ./dist
 # folder. There are no pycurl wheels so we build our own in the build stage.
-RUN python setup.py bdist_wheel
+RUN python -mpip install build && python -mbuild --wheel .
 RUN pip wheel pycurl --wheel-dir ./dist
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+  "jupyter-packaging >= 0.10",
+  "setuptools >= 40.9.0",
+  "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@ from jupyter_packaging import wrap_installers, npm_builder
 import os
 
 from setuptools import setup, find_packages
+import sys
+
+# ensure the current directory is on sys.path
+# so versioneer can be imported when pip uses
+# PEP 517/518 build rules.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+sys.path.append(os.path.dirname(__file__))
 
 import versioneer
 


### PR DESCRIPTION
Use jupyter-packaging for building JS assets..... in testing this I discovered `MANIFEST.in` was missing some files which meant the sdist was incomplete, so this seemed like a good opportunity to make the build PEP518 compatible (`python -mbuild .` first builds the sdist, then builds a wheel from the sdist, so if there are missing files you'll know).

### Related (added by Erik)
- https://github.com/jupyter/jupyter-packaging#readme
  > [jupyter-packaging are] Tools to help build and install Jupyter Python packages that require a pre-build step that may include JavaScript build steps.
- https://github.com/jupyterhub/nbgitpuller/pull/211