### PR TITLE
Manually create the launch URL instead of using the response from JHub

### DIFF
--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -284,7 +284,7 @@ class Launcher(LoggingConfigurable):
             else:
                 url_parts.extend(["server/progress"])
             progress_api_url = url_path_join(*url_parts)
-            self.log.debug("Requesting progress for {username}: {progress_api_url}")
+            self.log.debug(f"Requesting progress for {username}: {progress_api_url}")
             resp_future = self.api_request(
                 progress_api_url,
                 streaming_callback=lambda chunk: asyncio.ensure_future(
@@ -329,5 +329,6 @@ class Launcher(LoggingConfigurable):
                 500, f"Image {image} for user {username} failed to launch"
             )
 
-        data["url"] = url_path_join(self.hub_url, ready_event["url"])
+        data["url"] = self.hub_url + f"user/{escaped_username}/{server_name}"
+        self.log.debug(data["url"])
         return data


### PR DESCRIPTION
https://github.com/jupyterhub/binderhub/pull/1393 broke binder deployments which were using a base_url with a base_url for JupyterHub. 

The `ready` [event from JupyterHub](https://github.com/jupyterhub/jupyterhub/blob/5f0077cb5b8d6507bbfe36d094fbabf7aaabe65b/jupyterhub/apihandlers/users.py#L678) embeds the `base_url` of JupyterHub already so it was creating URL with `http://<IP>:<PORT>/<Jhub_base_url>/<Jhub_base_url>/<user>/<server_name>`

Not sure if this is the right way to fix this or if this should be changed in the jupyterhub API handler.