### PR TITLE
use hub/api/health endpoint

### DIFF
--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -138,7 +138,7 @@ class HealthHandler(BaseHandler):
     @retry
     async def check_jupyterhub_api(self, hub_url):
         """Check JupyterHub API health"""
-        await AsyncHTTPClient().fetch(hub_url + "hub/health", request_timeout=3)
+        await AsyncHTTPClient().fetch(hub_url + "hub/api/health", request_timeout=3)
         return True
 
     @false_if_raises


### PR DESCRIPTION
allows api-only deployments, where only `/hub/api` is routed to the Hub, instead of all `/hub/` urls

this duplicate endpoint of `/hub/health` was [added][] in JupyterHub 1.4, which we now require

[added]: https://github.com/jupyterhub/jupyterhub/pull/3373