### PR TITLE
helm-chart: fix inability to omit ingress.hosts, make it optional

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -21,9 +21,8 @@ spec:
   ingressClassName: "{{ . }}"
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
-      http:
+    {{- range $host := .Values.ingress.hosts | default (list "") }}
+    - http:
         paths:
           - path: /{{ $.Values.ingress.pathSuffix }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
@@ -38,6 +37,9 @@ spec:
               serviceName: binder
               servicePort: 80
             {{- end }}
+      {{- if $host }}
+      host: {{ $host | quote }}
+      {{- end }}
     {{- end }}
   {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
   tls:


### PR DESCRIPTION
We should allow our template to generate properly without forcing users
to specify ingress.hosts as it is a viable configuration that has been
requested as in z2jh already.

### Related
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2027
- https://github.com/dask/helm-chart/pull/210