### PR TITLE
helm-chart: support modern api-version of PDBs

### DIFF
--- a/helm-chart/binderhub/templates/pdb.yaml
+++ b/helm-chart/binderhub/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.pdb.enabled -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: binderhub


### PR DESCRIPTION
I think when a helm chart upgrades and renders this changed template, it will conclude that one PDB of old version is no longer rendered and should be removed, and one new PDB of a new version is now rendered and should be created: this kind of change makes it fine for `helm` and k8s to update this resource while changes to values within it can be troublesome.

Closes #1396 fully.