### PR TITLE
helm-chart: fix typo for new Ingress apiVersion format

### DIFF
--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
               service:
                 name: binder
                 port:
-                  name: 80
+                  number: 80
             {{- else }}
             backend:
               serviceName: binder


### PR DESCRIPTION
Small followup to #1407.

I think this would have been caught by an upgrade test in our CI system, I'm not fully not sure. #1195 represent that need.