### PR TITLE
image: use tini to react on SIGTERM for quick terminations

### DIFF
--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -27,18 +27,28 @@ WORKDIR /tmp/binderhub
 RUN python -mpip install build && python -mbuild --wheel .
 RUN pip wheel pycurl --wheel-dir ./dist
 
+# We download tini from here were we have wget available.
+RUN ARCH=$(uname -m); \
+    if [ "$ARCH" = x86_64 ]; then ARCH=amd64; fi; \
+    if [ "$ARCH" = aarch64 ]; then ARCH=arm64; fi; \
+    wget -qO /tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$ARCH" \
+ && chmod +x /tini
 
 # The final stage
 # ---------------
 FROM python:3.8-slim-$DIST
 WORKDIR /
 
+# We use tini as an entrypoint to not loose track of SIGTERM signals as sent
+# before SIGKILL when "docker stop" or "kubectl delete pod" is run. By doing
+# that the pod can terminate very quickly.
+COPY --from=build-stage /tini /tini
+ 
 # The slim version doesn't include git as required by binderhub
 RUN apt-get update \
  && apt-get install --yes \
         git \
  && rm -rf /var/lib/apt/lists/*
-
 
 # Copy the built wheels from the build-stage. Also copy the image
 # requirements.txt built from the binderhub package requirements.txt and the
@@ -57,7 +67,7 @@ RUN pip install --no-cache-dir \
 ARG PIP_TOOLS=
 RUN test -z "$PIP_TOOLS" || pip install --no-cache pip-tools==$PIP_TOOLS
 
-ENTRYPOINT ["python3", "-m", "binderhub"]
+ENTRYPOINT ["/tini", "--", "python3", "-m", "binderhub"]
 CMD ["--config", "/etc/binderhub/config/binderhub_config.py"]
 ENV PYTHONUNBUFFERED=1
 EXPOSE 8585


### PR DESCRIPTION
I know the binder pod is slow to terminate without this, and I know the binder pod is quick to terminate with this - so somehow the SIGTERM signal is lost without it. I can't say for sure why, but that's the case.

Let's go with it, and if someone can make it optimized to not need `tini` for this purpose, we can switch to that later.