### PR TITLE
[TST] only record response if there is one

### DIFF
--- a/binderhub/tests/utils.py
+++ b/binderhub/tests/utils.py
@@ -82,7 +82,8 @@ class MockAsyncHTTPClient(CurlAsyncHTTPClient):
             error = e
             response = e.response
 
-        self._record_response(url_key, response)
+        if response:
+            self._record_response(url_key, response)
         # return or raise the original result
         if error:
             raise error


### PR DESCRIPTION
there _usually_ is a response, but in some error cases (e.g. connection error) it could be None. In which case, there's nothing to record.

This is causing some CI failures, I think.