### PR TITLE
add quota rejections to launch count metric

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -542,8 +542,12 @@ class BuildHandler(BaseHandler):
 
             if pod_quota is not None and total_pods >= pod_quota:
                 # check overall quota first
+                LAUNCH_COUNT.labels(
+                    status="pod_quota",
+                    **self.repo_metric_labels,
+                ).inc()
                 app_log.error(f"BinderHub is full: {total_pods}/{pod_quota}")
-                await self.fail(f"Too many users on this BinderHub! Try again soon.")
+                await self.fail("Too many users on this BinderHub! Try again soon.")
                 return
 
             for pod in pods["items"]:
@@ -556,6 +560,10 @@ class BuildHandler(BaseHandler):
                         break
 
             if repo_quota and matching_pods >= repo_quota:
+                LAUNCH_COUNT.labels(
+                    status="repo_quota",
+                    **self.repo_metric_labels,
+                ).inc()
                 app_log.error(
                     f"{self.repo_url} has exceeded quota: {matching_pods}/{repo_quota} ({total_pods} total)"
                 )


### PR DESCRIPTION
so we can track launches being rejected for capacity, which users experience as a failure. Right now, if 90% of user launches are failing because they all want to use the same repo, Grafana still looks like everything is perfect.

Alternative: separate metric entirely. Which one to go with depends a bit on whether we want this metric to represent _user_ launch attempts or _BinderHub_ launch attempts. We can make whatever chart we want either way, but that's how I'd think about it.