### PR TITLE
Support `...image.pull[Policy|Secrets]` consistently and hook into JupyterHub's chart wide configuration for imagePullSecrets

### DIFF
--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.image) }}
+      imagePullSecrets: {{ . }}
+      {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- . | toYaml | nindent 8 }}
@@ -70,12 +73,6 @@ spec:
 
       {{- with .Values.extraVolumes }}
       {{- . | toYaml | nindent 6 }}
-      {{- end }}
-      {{- with .Values.image.pullSecrets }}
-      imagePullSecrets:
-        {{- range . }}
-        - name: {{ . }}
-        {{- end }}
       {{- end }}
       containers:
       - name: binder

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -71,6 +71,12 @@ spec:
       {{- with .Values.extraVolumes }}
       {{- . | toYaml | nindent 6 }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: binder
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -18,6 +18,9 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.dind.daemonset.image) }}
+      imagePullSecrets: {{ . }}
+      {{- end }}
       tolerations:
       - effect: NoSchedule
         key: hub.jupyter.org/dedicated
@@ -35,6 +38,9 @@ spec:
       containers:
       - name: dind
         image: {{ .Values.dind.daemonset.image.name }}:{{ .Values.dind.daemonset.image.tag }}
+        {{- with .Values.dind.daemonset.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         resources:
           {{- .Values.dind.resources | toYaml | nindent 10 }}
         args:

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -19,6 +19,9 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.imageCleaner.image) }}
+      imagePullSecrets: {{ . }}
+      {{- end }}
       tolerations:
       - effect: NoSchedule
         key: hub.jupyter.org/dedicated
@@ -37,6 +40,9 @@ spec:
       {{- if or (and (eq $kind "dind") $Values.dind.enabled) (and (eq $kind "host") $Values.imageCleaner.host.enabled) }}
       - name: image-cleaner-{{ $kind }}
         image: {{ $Values.imageCleaner.image.name }}:{{ $Values.imageCleaner.image.tag }}
+        {{- with $Values.imageCleaner.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         volumeMounts:
         - name: dockerlib-{{ $kind }}
           mountPath: /var/lib/docker

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -18,6 +18,8 @@ nodeSelector: {}
 image:
   name: jupyterhub/k8s-binderhub
   tag: "set-by-chartpress"
+  pullPolicy: ""
+  pullSecrets: []
 
 # registry here is only used to create docker config.json
 registry:
@@ -252,6 +254,8 @@ dind:
     image:
       name: docker
       tag: 20.10.12-dind
+      pullPolicy: ""
+      pullSecrets: []
     # Additional command line arguments to pass to dockerd
     extraArgs: []
     lifecycle: {}
@@ -267,6 +271,8 @@ imageCleaner:
   image:
     name: quay.io/jupyterhub/docker-image-cleaner
     tag: 1.0.0-beta.2
+    pullPolicy: ""
+    pullSecrets: []
   # delete an image at most every 5 seconds
   delay: 5
   # Interpret threshold values as percentage or bytes


### PR DESCRIPTION
Fixing the unused image.pullSecrets value in the binderhub Deployment.

## Update by Erik

Thanks to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2546, we can hook into z2jh's chart wide configuration of imagePullSecrets. With this PR, we do that for all our pods where we specify an image.

I also added support for image.pullPolicy which wasn't supported in practice even though the schema supported it.