### PR TITLE
Bump version of docker used in image builder

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -243,7 +243,7 @@ dind:
   daemonset:
     image:
       name: docker
-      tag: 19.03.5-dind
+      tag: 20.10.12-dind
     # Additional command line arguments to pass to dockerd
     extraArgs: []
     lifecycle: {}


### PR DESCRIPTION
The version we were running was more than 2 years old,
and might also have other vulnerabilities that are not patched.

Fixes https://github.com/jupyterhub/binderhub/issues/1445