### PR TITLE
Fix mini-css-extract-plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "babel-loader": "^8.2.2",
     "css-loader": "^6.2.0",
     "eslint": "^7.32.0",
-    "mini-css-extract-plugin": "^2.3.0",
+    "mini-css-extract-plugin": "2.4.5",
     "webpack": "^5.52.1",
     "webpack-cli": "^4.8.0"
   },


### PR DESCRIPTION
Fixing the similar issue with `webpack` as in:
- https://github.com/facebook/create-react-app/issues/11930
