### PR TITLE
Update Turing Way's Zero-to-Binder link

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -19,7 +19,7 @@
         </div>
       </div>
       <div id="tutorials" class="text-center">
-        <h4>New to Binder? Get started with a Zero-to-Binder tutorial in <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-julia.md">Julia</a>, <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-python.md">Python</a> or <a href="https://github.com/alan-turing-institute/the-turing-way/blob/master/workshops/boost-research-reproducibility-binder/workshop-presentations/zero-to-binder-r.md">R</a>.</h4>
+        <h4>New to Binder? Get started with a <a href="https://the-turing-way.netlify.app/communication/binder/zero-to-binder.html" target="_blank">Zero-to-Binder tutorial</a> in Julia, Python, or R.</h4>
       </div>
       {% endblock header %}
 


### PR DESCRIPTION
The Zero-to-Binder tutorial maintained by the Turing Way has been moved into the book and now lives at the following URL (for all three languages!): https://the-turing-way.netlify.app/communication/binder/zero-to-binder.html