### PR TITLE
Fix broken link to Chart.yaml referenced logo

### DIFF
--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -21,7 +21,7 @@ description: |-
 keywords: [jupyter, jupyterhub, binderhub]
 home: https://binderhub.readthedocs.io/en/latest/
 sources: [https://github.com/jupyterhub/binderhub]
-icon: https://jupyter.org/assets/hublogo.svg
+icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
 kubeVersion: ">=1.17.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers


### PR DESCRIPTION
Mirrors https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2604.