### PR TITLE
Count repos across federation members in quota

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install requirements
+        run: pip install ruamel.yaml
+
       - name: check embedded chart code
         run: ./ci/check_embedded_chart_code.py
 

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -6,6 +6,7 @@ import ipaddress
 import json
 import logging
 import os
+import random
 import re
 import secrets
 from binascii import a2b_hex
@@ -612,6 +613,41 @@ class BinderHub(Application):
         """
     )
 
+    federation_id = Unicode(
+        config=True,
+        help="""
+        My id in the federation.
+
+        Used to exclude myself when checking federation members,
+        so all federation members can share the same federation config.
+        """,
+    )
+    federation_members = Dict(
+        key_trait=Unicode(),
+        value_trait=Unicode(),
+        config=True,
+        help="""
+        Dict of "federation-id": "url" for federation members.
+
+        Used for federation-wide application of quotas.
+        """,
+    )
+    federation_check_seconds = Integer(
+        180,
+        config=True,
+        help="""
+        Interval (in seconds) on which to check the health of other federtion members.
+        """,
+    )
+    federation_status = Dict(
+        key_trait=Unicode(),
+        value_trait=Dict(),
+        help="""status dict of federation members
+
+        Includes current counts of repos
+        """
+    )
+
     ban_networks = Dict(
         config=True,
         help="""
@@ -812,6 +848,7 @@ class BinderHub(Application):
                 "auth_enabled": self.auth_enabled,
                 "event_log": self.event_log,
                 "normalized_origin": self.normalized_origin,
+                "federation_status": self.federation_status,
             }
         )
         if self.auth_enabled:
@@ -874,6 +911,56 @@ class BinderHub(Application):
         self.http_server.stop()
         self.build_pool.shutdown()
 
+    def watch_federation(self):
+        """Watch federation members for their health, repo counts"""
+        if not self.federation_members:
+            # nothing to do
+            return
+        if not self.federation_id:
+            self.log.warning(
+                "BinderHub.federation_id not set, I don't know who I am in the federation!"
+            )
+
+        for federation_id, url in self.federation_members.items():
+            if federation_id != self.federation_id:
+                health_url = url_path_join(url, "health")
+                self.log.info(
+                    f"Watching federation member {federation_id} at {health_url}"
+                )
+                asyncio.ensure_future(
+                    self.watch_federation_member(federation_id, health_url)
+                )
+
+    async def watch_federation_member(self, federation_id, health_url):
+        """Long-running coroutine for checking health of one federation member"""
+        while True:
+            repo_counts = {}
+            try:
+                self.log.debug(
+                    f"Checking federation member {federation_id} at {health_url}"
+                )
+                response = await AsyncHTTPClient().fetch(health_url)
+                status = json.loads(response.body)
+                for check in status["checks"]:
+                    if check.get("service") == "Pod quota":
+                        print(check)
+                        total = check["total_pods"]
+                        quota  = check["quota"]
+                        self.log.debug(f"Federation member {federation_id} running {total}/{quota} pods")
+                        repo_counts = check.get("repo_counts", {})
+                        break
+                else:
+                    self.log.warning(f"No Pod quota check for {federation_id}: {status}")
+            except Exception as e:
+                self.log.error(f"Error checking federation member {federation_id}: {e}")
+
+            self.federation_status[federation_id] = {
+                "repo_counts": repo_counts,
+            }
+            # add some jitter, +/- 10%
+            t = self.federation_check_seconds * (0.9 + 0.2 * random.random())
+            await asyncio.sleep(t)
+
     async def watch_build_pods(self):
         """Watch build pods
 
@@ -905,6 +992,9 @@ class BinderHub(Application):
         self.http_server.listen(self.port)
         if self.builder_required:
             asyncio.ensure_future(self.watch_build_pods())
+        if self.federation_members:
+            self.watch_federation()
+
         if run_loop:
             tornado.ioloop.IOLoop.current().start()
 

--- a/binderhub/binderspawner_mixin.py
+++ b/binderhub/binderspawner_mixin.py
@@ -2,12 +2,12 @@
 Helpers for creating BinderSpawners
 
 FIXME:
-This file is defined in helm-chart/binderhub/values.yaml and is copied to
-binderhub/binderspawner_mixin.py by setup.py so that it can be used by other JupyterHub
-container spawners.
+This file is defined in binderhub/binderspawner_mixin.py
+and is copied to helm-chart/binderhub/values.yaml
+by ci/check_embedded_chart_code.py
 
-The BinderHub repo is just used as the distribution mechanism for this spawner, BinderHub
-itself doesn't require this code.
+The BinderHub repo is just used as the distribution mechanism for this spawner,
+BinderHub itself doesn't require this code.
 
 Longer term options include:
 - Move BinderSpawnerMixin to a separate Python package and include it in the Z2JH Hub

--- a/binderhub/binderspawner_mixin.py
+++ b/binderhub/binderspawner_mixin.py
@@ -87,6 +87,11 @@ class BinderSpawnerMixin(Configurable):
         return args
 
     def start(self):
+        annotations = self.extra_annotations
+        if "repo_url" in self.user_options:
+            annotations["binder.hub.jupyter.org/repo_url"]: self.user_options["repo_url"]
+        if "binder_ref_url" in self.user_options:
+            annotations["binder.hub.jupyter.org/ref_url"]: self.user_options["binder_ref_url"]
         if not self.auth_enabled:
             if 'token' not in self.user_options:
                 raise web.HTTPError(400, "token required")

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -553,6 +553,9 @@ class BuildHandler(BaseHandler):
             for pod in pods:
                 if pod["metadata"]["annotations"].get("binder.hub.jupyter.org/repo_url") == self.repo_url:
                     matching_pods += 1
+            for federation_id, fed_info in self.settings["federation_status"].items():
+                repo_counts = fed_info.get("repo_counts", {})
+                matching_pods += repo_counts.get(self.repo_url, 0)
 
             if repo_quota and matching_pods >= repo_quota:
                 LAUNCH_COUNT.labels(

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -551,13 +551,8 @@ class BuildHandler(BaseHandler):
                 return
 
             for pod in pods:
-                for container in pod["spec"]["containers"]:
-                    # is the container running the same image as us?
-                    # if so, count one for the current repo.
-                    image = container["image"].rsplit(":", 1)[0]
-                    if image == image_no_tag:
-                        matching_pods += 1
-                        break
+                if pod["metadata"]["annotations"].get("binder.hub.jupyter.org/repo_url") == self.repo_url:
+                    matching_pods += 1
 
             if repo_quota and matching_pods >= repo_quota:
                 LAUNCH_COUNT.labels(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,10 +10,6 @@ pycurl
 pytest
 pytest-asyncio
 pytest-cov
-# pyyaml is used by the scripts in tools/ and could absolutely be replaced by
-# using ruamel.yaml. ruamel.yaml is more powerful than pyyaml, and that is
-# relevant when writing YAML files back after having loaded them from disk.
-pyyaml
 jupyter-repo2docker>=2021.08.0
 requests
 ruamel.yaml>=0.15

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -2,7 +2,9 @@ from collections.abc import Mapping
 import os
 from functools import lru_cache
 from urllib.parse import urlparse
-import yaml
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")
 
 
 def _merge_dictionaries(a, b):
@@ -34,7 +36,7 @@ def _load_values():
         if os.path.exists(path):
             print(f"Loading {path}")
             with open(path) as f:
-                values = yaml.safe_load(f)
+                values = yaml.load(f)
             cfg = _merge_dictionaries(cfg, values)
         else:
             print(f"No config at {path}")

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -68,12 +68,12 @@ jupyterhub:
         Helpers for creating BinderSpawners
 
         FIXME:
-        This file is defined in helm-chart/binderhub/values.yaml and is copied to
-        binderhub/binderspawner_mixin.py by setup.py so that it can be used by other JupyterHub
-        container spawners.
+        This file is defined in binderhub/binderspawner_mixin.py
+        and is copied to helm-chart/binderhub/values.yaml
+        by ci/check_embedded_chart_code.py
 
-        The BinderHub repo is just used as the distribution mechanism for this spawner, BinderHub
-        itself doesn't require this code.
+        The BinderHub repo is just used as the distribution mechanism for this spawner,
+        BinderHub itself doesn't require this code.
 
         Longer term options include:
         - Move BinderSpawnerMixin to a separate Python package and include it in the Z2JH Hub

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -153,6 +153,11 @@ jupyterhub:
                 return args
 
             def start(self):
+                annotations = self.extra_annotations
+                if "repo_url" in self.user_options:
+                    annotations["binder.hub.jupyter.org/repo_url"]: self.user_options["repo_url"]
+                if "binder_ref_url" in self.user_options:
+                    annotations["binder.hub.jupyter.org/ref_url"]: self.user_options["binder_ref_url"]
                 if not self.auth_enabled:
                     if 'token' not in self.user_options:
                         raise web.HTTPError(400, "token required")

--- a/tools/generate-json-schema.py
+++ b/tools/generate-json-schema.py
@@ -14,7 +14,8 @@ import os
 
 from collections.abc import MutableMapping
 
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML(typ="safe")
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
 schema_yaml = os.path.join(
@@ -50,7 +51,7 @@ def run():
     # Using these sets, we can validate further manually by printing the results
     # of set operations.
     with open(schema_yaml) as f:
-        schema = yaml.safe_load(f)
+        schema = yaml.load(f)
 
     # Drop what isn't relevant for a values.schema.json file packaged with the
     # Helm chart, such as the description keys only relevant for our

--- a/tools/validate-against-schema.py
+++ b/tools/validate-against-schema.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-import jsonschema
 import os
-import yaml
+
+import jsonschema
+from ruamel.yaml import YAML
+yaml = YAML(typ="safe")
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
 schema_yaml = os.path.join(
@@ -18,13 +20,13 @@ binderhub_chart_config_yaml = os.path.join(
 )
 
 with open(schema_yaml) as f:
-    schema = yaml.safe_load(f)
+    schema = yaml.load(f)
 with open(values_yaml) as f:
-    values = yaml.safe_load(f)
+    values = yaml.load(f)
 with open(lint_and_validate_values_yaml) as f:
-    lint_and_validate_values = yaml.safe_load(f)
+    lint_and_validate_values = yaml.load(f)
 with open(binderhub_chart_config_yaml) as f:
-    binderhub_chart_config_yaml = yaml.safe_load(f)
+    binderhub_chart_config_yaml = yaml.load(f)
 
 # Validate values.yaml against schema
 print("Validating values.yaml against schema.yaml...")


### PR DESCRIPTION
This is an alternative to #1460, also for https://github.com/jupyterhub/mybinder.org-deploy/issues/2143

Unlike #1460, it keeps all the definitions of quotas and such, except:

1. repo counts are added to health check reports (doesn't require any additional k8s API calls, since we already collect them for the count)
2. each federation member collects repo counts from the health endpoint of each _other_ federation member
3. repo_quota is measured against the sum of all federation members, instead of only the current instance

This is quite a bit simpler thank #1460, but potentially more costly (I'm not sure)

Additionally, I placed the binder repo_url in pod annotations, for easier lookup.

includes #1459 