### PR TITLE
helm chart: fix typo in schema and support global values

### DIFF
--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -11,7 +11,7 @@
 #
 # ref: https://json-schema.org/learn/getting-started-step-by-step.html
 #
-$schema": http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-07/schema#
 type: object
 additionalProperties: false
 required:

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -36,6 +36,7 @@ required:
   - extraVolumeMounts
   - extraEnv
   - podAnnotations
+  - global
 properties:
 
   pdb: &pdb-spec
@@ -561,3 +562,8 @@ properties:
     additionalProperties: true
     description: |
       DEPRECATED.
+
+# A placeholder as global values that can be referenced from the same location
+# of any chart should be possible to provide, but aren't necessarily provided or
+# used.
+global: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -302,3 +302,5 @@ podAnnotations: {}
 
 # Deprecated values, kept here so we can provide useful error messages
 cors: {}
+
+global: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -149,3 +149,6 @@ extraEnv: &extraEnv
   MOCK_ENV_VAR_NAME2:
     value: MOCK_ENV_VAR_VALUE2
 podAnnotations: *annotations
+
+global:
+  dummyConfigKey: "test"


### PR DESCRIPTION
I figure all Helm charts should allow `global` to be set, this change makes the schema accept `global` values to be passed. It also makes fixes a harmless typo.