### PR TITLE
pre-commit: fix pre-commit.ci failure by declaring ruamel.yaml as dep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,10 @@ repos:
   #   more details.
   - repo: local
     hooks:
-      - id: update-values-based-on-bindarspawner-mixin
+      - id: update-values-based-on-binderspawner-mixin
         name: Update helm-chart/binderhub/values.yaml based on binderhub/binderspawner_mixin.py
-        language: system
+        language: conda
+        additional_dependencies: ["ruamel.yaml"]
         entry: python ci/check_embedded_chart_code.py
         args:
           - --update


### PR DESCRIPTION
In #1465 I added a script that didn't manage to run in pre-commit.ci because of an undeclared dependency.