### PR TITLE
Main page footer can be overridden

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -145,10 +145,10 @@ class BinderHub(Application):
         config=True,
     )
 
-    main_footer_message = Unicode(
+    about_summary_message = Unicode(
         "",
         help="""
-        Override the footer on the main page.
+        An optional summary that appears on all pages apart from the about page.
 
         The value will be inserted "as is". Raw HTML is supported.
         """,
@@ -832,7 +832,7 @@ class BinderHub(Application):
                 "google_analytics_domain": self.google_analytics_domain,
                 "about_message": self.about_message,
                 "banner_message": self.banner_message,
-                "main_footer_message": self.main_footer_message,
+                "about_summary_message": self.about_summary_message,
                 "extra_footer_scripts": self.extra_footer_scripts,
                 "jinja2_env": jinja_env,
                 "build_memory_limit": self.build_memory_limit,

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -145,6 +145,16 @@ class BinderHub(Application):
         config=True,
     )
 
+    main_footer_message = Unicode(
+        "",
+        help="""
+        Override the footer on the main page.
+
+        The value will be inserted "as is". Raw HTML is supported.
+        """,
+        config=True,
+    )
+
     extra_footer_scripts = Dict(
         {},
         help="""
@@ -822,6 +832,7 @@ class BinderHub(Application):
                 "google_analytics_domain": self.google_analytics_domain,
                 "about_message": self.about_message,
                 "banner_message": self.banner_message,
+                "main_footer_message": self.main_footer_message,
                 "extra_footer_scripts": self.extra_footer_scripts,
                 "jinja2_env": jinja_env,
                 "build_memory_limit": self.build_memory_limit,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -36,7 +36,7 @@ class MainHandler(BaseHandler):
             submit=False,
             google_analytics_code=self.settings["google_analytics_code"],
             google_analytics_domain=self.settings["google_analytics_domain"],
-            main_footer_message=self.settings["main_footer_message"],
+            about_summary_message=self.settings["about_summary_message"],
             extra_footer_scripts=self.settings["extra_footer_scripts"],
             repo_providers=self.settings["repo_providers"],
         )
@@ -123,6 +123,7 @@ class ParameterizedMainHandler(BaseHandler):
             submit=True,
             google_analytics_code=self.settings["google_analytics_code"],
             google_analytics_domain=self.settings["google_analytics_domain"],
+            about_summary_message=self.settings["about_summary_message"],
             extra_footer_scripts=self.settings["extra_footer_scripts"],
         )
 

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -36,6 +36,7 @@ class MainHandler(BaseHandler):
             submit=False,
             google_analytics_code=self.settings["google_analytics_code"],
             google_analytics_domain=self.settings["google_analytics_domain"],
+            main_footer_message=self.settings["main_footer_message"],
             extra_footer_scripts=self.settings["extra_footer_scripts"],
             repo_providers=self.settings["repo_providers"],
         )

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -195,7 +195,15 @@
 {% endblock main %}
 
 {% block footer %}
+
+{% if main_footer_message %}
+<div class="container">
+  {{ main_footer_message | safe }}
+</div>
+{% else %}
 {{ super () }}
+{% endif %}
+
 <script type="text/javascript">
 indexMain();
 </script>

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -195,15 +195,7 @@
 {% endblock main %}
 
 {% block footer %}
-
-{% if main_footer_message %}
-<div class="container">
-  {{ main_footer_message | safe }}
-</div>
-{% else %}
 {{ super () }}
-{% endif %}
-
 <script type="text/javascript">
 indexMain();
 </script>

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -39,6 +39,14 @@
   {% block main %}
   {% endblock main %}
 
+  {% block about_summary %}
+  {% if about_summary_message %}
+  <div class="container">
+    {{ about_summary_message | safe }}
+  </div>
+  {% endif %}
+  {% endblock about_summary %}
+
   {% block footer %}
   <div class="container">
     <div class="row text-center">

--- a/testing/local-binder-local-hub/binderhub_config.py
+++ b/testing/local-binder-local-hub/binderhub_config.py
@@ -29,6 +29,7 @@ c.BinderHub.about_message = "This is a local dev deployment without Kubernetes"
 c.BinderHub.banner_message = (
     'See <a href="https://github.com/jupyterhub/binderhub">BinderHub on GitHub</a>'
 )
+c.BinderHub.main_footer_message = '<div class="row text-center" style="transform:rotate(10deg);padding-top:3em;"><h3>This is a custom footer message.</h3></div>'
 
 c.BinderHub.hub_url_local = "http://localhost:8000"
 

--- a/testing/local-binder-local-hub/binderhub_config.py
+++ b/testing/local-binder-local-hub/binderhub_config.py
@@ -29,7 +29,7 @@ c.BinderHub.about_message = "This is a local dev deployment without Kubernetes"
 c.BinderHub.banner_message = (
     'See <a href="https://github.com/jupyterhub/binderhub">BinderHub on GitHub</a>'
 )
-c.BinderHub.main_footer_message = '<div class="row text-center" style="transform:rotate(10deg);padding-top:3em;"><h3>This is a custom footer message.</h3></div>'
+c.BinderHub.about_summary_message = '<div class="row text-center" style="transform:rotate(10deg);padding-top:3em;"><h3>This is a summary of the about message.</h3></div>'
 
 c.BinderHub.hub_url_local = "http://localhost:8000"
 


### PR DESCRIPTION
This allows the footer on the main (index) page to be replaced with custom HTML.

Related to https://github.com/jupyterhub/mybinder.org-deploy/issues/2156

Current default:
![image](https://user-images.githubusercontent.com/1644105/164896847-caa87e27-b1f2-4f54-8a18-fa60e73d4d81.png)

With ` c.BinderHub.main_footer_message = '<div class="row text-center" style="transform:rotate(10deg);padding-top:3em;"><h3>This is a custom footer message.</h3></div>'`:
![image](https://user-images.githubusercontent.com/1644105/164896866-4263108b-9583-4f72-a905-40e5a34e9c4a.png)

I decided to override the main page footer instead of prefixing/suffixing it to give us more flexibility in layout.