### PR TITLE
ci: add workflow to bump helm chart image dependencies

### DIFF
--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -20,6 +20,7 @@ on:
     branches-ignore:
       - "dependabot/**"
       - "pre-commit-ci-update-config"
+      - "update-*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -1,0 +1,89 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+# - Watch multiple images tags referenced in values.yaml to match the latest
+#   stable image tag (ignoring pre-releases).
+#
+name: Watch dependencies
+
+on:
+  push:
+    paths:
+      - ".github/workflows/watch-dependencies.yaml"
+  schedule:
+    # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-image-dependencies:
+    # Don't run this job on forks
+    if: github.repository == 'jupyterhub/binderhub'
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: docker
+            registry: registry.hub.docker.com
+            repository: library/docker
+            values_path: dind.daemonset.image.tag
+
+          # FIXME: After docker-image-cleaner 1.0.0 is released, we can enable
+          #        this. So far, there isn't any available stable release, and
+          #        due to that our regexp fails to match anything at all.
+          #
+          # - name: docker-image-cleaner
+          #   registry: quay.io
+          #   repository: jupyterhub/docker-image-cleaner
+          #   values_path: imageCleaner.image.tag
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get values.yaml pinned tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: local
+        run: |
+          local_tag=$(cat helm-chart/binderhub/values.yaml | yq e '.${{ matrix.values_path }}' -)
+          echo "::set-output name=tag::$local_tag"
+
+      - name: Get latest tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: latest
+        # The skopeo image helps us list tags consistently from different docker
+        # registries. We use jq to filter out tags of the x.y or x.y.z format
+        # with the optional v prefix or version_startswith filter, and then sort
+        # based on the numerical x, y, and z values. Finally, we pick the last
+        # value in the list.
+        #
+        run: |
+          latest_tag=$(
+              docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
+            | jq -r '[.Tags[] | select(. | match("^\\d+\\.\\d+\\.\\d+$") | .string)] | sort_by(split(".") | map(tonumber)) | last'
+          )
+          echo "::set-output name=tag::$latest_tag"
+
+      - name: Update values.yaml pinned tag
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        run: |
+          sed --in-place 's/tag: "${{ steps.local.outputs.tag }}"/tag: "${{ steps.latest.outputs.tag }}"/g' helm-chart/binderhub/values.yaml
+
+      - name: git diff
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - name: Create a PR
+        if: steps.local.outputs.tag != steps.latest.outputs.tag
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          token: "${{ secrets.jupyterhub_bot_pat }}"
+          author: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          committer: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          branch: update-image-${{ matrix.name }}
+          labels: maintenance,dependencies
+          commit-message: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          title: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          body: >-
+            A new ${{ matrix.repository }} image version has been detected, version
+            `${{ steps.latest.outputs.tag }}`.


### PR DESCRIPTION
I added a workflow to z2jh to automatically bump the version of various images after learning how to do this quite reliably independent of container registries when assisting in dask/helm-chart.

This is the equivalent for that work in z2jh (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2711), but for the binderhub helm chart.

---

The CI system fails for some unrelated reason...