### PR TITLE
Bump docker-image-cleaner to 1.0.0-beta.1

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -261,7 +261,7 @@ imageCleaner:
   enabled: true
   image:
     name: quay.io/jupyterhub/docker-image-cleaner
-    tag: 1.0.0-alpha.2
+    tag: 1.0.0-beta.1
   # delete an image at most every 5 seconds
   delay: 5
   # Interpret threshold values as percentage or bytes


### PR DESCRIPTION
The CI system fails for some unrelated reason of some kind, accessing a RTD link that works to access from my computer.