### PR TITLE
docs: prefer use of https over http

### DIFF
--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -177,7 +177,7 @@
         <span class="point point-red">2</span>
       </div>
       <div class="col-md-7 front">
-        <span class="front-em">We build a Docker image of your repository</span><br />Binder will search for a dependency file, such as requirements.txt or environment.yml, in the repository's root directory (<a href="http://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder">more details on more complex dependencies in documentation</a>). The dependency files will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
+        <span class="front-em">We build a Docker image of your repository</span><br />Binder will search for a dependency file, such as requirements.txt or environment.yml, in the repository's root directory (<a href="https://mybinder.readthedocs.io/en/latest/using.html#preparing-a-repository-for-binder">more details on more complex dependencies in documentation</a>). The dependency files will be used to build a Docker image. If an image has already been built for the given repository, it will not be rebuilt. If a new commit has been made, the image will automatically be rebuilt.
       </div>
     </div>
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -128,7 +128,7 @@ Ready
 When your notebook is ready! You get a endpoint URL and a token used to
 access it. You can access the notebook / API by using the token in one
 of the ways the `notebook accepts security
-tokens <http://jupyter-notebook.readthedocs.io/en/stable/security.html>`__.
+tokens <https://jupyter-notebook.readthedocs.io/en/stable/security.html>`__.
 
 ::
 

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -25,7 +25,7 @@ you need to add the following into ``config.yaml``:
         services:
           binder:
             oauth_no_confirm: true
-            oauth_redirect_uri: "http://<binderhub_url>/oauth_callback"
+            oauth_redirect_uri: "https://<binderhub_url>/oauth_callback"
             oauth_client_id: "binder-oauth-client-test"
 
       singleuser:

--- a/doc/zero-to-binderhub/setup-prerequisites.rst
+++ b/doc/zero-to-binderhub/setup-prerequisites.rst
@@ -3,7 +3,7 @@
 Set up the prerequisites
 ========================
 
-BinderHub is built to run in a `Kubernetes cluster <http://kubernetes.io/>`_. It
+BinderHub is built to run in a `Kubernetes cluster <https://kubernetes.io/>`_. It
 relies on JupyterHub to launch and manage user servers, as well as a docker
 registry to cache docker images it builds.
 

--- a/doc/zero-to-binderhub/setup-registry.rst
+++ b/doc/zero-to-binderhub/setup-registry.rst
@@ -172,4 +172,4 @@ Next step
 
 Now that our cloud resources are set up, it's time to :doc:`setup-binderhub`.
 
-.. _console.cloud.google.com: http://console.cloud.google.com
+.. _console.cloud.google.com: https://console.cloud.google.com

--- a/versioneer.py
+++ b/versioneer.py
@@ -1994,7 +1994,7 @@ def do_setup():
     except EnvironmentError:
         pass
     # That doesn't cover everything MANIFEST.in can do
-    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # (https://docs.python.org/2/distutils/sourcedist.html#commands), so
     # it might give some false negatives. Appending redundant 'include'
     # lines is safe, though.
     if "versioneer.py" not in simple_includes:


### PR DESCRIPTION
This is a PR looking to fix our currently broken tests, where we get a 403 response from visiting http://mybinder.readthedocs.io/en/latest/using/using.html#preparing-a-repository-for-binder. I'm not sure why, but I figure we should try using https:// instead as done in this PR. This PR also updates a few other links to use https:// instead of http://.

This apparently didn't resolve the test errors. I'm not sure why we get 403 from readthedocs when accessed via our GitHub runners, but with this we can rule out its related to the use of http:// over https:// at least.