### PR TITLE
breaking: start require k8s 1.20+ and test against k8s 1.20 and latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,15 +56,14 @@ jobs:
           - helm
         include:
           # Chart.yaml contains the chart's oldest supported k8s version, we
-          # want to test against that. We also test against the oldest known
-          # supported helm cli version which isn't documented anywhere, but is
-          # currently at 3.5.0. Currently we have listed 1.17 in Chart.yaml, but
-          # due to a k3s issue with their k8s 1.17 release, we can't test
-          # against k8s 1.17 and settle for k8s 1.18 for now.
-          - k3s-channel: v1.18
+          # test against that and the oldest known supported helm cli version
+          # which isn't documented anywhere, but is currently at 3.5.0. We also
+          # test with the latest k8s and helm versions.
+          #
+          - k3s-channel: v1.20
             helm-version: v3.5.0
             test: helm
-          - k3s-channel: stable
+          - k3s-channel: latest
             test: helm
             test-variation: upgrade
             # upgrade-from represents a release channel, see: https://jupyterhub.github.io/helm-chart/info.json

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -22,7 +22,7 @@ keywords: [jupyter, jupyterhub, binderhub]
 home: https://binderhub.readthedocs.io/en/latest/
 sources: [https://github.com/jupyterhub/binderhub]
 icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.17.0-0"
+kubeVersion: ">=1.20.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team


### PR DESCRIPTION
Is the mybinder.org federation beyond k8s 1.19 at this point?

Z2JH requires k8s 1.20 currently, see https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2635. @manics made a great job documenting the status of various cloud providers in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2591#issuecomment-1048790139. In short, k8s 1.19 is not supported by Google, Amazon, or Azure.

While we could wait to bump this until we run into a need raise the lower level, I'd prefer to not wait. If we realize there is a need to raise the lower lever, then suddenly the person fixing something ends up needing to side-track and do this breaking change first before etc. In other words, by doing this now, we avoid slowing down and blocking something else when we really need to do it.