### PR TITLE
docker-image-cleaner 1.0.0-beta.2

### DIFF
--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -43,19 +43,19 @@ spec:
         - name: dockersocket-{{ $kind }}
           mountPath: /var/run/docker.sock
         env:
-        - name: NODE_NAME
+        - name: DOCKER_IMAGE_CLEANER_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: PATH_TO_CHECK
+        - name: DOCKER_IMAGE_CLEANER_PATH_TO_CHECK
           value: /var/lib/docker
-        - name: IMAGE_GC_DELAY
+        - name: DOCKER_IMAGE_CLEANER_DELAY_SECONDS
           value: {{ $Values.imageCleaner.delay | quote }}
-        - name: IMAGE_GC_THRESHOLD_TYPE
+        - name: DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE
           value: {{ $Values.imageCleaner.imageGCThresholdType | quote }}
-        - name: IMAGE_GC_THRESHOLD_HIGH
+        - name: DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH
           value: {{ $Values.imageCleaner.imageGCThresholdHigh | quote }}
-        - name: IMAGE_GC_THRESHOLD_LOW
+        - name: DOCKER_IMAGE_CLEANER_THRESHOLD_LOW
           value: {{ $Values.imageCleaner.imageGCThresholdLow | quote }}
       {{- end }}
       {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -261,7 +261,7 @@ imageCleaner:
   enabled: true
   image:
     name: quay.io/jupyterhub/docker-image-cleaner
-    tag: 1.0.0-beta.1
+    tag: 1.0.0-beta.2
   # delete an image at most every 5 seconds
   delay: 5
   # Interpret threshold values as percentage or bytes


### PR DESCRIPTION
Bring in https://github.com/jupyterhub/docker-image-cleaner/pull/51 to fix disk space issues on mybinder.org