### PR TITLE
[WIP] ProxyRepoProvider which routes requests to existing repoprovider based on external api

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -62,6 +62,7 @@ from .repoproviders import (
     HydroshareProvider,
     RepoProvider,
     ZenodoProvider,
+    ProxyRepoProvider
 )
 from .utils import ByteSpecification, url_path_join
 
@@ -517,6 +518,7 @@ class BinderHub(Application):
             "figshare": FigshareProvider,
             "hydroshare": HydroshareProvider,
             "dataverse": DataverseProvider,
+            "proxy": ProxyRepoProvider,
         },
         config=True,
         help="""

--- a/binderhub/event-schemas/launch.json
+++ b/binderhub/event-schemas/launch.json
@@ -14,7 +14,8 @@
         "Zenodo",
         "Figshare",
         "Hydroshare",
-        "Dataverse"
+        "Dataverse",
+        "Proxy"
       ],
       "description": "Provider for the repository being launched"
     },

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -21,6 +21,7 @@ SPEC_NAMES = {
     "figshare": "Figshare",
     "hydroshare": "Hydroshare",
     "dataverse": "Dataverse",
+    "proxy": "Proxy"
 }
 
 

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -114,7 +114,7 @@ function getBuildFormValues() {
 
   let ref = $('#ref').val().trim() || $("#ref").attr("placeholder");
   if (providerPrefix === 'zenodo' || providerPrefix === 'figshare' || providerPrefix === 'dataverse' ||
-      providerPrefix === 'hydroshare') {
+      providerPrefix === 'hydroshare' || providerPrefix === 'proxy') {
     ref = "";
   }
   const path = $('#filepath').val().trim();


### PR DESCRIPTION
## What does this do?

This creates a RepoProvider subclass that allows for routing spec resolution through an external API. This has benefits for my use case and may or may not be useful enough to warrant inclusion in binderhub. The most direct use case is that this allows for a dynamic list of allowed repositories #280, which could be useful for organizations that wish to host a binderhub with the ability to regulate repositories that are available.

## How else can this be done?

This can be done through extraConfig. Due to `SPEC_NAMES` in `main.py` however, the repoprovider would have to be routed through an existing provider name, which seems somewhat hacky. Another potential update would be making all references to the list of repoproviders configurable. This might also be related to a solution to #322