### PR TITLE
Add `capabilities`/`privileged` to build container to support running on K8s without Docker 

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -410,16 +410,19 @@ class BinderHub(Application):
 
         Currently, only paths are supported, and they are expected to be available on
         all the hosts.
+
+        Set to empty to disable the docker socket mount.
         """,
     )
 
     @validate("build_docker_host")
     def docker_build_host_validate(self, proposal):
-        parts = urlparse(proposal.value)
-        if parts.scheme != "unix" or parts.netloc != "":
-            raise TraitError(
-                "Only unix domain sockets on same node are supported for build_docker_host"
-            )
+        if proposal.value:
+            parts = urlparse(proposal.value)
+            if parts.scheme != "unix" or parts.netloc != "":
+                raise TraitError(
+                    "Only unix domain sockets on same node are supported for build_docker_host"
+                )
         return proposal.value
 
     build_docker_config = Dict(

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -30,6 +30,7 @@ from traitlets import (
     Bytes,
     Dict,
     Integer,
+    List,
     TraitError,
     Type,
     Unicode,
@@ -502,6 +503,17 @@ class BinderHub(Application):
         config=True,
     )
 
+    build_capabilities = List(
+        [],
+        help="""
+        Additional Kubernetes capabilities to add to the build container
+
+        If the special string "privileged" is found the container is run in
+        privileged mode and other capabilities are ignored.
+        """,
+        config=True,
+    )
+
     build_node_selector = Dict(
         {},
         config=True,
@@ -805,6 +817,7 @@ class BinderHub(Application):
                 "ban_networks_min_prefix_len": self.ban_networks_min_prefix_len,
                 "build_namespace": self.build_namespace,
                 "build_image": self.build_image,
+                "build_capabilities": self.build_capabilities,
                 "build_node_selector": self.build_node_selector,
                 "build_pool": self.build_pool,
                 "build_token_check_origin": self.build_token_check_origin,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -393,6 +393,13 @@ class Build:
                 client.V1EnvVar(name="GIT_CREDENTIAL_ENV", value=self.git_credentials)
             )
 
+        if "privileged" in self.build_capabilities:
+            security_context = client.V1SecurityContext(privileged=True)
+        else:
+            security_context = client.V1SecurityContext(
+                capabilities=client.V1Capabilities(add=self.build_capabilities)
+            )
+
         self.pod = client.V1Pod(
             metadata=client.V1ObjectMeta(
                 name=self.name,
@@ -416,11 +423,7 @@ class Build:
                             requests={"memory": self.memory_request},
                         ),
                         env=env,
-                        security_context=client.V1SecurityContext(
-                            capabilities=client.V1Capabilities(
-                                add=self.build_capabilities
-                            )
-                        ),
+                        security_context=security_context,
                     )
                 ],
                 tolerations=[

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -124,6 +124,7 @@ class LocalRepo2dockerBuild(Build):
         build_image,
         docker_host,
         image_name,
+        build_capabilities=None,
         git_credentials=None,
         push_secret=None,
         memory_limit=0,
@@ -151,6 +152,7 @@ class LocalRepo2dockerBuild(Build):
             Ref of repository to build
             Passed through to repo2docker.
         build_image : ignored
+        build_capabilities: ignored
         docker_host : ignored
         image_name : str
             Full name of the image to build. Includes the tag.

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -436,6 +436,7 @@ class BuildHandler(BaseHandler):
             image_name=image_name,
             push_secret=push_secret,
             build_image=self.settings["build_image"],
+            build_capabilities=self.settings["build_capabilities"],
             memory_limit=self.settings["build_memory_limit"],
             memory_request=self.settings["build_memory_request"],
             docker_host=self.settings["build_docker_host"],


### PR DESCRIPTION
I thought it'd be interesting to get BinderHub running on K8S without Docker. This is the first step:
- `build_docker_host` is optional
- support for adding capabilities to the build container, or running it as privileged (https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1SecurityContext.md)

I've only added one new config, `build_capabilities`, and overloaded it to set `privileged=True`. Alternatives include:
- separate config for `capabilities` and `privileged`
- allowing the full security_context to be specified- this would be the most flexible, but looking at https://github.com/kubernetes-client/python/issues/977 it doesn't sound like it's possible to construct the a Kubernetes object form JSON... unless someone knows a way to do so?