### PR TITLE
Using escaped username in progress api call affecting launch of serve…

### DIFF
--- a/binderhub/launcher.py
+++ b/binderhub/launcher.py
@@ -302,7 +302,7 @@ class Launcher(LoggingConfigurable):
                                     )
                                 )
 
-            url_parts = ["users", username]
+            url_parts = ["users", escaped_username]
             if server_name:
                 url_parts.extend(["servers", server_name, "progress"])
             else:


### PR DESCRIPTION
Hi,

This PR aims to solve launch issues where binderhub would call the server progress api with an unescaped username, causing a 400 Bad Request to be thrown by the server. In turn, this would fail the server execution and launch another server, up to a maximum of 4 server. This behavior should also be addressed, in another PR.

Signed-off-by: Pedro Osório <pedro.osorio@atlar.pt>