### PR TITLE
Check for low-level errors when submitting builds

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -460,6 +460,7 @@ class BuildHandler(BaseHandler):
                     app_log.error("task failed: %s", exc_info=True)
                     done = True
                     failed = True
+                    # TODO: Propagate error to front-end
 
             build_starttime = time.perf_counter()
             pool = self.settings["build_pool"]

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -457,7 +457,7 @@ class BuildHandler(BaseHandler):
                     r = future.result()
                     app_log.debug("task completed: %s", r)
                 except Exception:
-                    app_log.error("task failed: %s", exc_info=True)
+                    app_log.error("task failed", exc_info=True)
                     done = True
                     failed = True
                     # TODO: Propagate error to front-end


### PR DESCRIPTION
The builder uses `pool.submit` to submit a task, but it doesn't check that the task was successfully submitted. Instead it relies on progress events being pushed to a shared queue. If there is an error in the task it will hang forever waiting for a non-existing item to be pushed to the queue.

`add_done_callback` will be called when the task is finished.
- https://docs.python.org/3/library/asyncio-future.html#asyncio.Future.add_done_callback
- https://stackoverflow.com/questions/53701841/what-is-the-use-case-for-future-add-done-callback

Since these are likely to be internal BinderHub development errors this just generates an exception in the logs. In theory it should be possible to push an event that the user can see, but when I tried this it didn't work- I think there may be a race condition between the task ending and the events appearing in the queue, and given that it's been fine up to now I think just exposing it in the BinderHub logs is good enough.

For example, modify `FakeBuild.stream_logs` to include `print(non_existent_variable)`. Without this PR there is no indication that anything is wrong.