### PR TITLE
If build pod is deleted check status instead of assuming Succeeded

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -460,11 +460,22 @@ class KubernetesBuildExecutor(BuildExecutor):
                     _request_timeout=KUBE_REQUEST_TIMEOUT,
                 ):
                     if f["type"] == "DELETED":
-                        # Assume this is a successful completion
-                        self.progress(
-                            ProgressEvent.Kind.BUILD_STATUS_CHANGE,
-                            ProgressEvent.BuildStatus.COMPLETED,
+                        phase = f["object"].status.phase
+                        app_log.debug(
+                            "Pod %s was deleted with phase %s",
+                            f["object"].metadata.name,
+                            phase,
                         )
+                        if phase == "Succeeded":
+                            self.progress(
+                                ProgressEvent.Kind.BUILD_STATUS_CHANGE,
+                                ProgressEvent.BuildStatus.COMPLETED,
+                            )
+                        else:
+                            self.progress(
+                                ProgressEvent.Kind.BUILD_STATUS_CHANGE,
+                                ProgressEvent.BuildStatus.FAILED,
+                            )
                         return
                     self.pod = f["object"]
                     if not self.stop_event.is_set():

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -472,7 +472,7 @@ class KubernetesBuildExecutor(BuildExecutor):
                         if phase == "Succeeded":
                             self.progress(
                                 ProgressEvent.Kind.BUILD_STATUS_CHANGE,
-                                ProgressEvent.BuildStatus.COMPLETED,
+                                ProgressEvent.BuildStatus.BUILT,
                             )
                         else:
                             self.progress(
@@ -713,7 +713,7 @@ class FakeBuild(BuildExecutor):
                 ),
             )
         self.progress(
-            ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.COMPLETED
+            ProgressEvent.Kind.BUILD_STATUS_CHANGE, ProgressEvent.BuildStatus.BUILT
         )
         self.progress(
             "log",

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -40,9 +40,6 @@ class ProgressEvent:
         The state the build is now in
 
         Used when `kind` is `Kind.BUILD_STATUS_CHANGE`
-
-        These enum values are referenced in the front-end to display the build status,
-        hence the mismatch between the Enum name (backend) and value (frontend).
         """
 
         PENDING = "pending"

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -47,7 +47,7 @@ class ProgressEvent:
 
         PENDING = "pending"
         RUNNING = "running"
-        COMPLETED = "built"
+        BUILT = "built"
         FAILED = "failed"
         UNKNOWN = "unknown"
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -40,13 +40,16 @@ class ProgressEvent:
         The state the build is now in
 
         Used when `kind` is `Kind.BUILD_STATUS_CHANGE`
+
+        These enum values are referenced in the front-end to display the build status,
+        hence the mismatch between the Enum name (backend) and value (frontend).
         """
 
-        PENDING = 1
-        RUNNING = 2
-        COMPLETED = 3
-        FAILED = 4
-        UNKNOWN = 5
+        PENDING = "pending"
+        RUNNING = "running"
+        COMPLETED = "built"
+        FAILED = "failed"
+        UNKNOWN = "unknown"
 
     def __init__(self, kind: Kind, payload: Union[str, BuildStatus]):
         self.kind = kind

--- a/binderhub/build_local.py
+++ b/binderhub/build_local.py
@@ -140,7 +140,7 @@ class LocalRepo2dockerBuild(BuildExecutor):
                 self._handle_log(line)
             self.progress(
                 ProgressEvent.Kind.BUILD_STATUS_CHANGE,
-                ProgressEvent.BuildStatus.COMPLETED,
+                ProgressEvent.BuildStatus.BUILT,
             )
         except subprocess.CalledProcessError:
             self.progress(

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -509,12 +509,13 @@ class BuildHandler(BaseHandler):
                 # FIXME: If pod goes into an unrecoverable stage, such as ImagePullBackoff or
                 # whatever, we should fail properly.
                 if progress.kind == ProgressEvent.Kind.BUILD_STATUS_CHANGE:
+                    phase = progress.payload.value
                     if progress.payload == ProgressEvent.BuildStatus.PENDING:
                         # nothing to do, just waiting
                         continue
                     elif progress.payload == ProgressEvent.BuildStatus.COMPLETED:
                         event = {
-                            "phase": "built",
+                            "phase": phase,
                             "message": "Built image, launching...\n",
                             "imageName": image_name,
                         }
@@ -529,9 +530,13 @@ class BuildHandler(BaseHandler):
                         # Do nothing, is ok!
                         continue
                     elif progress.payload == ProgressEvent.BuildStatus.FAILED:
-                        event = {"phase": "failure"}
+                        event = {"phase": phase}
                     elif progress.payload == ProgressEvent.BuildStatus.UNKNOWN:
-                        event = {"phase": "unknown"}
+                        event = {"phase": phase}
+                    else:
+                        raise ValueError(
+                            f"Found unknown phase {phase} in ProgressEvent"
+                        )
                 elif progress.kind == ProgressEvent.Kind.LOG_MESSAGE:
                     # The logs are coming out of repo2docker, so we expect
                     # them to be JSON structured anyway

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -513,7 +513,7 @@ class BuildHandler(BaseHandler):
                     if progress.payload == ProgressEvent.BuildStatus.PENDING:
                         # nothing to do, just waiting
                         continue
-                    elif progress.payload == ProgressEvent.BuildStatus.COMPLETED:
+                    elif progress.payload == ProgressEvent.BuildStatus.BUILT:
                         event = {
                             "phase": phase,
                             "message": "Built image, launching...\n",
@@ -526,7 +526,7 @@ class BuildHandler(BaseHandler):
                             log_future = pool.submit(build.stream_logs)
                             log_future.add_done_callback(_check_result)
                         continue
-                    elif progress.payload == ProgressEvent.BuildStatus.COMPLETED:
+                    elif progress.payload == ProgressEvent.BuildStatus.BUILT:
                         # Do nothing, is ok!
                         continue
                     elif progress.payload == ProgressEvent.BuildStatus.FAILED:

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -259,7 +259,7 @@ async def test_local_repo2docker_build():
         event = await q.get(10)
         if (
             event.kind == ProgressEvent.Kind.BUILD_STATUS_CHANGE
-            and event.payload == ProgressEvent.BuildStatus.COMPLETED
+            and event.payload == ProgressEvent.BuildStatus.BUILT
         ):
             break
         events.append(event)

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -100,7 +100,7 @@ async def test_build_fail(app, needs_build, needs_launch, always_build, pytestco
     """
     Test build a repo that should fail immediately.
     """
-    slug = "gist/manics/cc003c8264db20d22b5fa437770f655e"
+    slug = "gh/binderhub-ci-repos/minimal-dockerfile/failed"
     build_url = f"{app.url}/build/{slug}"
     r = await async_requests.get(build_url, stream=True)
     r.raise_for_status()


### PR DESCRIPTION
Sometimes a build fails but BinderHub still attempts to launch the image.

I'm not sure if this is a race condition due to a pod exiting before BinderHub receives an error log from repo2docker, but it occurs everytime I try to build https://gist.github.com/manics/3c1a4babe6e9c368ee995c703fc0a2a9 on mybinder.org:

![image](https://user-images.githubusercontent.com/1644105/184975858-ae1e6b9a-fa3e-425d-aa7a-47311012e7cc.png)

The log shows that `postBuild` fails with a non-zero error code as expected, but BinderHub continues to attempt to launch it... and obviously fails since the image wasn't built!

With this change the pod status/phase is checked, instead of always assuming it's succeeded.

This ensure BinderHub will not attempt to launch the image, but I don't think this correctly updates the front-end UI to an error status, instead the progress bar is stuck on `Building` (ignore the rest of the build logs, I'm playing with podman :smile:)
![image](https://user-images.githubusercontent.com/1644105/184976776-23beee4c-bb9e-432e-a0de-3630b80d90a4.png)
