### PR TITLE
Move pod quota checking into separate class

### DIFF
--- a/binderhub/quota.py
+++ b/binderhub/quota.py
@@ -1,0 +1,161 @@
+"""
+Singleuser server quotas
+"""
+
+import asyncio
+import json
+import os
+from collections import namedtuple
+
+import kubernetes.config
+from kubernetes import client
+from traitlets import Any, Integer, Unicode, default
+from traitlets.config import LoggingConfigurable
+
+from .utils import KUBE_REQUEST_TIMEOUT
+
+
+class LaunchQuotaExceeded(Exception):
+    """Raised when a quota will be exceeded by a launch"""
+
+    def __init__(self, message, *, quota, used, status):
+        """
+        message: User-facing message
+        quota: Quota limit
+        used: Quota used
+        status: String indicating the type of quota
+        """
+        super().__init__()
+        self.message = message
+        self.quota = quota
+        self.used = used
+        self.status = status
+
+
+ServerQuotaCheck = namedtuple("ServerQuotaCheck", ["total", "matching", "quota"])
+
+
+class LaunchQuota(LoggingConfigurable):
+
+    executor = Any(
+        allow_none=True, help="Optional Executor to use for blocking operations"
+    )
+
+    total_quota = Integer(
+        None,
+        help="""
+        The number of concurrent singleuser servers that can be run.
+
+        None: no quota
+        0: the hub can't run any singleuser servers (e.g. in maintenance mode)
+        Positive integer: sets the quota
+        """,
+        allow_none=True,
+        config=True,
+    )
+
+    async def check_repo_quota(self, image_name, repo_config, repo_url):
+        """
+        Check whether launching a repository would exceed a quota.
+
+        Parameters
+        ----------
+        image_name: str
+        repo_config: dict
+        repo_url: str
+
+        Returns
+        -------
+        If quotas are disabled returns None
+        If quotas are exceeded raises LaunchQuotaExceeded
+        Otherwise returns:
+          - total servers
+          - matching servers running image_name
+          - quota
+        """
+        return None
+
+
+class KubernetesLaunchQuota(LaunchQuota):
+
+    api = Any(
+        help="Kubernetes API object to make requests (kubernetes.client.CoreV1Api())",
+    )
+
+    @default("api")
+    def _default_api(self):
+        try:
+            kubernetes.config.load_incluster_config()
+        except kubernetes.config.ConfigException:
+            kubernetes.config.load_kube_config()
+        return client.CoreV1Api()
+
+    namespace = Unicode(help="Kubernetes namespace to check", config=True)
+
+    @default("namespace")
+    def _default_namespace(self):
+        return os.getenv("BUILD_NAMESPACE", "default")
+
+    async def check_repo_quota(self, image_name, repo_config, repo_url):
+        # the image name (without tag) is unique per repo
+        # use this to count the number of pods running with a given repo
+        # if we added annotations/labels with the repo name via KubeSpawner
+        # we could do this better
+        image_no_tag = image_name.rsplit(":", 1)[0]
+
+        # TODO: put busy users in a queue rather than fail?
+        # That would be hard to do without in-memory state.
+        repo_quota = repo_config.get("quota")
+        pod_quota = self.total_quota
+
+        # Fetch info on currently running users *only* if quotas are set
+        if pod_quota is not None or repo_quota:
+            matching_pods = 0
+
+            # TODO: run a watch to keep this up to date in the background
+            f = self.executor.submit(
+                self.api.list_namespaced_pod,
+                self.namespace,
+                label_selector="app=jupyterhub,component=singleuser-server",
+                _request_timeout=KUBE_REQUEST_TIMEOUT,
+                _preload_content=False,
+            )
+            resp = await asyncio.wrap_future(f)
+            pods = json.loads(resp.read())["items"]
+            total_pods = len(pods)
+
+            if pod_quota is not None and total_pods >= pod_quota:
+                # check overall quota first
+                self.log.error(f"BinderHub is full: {total_pods}/{pod_quota}")
+                raise LaunchQuotaExceeded(
+                    "Too many users on this BinderHub! Try again soon.",
+                    quota=pod_quota,
+                    used=total_pods,
+                    status="pod_quota",
+                )
+
+            for pod in pods:
+                for container in pod["spec"]["containers"]:
+                    # is the container running the same image as us?
+                    # if so, count one for the current repo.
+                    image = container["image"].rsplit(":", 1)[0]
+                    if image == image_no_tag:
+                        matching_pods += 1
+                        break
+
+            if repo_quota and matching_pods >= repo_quota:
+                self.log.error(
+                    f"{repo_url} has exceeded quota: {matching_pods}/{repo_quota} ({total_pods} total)"
+                )
+                raise LaunchQuotaExceeded(
+                    f"Too many users running {repo_url}! Try again soon.",
+                    quota=repo_quota,
+                    used=matching_pods,
+                    status="repo_quota",
+                )
+
+            return ServerQuotaCheck(
+                total=total_pods, matching=matching_pods, quota=repo_quota
+            )
+
+        return None

--- a/binderhub/tests/test_quota.py
+++ b/binderhub/tests/test_quota.py
@@ -1,0 +1,93 @@
+"""Test launch quotas"""
+import concurrent.futures
+import json
+from unittest import mock
+
+import pytest
+
+from binderhub.quota import KubernetesLaunchQuota, LaunchQuotaExceeded
+
+
+@pytest.fixture
+def mock_pod_list_resp():
+    r = mock.MagicMock()
+    r.read.return_value = json.dumps(
+        {
+            "items": [
+                {
+                    "spec": {
+                        "containers": [
+                            {"image": "example.org/test/kubernetes_quota:1.2.3"}
+                        ],
+                    },
+                },
+                {
+                    "spec": {
+                        "containers": [
+                            {"image": "example.org/test/kubernetes_quota:latest"}
+                        ],
+                    },
+                },
+                {
+                    "spec": {
+                        "containers": [{"image": "example.org/test/other:abc"}],
+                    },
+                },
+            ]
+        }
+    )
+    f = concurrent.futures.Future()
+    f.set_result(r)
+    return f
+
+
+async def test_kubernetes_quota_none(mock_pod_list_resp):
+    quota = KubernetesLaunchQuota(api=mock.MagicMock(), executor=mock.MagicMock())
+    quota.executor.submit.return_value = mock_pod_list_resp
+
+    r = await quota.check_repo_quota(
+        "example.org/test/kubernetes_quota", {}, "repo.url"
+    )
+    assert r is None
+
+
+async def test_kubernetes_quota_allowed(mock_pod_list_resp):
+    quota = KubernetesLaunchQuota(api=mock.MagicMock(), executor=mock.MagicMock())
+    quota.executor.submit.return_value = mock_pod_list_resp
+
+    r = await quota.check_repo_quota(
+        "example.org/test/kubernetes_quota", {"quota": 3}, "repo.url"
+    )
+    assert r.total == 3
+    assert r.matching == 2
+    assert r.quota == 3
+
+
+async def test_kubernetes_quota_total_exceeded(mock_pod_list_resp):
+    quota = KubernetesLaunchQuota(
+        api=mock.MagicMock(), executor=mock.MagicMock(), total_quota=3
+    )
+    quota.executor.submit.return_value = mock_pod_list_resp
+
+    with pytest.raises(LaunchQuotaExceeded) as excinfo:
+        await quota.check_repo_quota(
+            "example.org/test/kubernetes_quota", {}, "repo.url"
+        )
+    assert excinfo.value.message == "Too many users on this BinderHub! Try again soon."
+    assert excinfo.value.quota == 3
+    assert excinfo.value.used == 3
+    assert excinfo.value.status == "pod_quota"
+
+
+async def test_kubernetes_quota_repo_exceeded(mock_pod_list_resp):
+    quota = KubernetesLaunchQuota(api=mock.MagicMock(), executor=mock.MagicMock())
+    quota.executor.submit.return_value = mock_pod_list_resp
+
+    with pytest.raises(LaunchQuotaExceeded) as excinfo:
+        await quota.check_repo_quota(
+            "example.org/test/kubernetes_quota", {"quota": 2}, "repo.url"
+        )
+    assert excinfo.value.message == "Too many users running repo.url! Try again soon."
+    assert excinfo.value.quota == 2
+    assert excinfo.value.used == 2
+    assert excinfo.value.status == "repo_quota"

--- a/testing/local-binder-local-hub/binderhub_config.py
+++ b/testing/local-binder-local-hub/binderhub_config.py
@@ -12,6 +12,7 @@ import os
 import socket
 
 from binderhub.build_local import LocalRepo2dockerBuild
+from binderhub.quota import LaunchQuota
 
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 s.connect(("8.8.8.8", 80))
@@ -24,6 +25,7 @@ c.BinderHub.builder_required = False
 
 c.BinderHub.build_class = LocalRepo2dockerBuild
 c.BinderHub.push_secret = None
+c.BinderHub.launch_quota_class = LaunchQuota
 
 c.BinderHub.about_message = "This is a local dev deployment without Kubernetes"
 c.BinderHub.banner_message = (


### PR DESCRIPTION
Whilst working on https://github.com/jupyterhub/binderhub/pull/1521 I realised the Kubernetes client is still used a few places.

This moves the quota checking code from [`builder.BuildHandler.launch`](https://github.com/jupyterhub/binderhub/blob/c4af713bb20ed90606e9795834d160bd8a332578/binderhub/builder.py#L589-L645) into it's own class. The logic should be unchanged.

After this the remaining use of the `kubernetes_client` is in the health check: https://github.com/jupyterhub/binderhub/blob/656204bb62d46be51fc7fb79cc5d7600b71a7614/binderhub/health.py#L108-L113

Note I haven't tested this on a real system yet.