### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
   #
   Publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main'))
+    if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
   #
   Publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/master')
+    if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main'))
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,7 +368,7 @@ it with another version from the [JupyterHub Helm chart
 repository](https://jupyterhub.github.io/helm-chart/).
 
 Use the [JupyterHub Helm chart's
-changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CHANGELOG.md)
+changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/HEAD/CHANGELOG.md)
 to prepare for breaking changes associated with the version bump.
 
 ### Releasing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,7 @@ You are assumed to have a modern version of [Python](https://www.python.org/),
 1. Install `helm` - the Kubernetes package manager.
 
    ```bash
-   curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+   curl -sf https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
    ```
 
    Here are the [official installation instructions](https://helm.sh/docs/intro/install/).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/jupyterhub/binderhub/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue.svg)](https://discourse.jupyter.org/c/binder/binderhub)
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue.svg)](https://gitter.im/jupyterhub/binder)
-[![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md)
+[![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://github.com/jupyterhub/binderhub/blob/HEAD/CONTRIBUTING.md)
 
 ## What is BinderHub?
 
@@ -44,7 +44,7 @@ To contribute to the BinderHub project you can work on:
 
 To see how to build the documentation, edit the user interface or modify
 the code see [the contribution
-guide](https://github.com/jupyterhub/binderhub/blob/master/CONTRIBUTING.md).
+guide](https://github.com/jupyterhub/binderhub/blob/HEAD/CONTRIBUTING.md).
 
 ## Installation
 

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -38,8 +38,8 @@ def tokenize_spec(spec):
     spec_parts = spec.split("/", 2)  # allow ref to contain "/"
     if len(spec_parts) != 3:
         msg = f'Spec is not of the form "user/repo/ref", provided: "{spec}".'
-        if len(spec_parts) == 2 and spec_parts[-1] != "master":
-            msg += f' Did you mean "{spec}/master"?'
+        if len(spec_parts) == 2 and spec_parts[-1] not in ("main", "master"):
+            msg += f' Did you mean "{spec}/main"?'
         raise ValueError(msg)
 
     return spec_parts
@@ -456,8 +456,8 @@ class GitRepoProvider(RepoProvider):
     <url-escaped-namespace>/<resolved_ref>
 
     eg:
-    https%3A%2F%2Fgithub.com%2Fjupyterhub%2Fzero-to-jupyterhub-k8s/master
-    https%3A%2F%2Fgithub.com%2Fjupyterhub%2Fzero-to-jupyterhub-k8s/f7f3ff6d1bf708bdc12e5f10e18b2a90a4795603
+    https%3A%2F%2Fgithub.com%2Fbinder-examples%2Fconda/main
+    https%3A%2F%2Fgithub.com%2Fbinder-examples%2Fconda/034931911e853252322f2309f1246a4f1076fd7d
 
     This provider is typically used if you are deploying binderhub yourself and you require access to repositories that
     are not in one of the supported providers.
@@ -957,6 +957,7 @@ class GistRepoProvider(GitHubRepoProvider):
     The ref is optional, valid values are
         - a full sha1 of a ref in the history
         - master
+        - HEAD for the default branch
 
     If master or no ref is specified the latest revision will be used.
     """

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -367,7 +367,7 @@ class TestSpecErrorHandling(TestCase):
 
     def test_spec_with_suggestion(self):
         spec = "short/suggestion"
-        error = f'Did you mean "{spec}/master"?'
+        error = f'Did you mean "{spec}/main"?'
         with self.assertRaisesRegex(ValueError, error):
             user, repo, unresolved_ref = tokenize_spec(spec)
 

--- a/ci/common
+++ b/ci/common
@@ -4,7 +4,7 @@
 setup_helm() {
     helm_version="${1}"
     echo "setup helm ${helm_version}"
-    curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION="${helm_version}" bash
+    curl -sf https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION="${helm_version}" bash
 }
 
 await_jupyterhub() {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,8 +57,8 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 source_suffix = [".rst", ".md"]
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # Set the default role so we can use `foo` instead of ``foo``
 default_role = "literal"
@@ -107,7 +107,7 @@ html_theme_options = {
 html_context = {
     "github_user": "jupyterhub",
     "github_repo": "binderhub",
-    "github_version": "master",
+    "github_version": "main",
     "doc_path": "doc",
 }
 
@@ -145,7 +145,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "BinderHub.tex", "BinderHub Documentation", "Yuvi Panda", "manual"),
+    (root_doc, "BinderHub.tex", "BinderHub Documentation", "Yuvi Panda", "manual"),
 ]
 
 
@@ -153,7 +153,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "binderhub", "BinderHub Documentation", [author], 1)]
+man_pages = [(root_doc, "binderhub", "BinderHub Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -163,7 +163,7 @@ man_pages = [(master_doc, "binderhub", "BinderHub Documentation", [author], 1)]
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "BinderHub",
         "BinderHub Documentation",
         author,

--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -98,7 +98,7 @@ To do that add the following into your ``config.yaml``::
         args:
           - clone
           - --single-branch
-          - --branch=master
+          - --branch=main
           - --depth=1
           - --
           - <repo_url>

--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -72,7 +72,7 @@ Firstly assume that you have a Git repo ``binderhub_custom_files`` which holds y
         └── page.html
 
 where ``page.html`` extends the `base page.html
-<https://github.com/jupyterhub/binderhub/blob/master/binderhub/templates/page.html>`_ and
+<https://github.com/jupyterhub/binderhub/blob/HEAD/binderhub/templates/page.html>`_ and
 updates only the source url of the logo in order to use your custom logo::
 
     {% extends "templates/page.html" %}
@@ -82,7 +82,7 @@ updates only the source url of the logo in order to use your custom logo::
 .. note::
 
     If you want to extend `any other base template
-    <https://github.com/jupyterhub/binderhub/tree/master/binderhub/templates>`_,
+    <https://github.com/jupyterhub/binderhub/tree/HEAD/binderhub/templates>`_,
     you have to include ``{% extends "templates/<base_template_name>.html" %}``
     in the beginning of your custom template.
     It is also possible to have completely new template instead of extending the base one.

--- a/doc/developer/repoproviders.rst
+++ b/doc/developer/repoproviders.rst
@@ -24,7 +24,7 @@ Currently supported providers, their prefixes and specs are:
     | GitHub     | ``gh``             | ``<user>/<repo>/<commit-sha-or-tag-or-branch>``             | `GitHub <https://github.com/>`_ is a website for hosting and sharing git repositories.                                                    |
     +------------+--------------------+-------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+
     | GitLab     | ``gl``             | ``<url-escaped-namespace>/<unresolved_ref>``                | `GitLab <https://about.gitlab.com/>`_ offers hosted as well as self-hosted git repositories.                                              |
-    |            |                    | (e.g. ``group%2Fproject%2Frepo/master``)                    |                                                                                                                                           |
+    |            |                    | (e.g. ``group%2Fproject%2Frepo/main``)                    |                                                                                                                                           |
     +------------+--------------------+-------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+
     | Gist       | ``gist``           | ``<github-username>/<gist-id><commit-sha-or-tag>``          | `Gists <https://gist.github.com/>`_ are small collections of files stored on GitHub. They behave like lightweight repositories.           |
     +------------+--------------------+-------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------+
@@ -47,7 +47,7 @@ a BinderHub deployment to fetch repositories from new locations
 on the web. Doing so involves defining your own RepoProvider sub-class
 and modifying a set of methods/attributes to interface with the online
 provider to which you are providing access. It also often involves
-`building a new repo2docker content provider <https://github.com/jupyter/repo2docker/tree/master/repo2docker/contentproviders>`_.
+`building a new repo2docker content provider <https://github.com/jupyter/repo2docker/tree/HEAD/repo2docker/contentproviders>`_.
 
 In order to extend the supported repository providers,
 follow these instructions. We'll provide example links for each step to a
@@ -56,7 +56,7 @@ that implements the ``DataverseProvider`` class.
 
 #. Review the `repoprovider module <https://github.com/jupyterhub/binderhub/blob/HEAD/binderhub/repoproviders.py>`_.
    This shows a number of example repository providers.
-#. Check whether repo2docker has a `ContentProvider class <https://github.com/jupyter/repo2docker/tree/master/repo2docker/contentproviders>`_
+#. Check whether repo2docker has a `ContentProvider class <https://github.com/jupyter/repo2docker/tree/HEAD/repo2docker/contentproviders>`_
    that will work with your repository provider. If not, then you'll need to create one first.
 #. Create a new class that sub-classes the ``RepoProvider`` class.
    Define your own methods for actions that are repository provider-specific.

--- a/doc/developer/repoproviders.rst
+++ b/doc/developer/repoproviders.rst
@@ -54,7 +54,7 @@ follow these instructions. We'll provide example links for each step to a
 recent `BinderHub pull-request <https://github.com/jupyterhub/binderhub/pull/969>`_
 that implements the ``DataverseProvider`` class.
 
-#. Review the `repoprovider module <https://github.com/jupyterhub/binderhub/blob/master/binderhub/repoproviders.py>`_.
+#. Review the `repoprovider module <https://github.com/jupyterhub/binderhub/blob/HEAD/binderhub/repoproviders.py>`_.
    This shows a number of example repository providers.
 #. Check whether repo2docker has a `ContentProvider class <https://github.com/jupyter/repo2docker/tree/master/repo2docker/contentproviders>`_
    that will work with your repository provider. If not, then you'll need to create one first.

--- a/doc/eventlogging.rst
+++ b/doc/eventlogging.rst
@@ -55,4 +55,4 @@ Schemas:
 - `version 1 <https://github.com/jupyterhub/binderhub/blob/3da0f0c07eeea1b4517e5c7d1ec4a3166b3ca11c/binderhub/event-schemas/launch.json>`_
 - `version 2 <https://github.com/jupyterhub/binderhub/blob/5cc0f496cac98d6c9b7d645e6fb236fd1e5277f4/binderhub/event-schemas/launch.json>`_
 - `version 3 <https://github.com/jupyterhub/binderhub/blob/3bfee95f7c53d16604ea29f46b7e7c5aa1b49a63/binderhub/event-schemas/launch.json>`_
-- `version 4 <https://github.com/jupyterhub/binderhub/blob/master/binderhub/event-schemas/launch.json>`_
+- `version 4 <https://github.com/jupyterhub/binderhub/blob/HEAD/binderhub/event-schemas/launch.json>`_

--- a/doc/zero-to-binderhub/setup-prerequisites.rst
+++ b/doc/zero-to-binderhub/setup-prerequisites.rst
@@ -31,12 +31,12 @@ render the templates into valid k8s resources. Each installation of a chart is
 called a *release*, and each version of the release is called a *revision*.
 
 Several `methods to install Helm
-<https://github.com/helm/helm/blob/master/docs/install.md>`_ exist, the simplest
+<https://helm.sh/docs/intro/install/>`_ exist, the simplest
 way to install Helm is to run Helm's installer script in a terminal.
 
 .. code:: bash
 
-   curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+   curl -sf https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 
 Verifying the setup
 ~~~~~~~~~~~~~~~~~~~

--- a/examples/appendix/binderhub_config.py
+++ b/examples/appendix/binderhub_config.py
@@ -3,7 +3,7 @@ USER root
 ENV BINDER_URL={binder_url}
 ENV REPO_URL={repo_url}
 RUN cd /tmp \
- && wget -q https://github.com/jupyterhub/binderhub/archive/master.tar.gz -O binderhub.tar.gz \
+ && wget -q https://github.com/jupyterhub/binderhub/archive/main.tar.gz -O binderhub.tar.gz \
  && tar --wildcards -xzf binderhub.tar.gz --strip 2 */examples/appendix\
  && ./appendix/run-appendix \
  && rm -rf binderhub.tar.gz appendix

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -52,6 +52,6 @@ to build the docker images and rerender the helm chart.
 [kubernetes]: https://kubernetes.io
 [helm]: https://helm.sh/
 [helm repo]: https://github.com/kubernetes/helm
-[chart]: https://github.com/kubernetes/helm/blob/master/docs/charts.md
-[kubernetes introduction to charts]: https://github.com/kubernetes/helm/blob/master/docs/charts.md
+[chart]: https://helm.sh/docs/topics/charts/
+[kubernetes introduction to charts]: https://helm.sh/docs/topics/charts/
 [zero to jupyterhub with kubernetes]: https://zero-to-jupyterhub.readthedocs.io/en/latest/


### PR DESCRIPTION
Actions to take, in order:

- [x] https://github.com/binder-examples/conda: Rename `master` branch to `main`
- [x] approve this PR
- [x] rename the `master` branch to `main` in GitHub (this should automatically update all PRs)
- [ ] merge this PR
- [ ] check the publish workflow publishes the expected outputs if relevant
- [ ] If readthedocs.org is used, set main as the default branch explicitly: admin -> advanced -> default branch

Remaining mentions:
```
$ git grep -c master 
CHANGES.md:3
CONTRIBUTING.md:1
binderhub/_version.py:10
binderhub/builder.py:3
binderhub/main.py:1
binderhub/repoproviders.py:5
binderhub/tests/http-record.nbviewer.jupyter.org.json:4
binderhub/tests/http-record.www.hydroshare.org.json:1
binderhub/tests/http-record.zenodo.org.json:1
binderhub/tests/test_main.py:9
binderhub/tests/test_repoproviders.py:4
helm-chart/.gitignore:1
helm-chart/images/binderhub/requirements.in:1
versioneer.py:21
```

https://github.com/jupyterhub/team-compass/issues/412