### PR TITLE
Change component name from dind to image-builder

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -296,14 +296,16 @@ class KubernetesBuildExecutor(BuildExecutor):
         """
         resp = self.api.list_namespaced_pod(
             self.namespace,
-            label_selector="component=dind,app=binder",
+            label_selector="component=image-builder,app=binder",
             _request_timeout=KUBE_REQUEST_TIMEOUT,
             _preload_content=False,
         )
-        dind_pods = json.loads(resp.read())
+        image_builder_pods = json.loads(resp.read())
 
-        if self.sticky_builds and dind_pods:
-            node_names = [pod["spec"]["nodeName"] for pod in dind_pods["items"]]
+        if self.sticky_builds and image_builder_pods:
+            node_names = [
+                pod["spec"]["nodeName"] for pod in image_builder_pods["items"]
+            ]
             ranked_nodes = rendezvous_rank(node_names, self.repo_url)
             best_node_name = ranked_nodes[0]
 

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -118,7 +118,7 @@ async def test_build_fail(app, needs_build, needs_launch, always_build, pytestco
     assert failed_events > 0, "Should have seen phase 'failed'"
 
 
-def _list_dind_pods_mock():
+def _list_image_builder_pods_mock():
     """Mock list of DIND pods"""
     mock_response = mock.MagicMock()
     mock_response.read.return_value = json.dumps(
@@ -139,7 +139,7 @@ def _list_dind_pods_mock():
 def test_default_affinity():
     # check that the default affinity is a pod anti-affinity
 
-    mock_k8s_api = _list_dind_pods_mock()
+    mock_k8s_api = _list_image_builder_pods_mock()
 
     build = Build(
         mock.MagicMock(),
@@ -167,7 +167,7 @@ def test_default_affinity():
 
 def test_sticky_builds_affinity():
     # Setup some mock objects for the response from the k8s API
-    mock_k8s_api = _list_dind_pods_mock()
+    mock_k8s_api = _list_image_builder_pods_mock()
 
     build = Build(
         mock.MagicMock(),
@@ -205,7 +205,7 @@ def test_git_credentials_passed_to_podspec_upon_submit():
         "access_token": "my_access_token",
     }"""
 
-    mock_k8s_api = _list_dind_pods_mock()
+    mock_k8s_api = _list_image_builder_pods_mock()
 
     build = Build(
         mock.MagicMock(),

--- a/helm-chart/binderhub/templates/dind/daemonset.yaml
+++ b/helm-chart/binderhub/templates/dind/daemonset.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         name: {{ .Release.Name }}-dind
         app: binder
-        component: dind
+        component: image-builder
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:


### PR DESCRIPTION
In parallel of the work from #1531, this change will allow the use of other builders than Docker without being tied to its nomenclature which might make the whole a bit confusing when deploying and debugging.

Part of #1513