### PR TITLE
Update to z2jh 2 and JupyterHub 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         k3s-channel:
           # Available channels: https://github.com/k3s-io/k3s/blob/HEAD/channel.yaml
-          - v1.24
+          - latest
         test:
           - main
           - auth
@@ -64,7 +64,7 @@ jobs:
           - k3s-channel: v1.20
             helm-version: v3.5.0
             test: helm
-          - k3s-channel: v1.24
+          - k3s-channel: latest
             test: helm
             test-variation: upgrade
             # upgrade-from represents a release channel, see: https://jupyterhub.github.io/helm-chart/info.json

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -207,7 +207,6 @@ class RemoteBinderHub:
 
 
 @pytest.fixture
-@mock.patch.dict(os.environ, {"JUPYTERHUB_SERVICE_NAME": "binder"})
 def app(request, io_loop, _binderhub_config):
     """Launch the BinderHub app
 

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -207,6 +207,7 @@ class RemoteBinderHub:
 
 
 @pytest.fixture
+@mock.patch.dict(os.environ, {"JUPYTERHUB_SERVICE_NAME": "binder"})
 def app(request, io_loop, _binderhub_config):
     """Launch the BinderHub app
 
@@ -247,7 +248,6 @@ def app(request, io_loop, _binderhub_config):
         cfg = PyFileConfigLoader(binderhub_config_auth_additions_path).load_config()
         _binderhub_config.merge(cfg)
     bhub = BinderHub.instance(config=_binderhub_config)
-    os.environ["JUPYTERHUB_SERVICE_NAME"] = "binder"
     bhub.initialize([])
     bhub.start(run_loop=False)
     # instantiating binderhub configures this

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -247,6 +247,7 @@ def app(request, io_loop, _binderhub_config):
         cfg = PyFileConfigLoader(binderhub_config_auth_additions_path).load_config()
         _binderhub_config.merge(cfg)
     bhub = BinderHub.instance(config=_binderhub_config)
+    os.environ["JUPYTERHUB_SERVICE_NAME"] = "binder"
     bhub.initialize([])
     bhub.start(run_loop=False)
     # instantiating binderhub configures this

--- a/doc/authentication.rst
+++ b/doc/authentication.rst
@@ -26,7 +26,6 @@ you need to add the following into ``config.yaml``:
           binder:
             oauth_no_confirm: true
             oauth_redirect_uri: "https://<binderhub_url>/oauth_callback"
-            oauth_client_id: "binder-oauth-client-test"
 
       singleuser:
         # to make notebook servers aware of hub

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   #            and run "./dependencies freeze --upgrade".
   #
   - name: jupyterhub
-    version: "1.2.0"
+    version: "2.0.0"
     repository: "https://jupyterhub.github.io/helm-chart"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
               name: "{{ include "jupyterhub.hub.fullname" . }}"
               key: hub.services.binder.apiToken
         {{- if .Values.config.BinderHub.auth_enabled }}
+        - name: JUPYTERHUB_SERVICE_NAME
+          value: binder
         - name: JUPYTERHUB_API_URL
           value: {{ (print (.Values.config.BinderHub.hub_url_local | default .Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
         - name: JUPYTERHUB_BASE_URL

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -56,8 +56,6 @@ jupyterhub:
   cull:
     enabled: true
     users: true
-  rbac:
-    enabled: true
   hub:
     config:
       JupyterHub:
@@ -189,7 +187,7 @@ jupyterhub:
     services:
       binder:
         admin: true
-        apiToken:
+        display: false
   singleuser:
     # start notebook server with lab ui as default
     # *if available*

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -62,6 +62,14 @@ jupyterhub:
         authenticator_class: nullauthenticator.NullAuthenticator
       BinderSpawner:
         auth_enabled: false
+    loadRoles:
+      binder:
+        services:
+          - binder
+        scopes:
+          - servers
+          # we don't need admin:users if auth is not enabled!
+          - "admin:users"
     extraConfig:
       0-binderspawnermixin: |
         """
@@ -186,7 +194,6 @@ jupyterhub:
         c.JupyterHub.spawner_class = BinderSpawner
     services:
       binder:
-        admin: true
         display: false
   singleuser:
     # start notebook server with lab ui as default

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -10,7 +10,7 @@ google-cloud-logging==3.*
 # jupyterhub's major version should be matched with the JupyterHub Helm chart's
 # used version of JupyterHub.
 #
-jupyterhub==1.*
+jupyterhub==3.*
 
 # https://github.com/kubernetes-client/python
 kubernetes==9.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -26,8 +26,6 @@ cryptography==38.0.1
     # via pyopenssl
 docker==6.0.0
     # via -r helm-chart/images/binderhub/../../../requirements.txt
-entrypoints==0.4
-    # via jupyterhub
 escapism==1.0.1
     # via -r helm-chart/images/binderhub/../../../requirements.txt
 google-api-core[grpc]==2.10.2
@@ -40,13 +38,13 @@ google-auth==2.12.0
     #   google-api-core
     #   google-cloud-core
     #   kubernetes
-google-cloud-appengine-logging==1.1.5
+google-cloud-appengine-logging==1.1.6
     # via google-cloud-logging
 google-cloud-audit-log==0.2.4
     # via google-cloud-logging
 google-cloud-core==2.3.2
     # via google-cloud-logging
-google-cloud-logging==3.2.4
+google-cloud-logging==3.2.5
     # via -r helm-chart/images/binderhub/requirements.in
 googleapis-common-protos[grpc]==1.56.4
     # via
@@ -54,7 +52,7 @@ googleapis-common-protos[grpc]==1.56.4
     #   google-cloud-audit-log
     #   grpc-google-iam-v1
     #   grpcio-status
-greenlet==1.1.3
+greenlet==1.1.3.post0
     # via sqlalchemy
 grpc-google-iam-v1==0.12.4
     # via google-cloud-logging
@@ -68,6 +66,8 @@ grpcio-status==1.49.1
     # via google-api-core
 idna==3.4
     # via requests
+importlib-metadata==5.0.0
+    # via jupyterhub
 jinja2==3.1.2
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
@@ -78,7 +78,7 @@ jsonschema==4.16.0
     #   jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==1.5.0
+jupyterhub==3.0.0
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in
@@ -97,7 +97,9 @@ oauthlib==3.2.1
     #   jupyterhub
     #   requests-oauthlib
 packaging==21.3
-    # via docker
+    # via
+    #   docker
+    #   jupyterhub
 pamela==1.0.0
     # via jupyterhub
 prometheus-client==0.14.1
@@ -186,6 +188,8 @@ websocket-client==1.4.1
     # via
     #   docker
     #   kubernetes
+zipp==3.9.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
+++ b/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
@@ -26,9 +26,4 @@ c.HubOAuth.base_url = c.BinderHub.base_url
 c.HubOAuth.hub_prefix = c.BinderHub.base_url + "hub/"
 c.HubOAuth.oauth_redirect_uri = "http://127.0.0.1:8585/oauth_callback"
 c.HubOAuth.oauth_client_id = "service-binder"
-# We declare this environment variable, as it is used to set
-# c.HubAuth.access_scopes's default value of relevance.
-#
-# ref: https://github.com/jupyterhub/jupyterhub/blob/5997614f452a3cfebfa541800012a914d37f3ec8/jupyterhub/services/auth.py#L358-L378
-#
-os.environ["JUPYTERHUB_SERVICE_NAME"] = "binder"
+c.HubOAuth.access_scopes = {"access:services!service=binder"}

--- a/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
+++ b/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
@@ -26,3 +26,9 @@ c.HubOAuth.base_url = c.BinderHub.base_url
 c.HubOAuth.hub_prefix = c.BinderHub.base_url + "hub/"
 c.HubOAuth.oauth_redirect_uri = "http://127.0.0.1:8585/oauth_callback"
 c.HubOAuth.oauth_client_id = "service-binder"
+# We declare this environment variable, as it is used to set
+# c.HubAuth.access_scopes's default value of relevance.
+#
+# ref: https://github.com/jupyterhub/jupyterhub/blob/5997614f452a3cfebfa541800012a914d37f3ec8/jupyterhub/services/auth.py#L358-L378
+#
+os.environ["JUPYTERHUB_SERVICE_NAME"] = "binder"

--- a/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
+++ b/testing/local-binder-k8s-hub/binderhub_config_auth_additions.py
@@ -25,4 +25,4 @@ c.HubOAuth.api_url = c.BinderHub.hub_url + "/hub/api/"
 c.HubOAuth.base_url = c.BinderHub.base_url
 c.HubOAuth.hub_prefix = c.BinderHub.base_url + "hub/"
 c.HubOAuth.oauth_redirect_uri = "http://127.0.0.1:8585/oauth_callback"
-c.HubOAuth.oauth_client_id = "binder-oauth-client-test"
+c.HubOAuth.oauth_client_id = "service-binder"

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
@@ -14,7 +14,7 @@ hub:
     BinderSpawner:
       auth_enabled: true
   loadRoles:
-    users:
+    user:
       scopes:
         - self
         - "access:services"

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
@@ -13,3 +13,8 @@ hub:
       password: "dummy"
     BinderSpawner:
       auth_enabled: true
+  loadRoles:
+    users:
+      scopes:
+        - self
+        - "access:services"

--- a/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
+++ b/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml
@@ -6,7 +6,6 @@ hub:
     binder:
       oauth_no_confirm: true
       oauth_redirect_uri: "http://127.0.0.1:8585/oauth_callback"
-      oauth_client_id: "binder-oauth-client-test"
   config:
     JupyterHub:
       authenticator_class: "dummy"

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -53,8 +53,6 @@ jupyterhub:
   cull:
     enabled: true
     users: true
-  rbac:
-    enabled: true
   hub:
     config:
       JupyterHub:


### PR DESCRIPTION
This better be done at some point in time, and one reason to do it is because it makes us compatible with k8s 1.25 and higher among other things.

- Closes #1541 
- Enables resolving #1444 in a way like z2jh has done it

---

Since this may be relevant knowing about I pinged a lot of you who I guessed could be influenced.

## Draft status of PR because of ...

```
[D 2022-10-10 14:15:14.238 JupyterHub app:2035] Loading roles into database
[I 2022-10-10 14:15:14.249 JupyterHub roles:173] Role jupyterhub-idle-culler added to database
[I 2022-10-10 14:15:14.251 JupyterHub app:1934] Not using allowed_users. Any authenticated user will be allowed.
[W 2022-10-10 14:15:14.264 JupyterHub app:2312] Service binder sets `admin: True`, which is deprecated in JupyterHub 2.0. You can assign now assign roles via `JupyterHub.load_roles` configuration. If you specify services in the admin role configuration, the Service admin flag will be ignored.
[I 2022-10-10 14:15:14.265 JupyterHub roles:238] Adding role admin for Service: binder
[E 2022-10-10 14:15:14.268 JupyterHub app:3297]
    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/site-packages/jupyterhub/app.py", line 3294, in launch_instance_async
        await self.initialize(argv)
      File "/usr/local/lib/python3.9/site-packages/jupyterhub/app.py", line 2824, in initialize
        self.init_services()
      File "/usr/local/lib/python3.9/site-packages/jupyterhub/app.py", line 2338, in init_services
        setattr(service, key, value)
      File "/usr/local/lib/python3.9/site-packages/traitlets/traitlets.py", line 715, in __set__
        self.set(obj, value)
      File "/usr/local/lib/python3.9/site-packages/traitlets/traitlets.py", line 689, in set
        new_value = self._validate(obj, value)
      File "/usr/local/lib/python3.9/site-packages/traitlets/traitlets.py", line 723, in _validate
        value = self._cross_validate(obj, value)
      File "/usr/local/lib/python3.9/site-packages/traitlets/traitlets.py", line 729, in _cross_validate
        value = obj._trait_validators[self.name](obj, proposal)
      File "/usr/local/lib/python3.9/site-packages/traitlets/traitlets.py", line 1132, in __call__
        return self.func(*args, **kwargs)
      File "/usr/local/lib/python3.9/site-packages/jupyterhub/services/service.py", line 322, in _validate_client_id
        raise ValueError(
    ValueError: service  has oauth_client_id='binder-oauth-client-test'. Service oauth client ids must start with 'service-'
    
[D 2022-10-10 14:15:14.270 JupyterHub application:961] Exiting application: jupyterhub
```

And failures following trialing prefixing with `service-`. Feel free to push commits to resolve this!