### PR TITLE
Improve visual accessibility

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -77,8 +77,8 @@ p > a:hover {
 }
 
 .btn-submit{
-    background-color:rgb(243, 162, 83);
-    box-shadow: 1px 1px rgba(0,0,0,.075);
+    background-color:rgb(223, 132, 41);
+    box-shadow: 1px 1px rgba(0,0,0,.075);   
     color:white;
     border:none;
     height:35px;
@@ -235,19 +235,21 @@ h4 {
     padding-top: 4px;
 }
 
+/* Increase contrast to improve visual accessibility */
+
 .point-orange {
-    border-color: rgb(243, 162, 83);
-    color: rgb(243, 162, 83);
+    border-color: rgb(247, 144, 42);
+    color: rgb(247, 144, 42);
 }
 
 .point-red {
-    border-color: rgb(208, 102, 129);
-    color: rgb(208, 102, 129);
+    border-color: rgb(204, 67, 101);
+    color: rgb(204, 67, 101);
 }
 
 .point-blue {
-    border-color: rgb(87, 154, 202);
-    color: rgb(87, 154, 202);
+    border-color: rgb(41, 124, 184);
+    color: rgb(41, 124, 184);
 }
 
 span.front-em {

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -99,7 +99,7 @@
 
         <div class="badges row">
             <div class="dropdownmenu" id="toggle-badge-snippet">
-              <label>Expand to see the text below, paste it into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge_logo.svg")}}"></label>
+              <label>Expand to see the text below, paste it into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge_logo.svg")}}" alt="binder badge logo"></label>
               <a id="badge-link"></a>
               <a href="#" title="show badge snippets"><span id="badge-snippet-caret" class="glyphicon glyphicon-triangle-right"></span></a>
             </div>
@@ -107,7 +107,7 @@
               <!--Markdown section-->
               <div  class="badge-snippet-row">
                  <pre id="markdown-badge-snippet" data-default="Fill in the fields to see the markdown badge snippet."></pre>
-                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
+                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}" alt="markdown icon">
                  <img class="icon clipboard"
                     src="{{static_url("images/copy-icon-black.svg")}}"
                     data-clipboard-target="#markdown-badge-snippet"
@@ -116,7 +116,7 @@
               <!--RST section-->
               <div  class="badge-snippet-row">
                   <pre id="rst-badge-snippet" data-default="Fill in the fields to see the rST badge snippet."></pre>
-                  <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
+                  <img class="icon" src="{{static_url("images/rst-icon.svg")}}" alt="restructuredtext icon">
                   <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}"
                     data-clipboard-target="#rst-badge-snippet"
                     alt="Copy rst link to clipboard">

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -30,7 +30,7 @@
   <div class="container">
     <div class="row">
       <div id="logo-container">
-        <img id="logo" src={% block logo_image %}"{{static_url("logo.svg")}}"{% endblock logo_image %} width="390px"  />
+        <img id="logo" src={% block logo_image %}"{{static_url("logo.svg")}}"{% endblock logo_image %} width="390px"  alt="binder logo"/>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Haven accessed [minders](https://myminders.org) using WAVE and axe accessibility testing tool, I have made changes geared towards improving the visual accessibility of [minders](https://myminders.org) by:

- Adding an alt text to the images so that people that are visually impaired who depend on screen readers can use the site seamlessly.
- Adding sufficient color contrast to buttons and links on the page so text is more legible.