### PR TITLE
ci: extend test timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
   # jobs or have "template" jobs, so we use `if` conditions on steps
   tests:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       # keep running so we can see if tests with other k3s/k8s/helm versions pass
       fail-fast: false


### PR DESCRIPTION
tests are getting [cancelled](https://github.com/jupyterhub/binderhub/actions/runs/3214936169/jobs/5255678267) because 10 minutes is not enough.

time limits added in #1518