### PR TITLE
add timeout to tests

### DIFF
--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -271,7 +271,6 @@ async def test_local_repo2docker_build():
 
 @pytest.mark.asyncio(timeout=20)
 async def test_local_repo2docker_build_stop(io_loop):
-    io_loop = await io_loop
     q = Queue()
     # We need a slow build here so that we can interrupt it, so pick a large repo that
     # will take several seconds to clone

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,5 +11,6 @@ pycurl
 pytest
 pytest-asyncio
 pytest-cov
+pytest-timeout
 requests
 ruamel.yaml>=0.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,10 @@ requires = [
   "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+timeout = "60"
+addopts = [
+  "--durations=10"
+]


### PR DESCRIPTION
using pytest-timeout

default: 60s

can be overridden per test with `@pytest.mark.timeout`