### PR TITLE
fix default value for launch_quota_class

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -344,8 +344,8 @@ class BinderHub(Application):
     )
 
     launch_quota_class = Type(
-        LaunchQuota,
-        default=KubernetesLaunchQuota,
+        klass=LaunchQuota,
+        default_value=KubernetesLaunchQuota,
         help="""
         The class used to check quotas for launched servers.
 


### PR DESCRIPTION
first positional argument is default_value, there is no `default` argument. So what we had before was equivalent to `Type(default_value=LaunchQuota).tag(default=KubernetesLaunchQuota)` (where KubernetesLaunchQuota was placed in metadata and ignored).