### PR TITLE
Improve BinderHub page Accessibility

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -77,7 +77,7 @@ p > a:hover {
 }
 
 .btn-submit{
-    background-color:rgb(243, 162, 83);
+    background-color:rgb(223, 132, 41);
     box-shadow: 1px 1px rgba(0,0,0,.075);
     color:white;
     border:none;
@@ -236,18 +236,18 @@ h4 {
 }
 
 .point-orange {
-    border-color: rgb(243, 162, 83);
-    color: rgb(243, 162, 83);
+    border-color: rgb(247, 144, 42);
+    color: rgb(247, 144, 42);
 }
 
 .point-red {
-    border-color: rgb(208, 102, 129);
-    color: rgb(208, 102, 129);
+    border-color: rgb(204, 67, 101);
+    color: rgb(204, 67, 101);
 }
 
 .point-blue {
-    border-color: rgb(87, 154, 202);
-    color: rgb(87, 154, 202);
+    border-color: rgb(41, 124, 184);
+    color: rgb(41, 124, 184);
 }
 
 span.front-em {

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -251,11 +251,11 @@ h4 {
 }
 
 /*reduce font size of h1 and h2 so the initial design when h3 and h4 tags were used respectively is retained*/
-.first-level-header{
+h1{
     font-size:1.25em;
 }
 
-.second-level-header{
+h2{
     font-size:1.125em;
 }
 

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -250,6 +250,15 @@ h4 {
     color: rgb(41, 124, 184);
 }
 
+/*reduce font size of h1 and h2 so the initial design when h3 and h4 tags were used respectively is retained*/
+.first-level-header{
+    font-size:1.25em;
+}
+
+.second-level-header{
+    font-size:1.125em;
+}
+
 span.front-em {
     font-size: 1.5em;
 }

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -99,7 +99,7 @@
 
         <div class="badges row">
             <div class="dropdownmenu" id="toggle-badge-snippet">
-              <label>Expand to see the text below, paste it into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge_logo.svg")}}"></label>
+              <label>Expand to see the text below, paste it into your README to show a binder badge: <img id="badge" src="{{static_url("images/badge_logo.svg")}}" alt="Binder badge logo"></label>
               <a id="badge-link"></a>
               <a href="#" title="show badge snippets"><span id="badge-snippet-caret" class="glyphicon glyphicon-triangle-right"></span></a>
             </div>
@@ -107,7 +107,7 @@
               <!--Markdown section-->
               <div  class="badge-snippet-row">
                  <pre id="markdown-badge-snippet" data-default="Fill in the fields to see the markdown badge snippet."></pre>
-                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}">
+                 <img class="icon" src="{{static_url("images/markdown-icon.svg")}}" alt="Markdown icon">
                  <img class="icon clipboard"
                     src="{{static_url("images/copy-icon-black.svg")}}"
                     data-clipboard-target="#markdown-badge-snippet"
@@ -116,7 +116,7 @@
               <!--RST section-->
               <div  class="badge-snippet-row">
                   <pre id="rst-badge-snippet" data-default="Fill in the fields to see the rST badge snippet."></pre>
-                  <img class="icon" src="{{static_url("images/rst-icon.svg")}}">
+                  <img class="icon" src="{{static_url("images/rst-icon.svg")}}" alt="restructured text icon">
                   <img class="icon clipboard" src="{{static_url("images/copy-icon-black.svg")}}"
                     data-clipboard-target="#rst-badge-snippet"
                     alt="Copy rst link to clipboard">

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -13,13 +13,13 @@
     <div class="col-lg-10 col-lg-offset-1">
       {% block header %}
       <div id="header" class="text-center">
-        <h3>Turn a Git repo into a collection of interactive notebooks</h3>
+        <h1 class="first-level-header">Turn a Git repo into a collection of interactive notebooks</h1>
         <div id="explanation">
           Have a repository full of Jupyter notebooks? With Binder, open those notebooks in an executable environment, making your code immediately reproducible by anyone, anywhere.
         </div>
       </div>
       <div id="tutorials" class="text-center">
-        <h4>New to Binder? Get started with a <a href="https://the-turing-way.netlify.app/communication/binder/zero-to-binder.html" target="_blank">Zero-to-Binder tutorial</a> in Julia, Python, or R.</h4>
+        <h2 class="second-level-header">New to Binder? Get started with a <a href="https://the-turing-way.netlify.app/communication/binder/zero-to-binder.html" target="_blank">Zero-to-Binder tutorial</a> in Julia, Python, or R.</h2>
       </div>
       {% endblock header %}
 

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -13,13 +13,13 @@
     <div class="col-lg-10 col-lg-offset-1">
       {% block header %}
       <div id="header" class="text-center">
-        <h1 class="first-level-header">Turn a Git repo into a collection of interactive notebooks</h1>
+        <h1>Turn a Git repo into a collection of interactive notebooks</h1>
         <div id="explanation">
           Have a repository full of Jupyter notebooks? With Binder, open those notebooks in an executable environment, making your code immediately reproducible by anyone, anywhere.
         </div>
       </div>
       <div id="tutorials" class="text-center">
-        <h2 class="second-level-header">New to Binder? Get started with a <a href="https://the-turing-way.netlify.app/communication/binder/zero-to-binder.html" target="_blank">Zero-to-Binder tutorial</a> in Julia, Python, or R.</h2>
+        <h2>New to Binder? Get started with a <a href="https://the-turing-way.netlify.app/communication/binder/zero-to-binder.html" target="_blank">Zero-to-Binder tutorial</a> in Julia, Python, or R.</h2>
       </div>
       {% endblock header %}
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>{% block title %}Binder{% endblock %}</title>
   {% block meta_social %}

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -30,7 +30,7 @@
   <div class="container">
     <div class="row">
       <div id="logo-container">
-        <img id="logo" src={% block logo_image %}"{{static_url("logo.svg")}}"{% endblock logo_image %} width="390px"  />
+        <img id="logo" src={% block logo_image %}"{{static_url("logo.svg")}}"{% endblock logo_image %} width="390px" alt="Binder logo" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Haven accessed [BinderHub page](https://mybinder.org) using WAVE and axe accessibility tools stated in the [microtask](https://github.com/jupyterhub/outreachy/issues/57#issue-1409736912), I have implemented changes based on my solutions proffered  in the issue which are geared towards improving the accessibility of [BinderHub page](https://mybinder.org).

This PR does the following:

1. Add alt text to images via the alt attribute `alt="example text"`.
2. Add the lang attribute to the opening html tag `<html lang="en>"`.
3. Improve contrast between selected text and their background colors.
4. Fix missing first level heading.

More details about the changes made can be found in [issue #57](https://github.com/jupyterhub/outreachy/issues/57#issue-1409736912)