### PR TITLE
keep old default branch links working

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -306,7 +306,7 @@ class BuildHandler(BaseHandler):
 
                 if provider.unresolved_ref in {"master", "main"}:
                     error_message.append(
-                        "Tip: HEAD will always resolve to a repo's default branch."
+                        "Tip: HEAD will always resolve to a repository's default branch."
                     )
 
                     # keep old links working for default branch names

--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -38,8 +38,8 @@ def tokenize_spec(spec):
     spec_parts = spec.split("/", 2)  # allow ref to contain "/"
     if len(spec_parts) != 3:
         msg = f'Spec is not of the form "user/repo/ref", provided: "{spec}".'
-        if len(spec_parts) == 2 and spec_parts[-1] not in ("main", "master"):
-            msg += f' Did you mean "{spec}/main"?'
+        if len(spec_parts) == 2 and spec_parts[-1] not in {"main", "master", "HEAD"}:
+            msg += f' Did you mean "{spec}/HEAD"?'
         raise ValueError(msg)
 
     return spec_parts
@@ -564,7 +564,7 @@ class GitLabRepoProvider(RepoProvider):
     <url-escaped-namespace>/<unresolved_ref>
 
     eg:
-    group%2Fproject%2Frepo/master
+    group%2Fproject%2Frepo/main
     """
 
     name = Unicode("GitLab")
@@ -956,10 +956,9 @@ class GistRepoProvider(GitHubRepoProvider):
 
     The ref is optional, valid values are
         - a full sha1 of a ref in the history
-        - master
-        - HEAD for the default branch
+        - HEAD for the latest ref (also allow 'master', 'main' as aliases for HEAD)
 
-    If master or no ref is specified the latest revision will be used.
+    If HEAD or no ref is specified the latest revision will be used.
     """
 
     name = Unicode("Gist")
@@ -1020,7 +1019,7 @@ class GistRepoProvider(GitHubRepoProvider):
             )
 
         all_versions = [e["version"] for e in ref_info["history"]]
-        if self.unresolved_ref in {"", "HEAD", "master"}:
+        if self.unresolved_ref in {"", "HEAD", "master", "main"}:
             self.resolved_ref = all_versions[0]
         else:
             if self.unresolved_ref not in all_versions:

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -41,6 +41,8 @@ from .utils import async_requests
         # gh/ GitHub repo provider
         "gh/binderhub-ci-repos/cached-minimal-dockerfile/HEAD",
         "gh/binderhub-ci-repos/cached-minimal-dockerfile/596b52f10efb0c9befc0c4ae850cc5175297d71c",
+        # test redirect master->HEAD
+        "gh/binderhub-ci-repos/cached-minimal-dockerfile/master",
         # gl/ GitLab repo provider
         "gl/binderhub-ci-repos%2Fcached-minimal-dockerfile/HEAD",
         "gl/binderhub-ci-repos%2Fcached-minimal-dockerfile/596b52f10efb0c9befc0c4ae850cc5175297d71c",

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -360,14 +360,14 @@ class TestSpecErrorHandling(TestCase):
         assert len(spec_parts) == 3
 
     def test_spec_with_no_suggestion(self):
-        spec = "short/master"
+        spec = "short/HEAD"
         error = "^((?!Did you mean).)*$"  # negative match
         with self.assertRaisesRegex(ValueError, error):
             user, repo, unresolved_ref = tokenize_spec(spec)
 
     def test_spec_with_suggestion(self):
         spec = "short/suggestion"
-        error = f'Did you mean "{spec}/main"?'
+        error = f'Did you mean "{spec}/HEAD"?'
         with self.assertRaisesRegex(ValueError, error):
             user, repo, unresolved_ref = tokenize_spec(spec)
 


### PR DESCRIPTION
If 'master' or 'main' fail to resolve, try again with 'HEAD' after a delay.

this keeps outdated links to renamed default branches working for the big master->main migration

closes #1570