### PR TITLE
Auth requires `jupyterhub.hub.loadRoles`

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -26,6 +26,11 @@ you need to add the following into ``config.yaml``:
           binder:
             oauth_no_confirm: true
             oauth_redirect_uri: "https://<binderhub_url>/oauth_callback"
+        loadRoles:
+          user:
+            scopes:
+              - self
+              - "access:services"
 
       singleuser:
         # to make notebook servers aware of hub


### PR DESCRIPTION
This is in the test config but is missing from the docs https://github.com/jupyterhub/binderhub/blob/0a7c129b5423b9d81e74bd93149a1da39d1fffb6/testing/local-binder-k8s-hub/jupyterhub-chart-config-auth-additions.yaml#L16-L20
