### PR TITLE
Bump repo2docker to 2022.10.0

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -514,7 +514,7 @@ class BinderHub(Application):
         return os.environ.get("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2022.02.0",
+        "quay.io/jupyterhub/repo2docker:2022.10.0",
         help="""
         The repo2docker image to be used for doing builds
         """,

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -229,7 +229,7 @@ class KubernetesBuildExecutor(BuildExecutor):
         return os.getenv("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2022.02.0",
+        "quay.io/jupyterhub/repo2docker:2022.10.0",
         help="Docker image containing repo2docker that is used to spawn the build pods.",
         config=True,
     )


### PR DESCRIPTION
This needs to be updated in two places at the moment since we're in the middle of the Traitlets refactoring (https://github.com/jupyterhub/binderhub/pull/1521)