### PR TITLE
Warn about build_docker_config being a Helm Chart option not a BinderHub option

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -456,6 +456,10 @@ class BinderHub(Application):
         have an effect, as the push_secrets will overwrite
         .docker/config.json
         In this case, make sure that you include your config in your push_secret
+
+        WARNING: The value of this parameter is managed by the binderHub Helm Chart.
+        It is not managed by the BinderHub application itself.
+        If you are running BinderHub in another way this parameter has no effect.
         """,
         config=True,
     )


### PR DESCRIPTION
This was added in https://github.com/jupyterhub/binderhub/pull/1255

As far as I can see the value of `c.BinderHub.build_docker_config` isn't used by the BinderHub Python app, only it's presence is checked:
```
$ git grep build_docker_config origin/main

origin/main:binderhub/app.py:    build_docker_config = Dict(
origin/main:binderhub/app.py:                "build_docker_config": self.build_docker_config,
origin/main:binderhub/builder.py:        if self.settings["use_registry"] or self.settings["build_docker_config"]:
```
Instead it's used in the Helm Chart secret:
https://github.com/jupyterhub/binderhub/blob/2ba938bf20201ff864b3a6c473f66f30fbef92bc/helm-chart/binderhub/templates/secret.yaml#L34-L42

This adds a warning message to help avoid confusion.

Note I don't understand the Helm chart code....  the secret refers to `config.BinderHub.buildDockerConfig` instead of `config.BinderHub.build_docker_config`.