### PR TITLE
Fix the default `use_registry` value

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -40,7 +40,9 @@ service:
   loadBalancerIP:
 
 config:
-  BinderHub: {}
+  BinderHub:
+    # This must equal the default value of c.BinderHub.use_registry
+    use_registry: true
 
 extraConfig: {}
 

--- a/testing/k8s-binder-k8s-hub/binderhub-chart-config-old.yaml
+++ b/testing/k8s-binder-k8s-hub/binderhub-chart-config-old.yaml
@@ -25,7 +25,7 @@ ingress:
 # against which we haven't. We currently only test this via
 # lint-and-validate-values.yaml that makes sure our rendered templates are
 # valid against a k8s api-server.
-imageBuilderType: "local"
+imageBuilderType: host
 
 # NOTE: This is a mirror of the jupyterhub section in
 #       jupyterhub-chart-config.yaml in testing/local-binder-k8s-hub, keep these


### PR DESCRIPTION
`use_registry` defaults to try in BinderHub
https://github.com/jupyterhub/binderhub/blob/03545a1587f2d781ff4934beac8b8b8a19280754/binderhub/app.py#L261-L270

but the Helm chart implicitly defaults to `False`:
https://github.com/jupyterhub/binderhub/blob/03545a1587f2d781ff4934beac8b8b8a19280754/helm-chart/binderhub/templates/deployment.yaml#L68-L76

Which will lead to a broken deployment.

Also includes a commit to fix the CI upgrade/diff check.