### PR TITLE
Fix auth docs config (again)

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -21,9 +21,10 @@ you need to add the following into ``config.yaml``:
         redirectToServer: false
         config:
           BinderSpawner:
-            auth_enabled: false
+            auth_enabled: true
         services:
           binder:
+            oauth_client_id: service-binderhub
             oauth_no_confirm: true
             oauth_redirect_uri: "https://<binderhub_url>/oauth_callback"
         loadRoles:
@@ -75,7 +76,7 @@ you have to enable named servers on JupyterHub:
       hub:
         allowNamedServers: true
         # change this value as you wish,
-        # or remove this line if you don't want to have any limit
+        # or set to 0 if you don't want to have any limit
         namedServerLimitPerUser: 5
 
 .. note::


### PR DESCRIPTION
The value of `oauth_client_id` doesn't matter, but it's needed, otherwise you'll get
```
400 : Bad Request
Missing client_id parameter.
```

Omitting `namedServerLimitPerUser` fails because BinderHub ends up calling `int("")` and fails:
https://github.com/jupyterhub/binderhub/blob/1b040a654c79b01c9a6d56c04b19aa905281146d/helm-chart/binderhub/templates/deployment.yaml#L138-L143

I'm going to try and add a proper Helm test in a separate PR since we don't have a proper test for this config.