### PR TITLE
Add all `c.BinderHub.*` properties used in chart to Values.yaml

### DIFF
--- a/helm-chart/binderhub/templates/container-builder/daemonset.yaml
+++ b/helm-chart/binderhub/templates/container-builder/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
         key: hub.jupyter.org_dedicated
         operator: Equal
         value: user
-      nodeSelector: {{ .Values.config.BinderHub.build_node_selector | default dict | toJson }}
+      nodeSelector: {{ .Values.config.BinderHub.build_node_selector | toJson }}
 
       {{- with $builder.initContainers }}
       initContainers:

--- a/helm-chart/binderhub/templates/deployment.yaml
+++ b/helm-chart/binderhub/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
         {{- if .Values.deployment.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.config.BinderHub.base_url | default "/" }}versions
+            path: {{ .Values.config.BinderHub.base_url }}versions
             port: binder
           initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.deployment.readinessProbe.periodSeconds }}
@@ -161,7 +161,7 @@ spec:
         {{- if .Values.deployment.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.config.BinderHub.base_url | default "/" }}versions
+            path: {{ .Values.config.BinderHub.base_url }}versions
             port: binder
           initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.deployment.livenessProbe.periodSeconds }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -40,8 +40,13 @@ service:
   loadBalancerIP:
 
 config:
+  # These c.BinderHub properties are referenced by the Helm chart
   BinderHub:
-    # This must equal the default value of c.BinderHub.use_registry
+    # auth_enabled:
+    base_url: /
+    build_node_selector: {}
+    # hub_url:
+    # hub_url_local:
     use_registry: true
 
 extraConfig: {}


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/binderhub/pull/1597

Adds all `c.BinderHub.*` properties used in chart to Values.yaml for visibility, except for `buildDockerConfig` which will be [dealt with separately](https://github.com/jupyterhub/binderhub/issues/1594).

```
$ git grep Values\\.config\\. -- helm-chart/

helm-chart/binderhub/templates/_helpers.tpl:{{- if .Values.config.BinderHub.buildDockerConfig }}
helm-chart/binderhub/templates/_helpers.tpl:{{- $dockerConfig := merge $dockerConfig .Values.config.BinderHub.buildDockerConfig }}
helm-chart/binderhub/templates/container-builder/daemonset.yaml:      nodeSelector: {{ .Values.config.BinderHub.build_node_selector | default dict | toJson }}
helm-chart/binderhub/templates/deployment.yaml:      {{- if .Values.config.BinderHub.use_registry }}
helm-chart/binderhub/templates/deployment.yaml:          {{- if .Values.config.BinderHub.use_registry }}
helm-chart/binderhub/templates/deployment.yaml:        {{- if .Values.config.BinderHub.auth_enabled }}
helm-chart/binderhub/templates/deployment.yaml:          value: {{ (print (.Values.config.BinderHub.hub_url_local | default .Values.config.BinderHub.hub_url | trimSuffix "/") "/hub/api/") }}
helm-chart/binderhub/templates/deployment.yaml:            path: {{ .Values.config.BinderHub.base_url | default "/" }}versions
helm-chart/binderhub/templates/deployment.yaml:            path: {{ .Values.config.BinderHub.base_url | default "/" }}versions
helm-chart/binderhub/templates/image-cleaner.yaml:      nodeSelector: {{ .Values.config.BinderHub.build_node_selector | toJson }}
helm-chart/binderhub/templates/secret.yaml:{{- if or .Values.config.BinderHub.use_registry .Values.config.BinderHub.buildDockerConfig }}
```

This helps reduce the "hidden" configuration in the Helm Chart.