### PR TITLE
bump image-cleaner tag

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -295,7 +295,7 @@ imageCleaner:
   enabled: true
   image:
     name: quay.io/jupyterhub/docker-image-cleaner
-    tag: 1.0.0-beta.2
+    tag: 1.0.0-beta.3
     pullPolicy: ""
     pullSecrets: []
   # delete an image at most every 5 seconds


### PR DESCRIPTION
to get fixed pruning in https://github.com/jupyterhub/docker-image-cleaner/pull/94

our auto-image-bump workflow doesn't support prereleases, we can't use it for this image yet