### PR TITLE
ci: fix changed resolved ref for dataverse test, fix recent github ratelimit PR

### DIFF
--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -124,11 +124,11 @@ def mock_asynchttpclient(request):
     if not token:
         load_mock_responses("http-record.api.github.com.json")
         load_mock_responses("http-record.zenodo.org.json")
-    if token and token.startswith("ghs-"):
+    if token and token.startswith("ghs_"):
         # The GitHub Actions provided temporary token (secrets.github_token)
         # does not have access to api.github.com/gists. Due to this, we mock
         # such requests even if such token is provided. We recognize them by
-        # being a server-to-server token with a ghs- prefix as compared to for
+        # being a server-to-server token with a ghs_ prefix as compared to for
         # example a personal access token.
         #
         # More about github token prefixes:

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -95,11 +95,9 @@ def pytest_terminal_summary(terminalreporter, exitstatus):
             json.dump(records, f, sort_keys=True, indent=1)
 
 
-def load_mock_responses(host):
-    fname = os.path.join(here, f"http-record.{host}.json")
-    if not os.path.exists(fname):
-        return {}
-    with open(fname) as f:
+def load_mock_responses(file_name):
+    file_path = os.path.join(here, file_name)
+    with open(file_path) as f:
         records = json.load(f)
     MockAsyncHTTPClient.mocks.update(records)
 
@@ -120,12 +118,12 @@ def mock_asynchttpclient(request):
     # We should use as few mocked responses as possible because it means
     # we won't notice changes in the responses from the host that we are
     # mocking and our mock responses don't simulate every and all behavior
-    load_mock_responses("www.hydroshare.org")
+    load_mock_responses("http-record.www.hydroshare.org.json")
 
     token = os.getenv("GITHUB_ACCESS_TOKEN")
     if not token:
-        load_mock_responses("api.github.com")
-        load_mock_responses("zenodo.org")
+        load_mock_responses("http-record.api.github.com.json")
+        load_mock_responses("http-record.zenodo.org.json")
     if token and token.startswith("ghs-"):
         # The GitHub Actions provided temporary token (secrets.github_token)
         # does not have access to api.github.com/gists. Due to this, we mock
@@ -136,7 +134,7 @@ def mock_asynchttpclient(request):
         # More about github token prefixes:
         # https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/#identifiable-prefixes
         #
-        load_mock_responses("api.github.com.gists")
+        load_mock_responses("http-record.api.github.com.gists.json")
 
 
 @pytest.fixture

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -171,7 +171,7 @@ async def test_hydroshare_doi():
         [
             "10.7910/DVN/TJCLKP",
             "10.7910/DVN/TJCLKP",
-            "3035124.v3.0",
+            "3035124.v4.0",
             "https://doi.org/10.7910/DVN/TJCLKP",
             "dataverse-dvn-2ftjclkp",
         ],

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -170,21 +170,21 @@ async def test_hydroshare_doi():
     # "10.7910/DVN/TJCLKP" is a DOI associated with all versions of the
     # dataverse dataset, including the latest version and previous versions (v3,
     # v2, etc). Dataverse doesn't mint DOIs for each version of a dataset, but
-    # that has been discussed in https://github.com/IQSS/dataverse/issues/4499,
+    # that has been discussed in https://github.com/IQSS/dataverse/issues/4499
     #
     "spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug",
     [
         [
             "10.7910/DVN/TJCLKP",
             "10.7910/DVN/TJCLKP",
-            r"3035124.v\d+.\d+",
+            r"3035124\.v\d+\.\d+$",
             "https://doi.org/10.7910/DVN/TJCLKP",
             "dataverse-dvn-2ftjclkp",
         ],
         [
             "10.25346/S6/DE95RT",
             "10.25346/S6/DE95RT",
-            r"20460.v\d+.\d+",
+            r"20460\.v\d+\.\d+$",
             "https://doi.org/10.25346/S6/DE95RT",
             "dataverse-s6-2fde95rt",
         ],

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -1,3 +1,4 @@
+import re
 from unittest import TestCase
 from urllib.parse import quote
 
@@ -166,19 +167,24 @@ async def test_hydroshare_doi():
 
 
 @pytest.mark.parametrize(
+    # "10.7910/DVN/TJCLKP" is a DOI associated with all versions of the
+    # dataverse dataset, including the latest version and previous versions (v3,
+    # v2, etc). Dataverse doesn't mint DOIs for each version of a dataset, but
+    # that has been discussed in https://github.com/IQSS/dataverse/issues/4499,
+    #
     "spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug",
     [
         [
             "10.7910/DVN/TJCLKP",
             "10.7910/DVN/TJCLKP",
-            "3035124.v4.0",
+            r"3035124.v\d+.\d+",
             "https://doi.org/10.7910/DVN/TJCLKP",
             "dataverse-dvn-2ftjclkp",
         ],
         [
             "10.25346/S6/DE95RT",
             "10.25346/S6/DE95RT",
-            "20460.v1.0",
+            r"20460.v\d+.\d+",
             "https://doi.org/10.25346/S6/DE95RT",
             "dataverse-s6-2fde95rt",
         ],
@@ -191,7 +197,7 @@ async def test_dataverse(
 
     # have to resolve the ref first
     ref = await provider.get_resolved_ref()
-    assert ref == resolved_ref
+    assert re.match(resolved_ref, ref)
 
     slug = provider.get_build_slug()
     assert slug == build_slug


### PR DESCRIPTION
There was a new version of a DOI that was tested against, so "resolved_ref" transitioned from v3.0 to v4.0 it seems. The last update to this DOI was several years ago. I've made it into a regexp now though so if new releases happen, it should not break this again.

- Closes #1614

- Complements #1612 with a typo fix, and with that, our test suite should become reliable I think