### PR TITLE
Build memory limits/requests should be `ByteSpecification`

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -19,7 +19,7 @@ from tornado.log import app_log
 from traitlets import Any, Bool, Dict, Integer, Unicode, default
 from traitlets.config import LoggingConfigurable
 
-from .utils import KUBE_REQUEST_TIMEOUT, rendezvous_rank
+from .utils import KUBE_REQUEST_TIMEOUT, ByteSpecification, rendezvous_rank
 
 
 class ProgressEvent:
@@ -91,8 +91,10 @@ class BuildExecutor(LoggingConfigurable):
         config=True,
     )
 
-    memory_limit = Integer(
-        0, help="Memory limit for the build process in bytes", config=True
+    memory_limit = ByteSpecification(
+        0,
+        help="Memory limit for the build process in bytes (optional suffixes K M G T).",
+        config=True,
     )
 
     appendix = Unicode(
@@ -261,10 +263,10 @@ class KubernetesBuildExecutor(BuildExecutor):
         config=True,
     )
 
-    memory_request = Integer(
+    memory_request = ByteSpecification(
         0,
         help=(
-            "Memory request of the build pod. "
+            "Memory request of the build pod in bytes (optional suffixes K M G T). "
             "The actual building happens in the docker daemon, "
             "but setting request in the build pod makes sure that memory is reserved for the docker build "
             "in the node by the kubernetes scheduler."

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -201,6 +201,31 @@ def test_sticky_builds_affinity():
     ].preference.match_expressions[0].values[0] in ("node-a", "node-b")
 
 
+def test_build_memory_limits():
+    # Setup some mock objects for the response from the k8s API
+    mock_k8s_api = _list_image_builder_pods_mock()
+
+    build = KubernetesBuildExecutor(
+        q=mock.MagicMock(),
+        api=mock_k8s_api,
+        name="test_build",
+        namespace="build_namespace",
+        repo_url="repo",
+        ref="ref",
+        build_image="image",
+        image_name="name",
+        push_secret="",
+        memory_limit="2T",
+        memory_request="123G",
+        git_credentials="",
+        docker_host="http://mydockerregistry.local",
+        node_selector={},
+        sticky_builds=True,
+    )
+    assert build.memory_limit == 2199023255552
+    assert build.memory_request == 132070244352
+
+
 def test_git_credentials_passed_to_podspec_upon_submit():
     git_credentials = """{
         "client_id": "my_username",


### PR DESCRIPTION
This will hopefully fix https://github.com/jupyterhub/mybinder.org-deploy/pull/2477 on staging, which is failing due to
https://github.com/jupyterhub/mybinder.org-deploy/blob/b6c4eaee1a2f480319a661b15b01fed9880fcafe/mybinder/values.yaml#L162-L163
being rejected.