### PR TITLE
Proposed fix for ACR caching while providing guidance for GitLab users.

### DIFF
--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -264,7 +264,6 @@ class DockerRegistry(LoggingConfigurable):
                 client,
                 self.token_url,
                 scope=f"repository:{image}:pull",
-                service="container_registry",
             )
             req = httpclient.HTTPRequest(
                 url,

--- a/docs/source/zero-to-binderhub/setup-binderhub.rst
+++ b/docs/source/zero-to-binderhub/setup-binderhub.rst
@@ -174,6 +174,29 @@ where:
   If this is not provided, you may find BinderHub rebuilds images every launch instead of pulling them from the ACR.
   Suggestions for `<project-name>` could be `ACR_NAME` or the name you give your BinderHub.
 
+If you are using GitLab Container Registry 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want your BinderHub to push and pull images from a GitLab Container Registry, then your `config.yaml` file will look as follows::
+
+    config:
+      BinderHub:
+        use_registry: true
+        image_prefix: registry.gitlab.com/<gitlab-user>/<project-name>/<prefix>-
+      DockerRegistry:
+        token_url: "https://gitlab.com/jwt/auth?service=container_registry"
+        url: "https://registry.gitlab.com"
+    registry:
+      url: https://registry.gitlab.com
+
+where:
+
+* `<gitlab-user>` is your gitlab username,
+* `<project-name>` is an arbitrary name that is required due to BinderHub assuming that `image_prefix` contains an extra level for the project name.
+  See `this issue <https://github.com/jupyterhub/binderhub/issues/800>`_ for futher discussion.
+  If this is not provided, you may find BinderHub rebuilds images every launch instead of pulling them from the GitLab container registry.
+  Suggestions for `<project-name>` could be the name you give your BinderHub.
+
 If you are using OVH Container Registry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/zero-to-binderhub/setup-binderhub.rst
+++ b/docs/source/zero-to-binderhub/setup-binderhub.rst
@@ -174,10 +174,10 @@ where:
   If this is not provided, you may find BinderHub rebuilds images every launch instead of pulling them from the ACR.
   Suggestions for `<project-name>` could be `ACR_NAME` or the name you give your BinderHub.
 
-If you are using GitLab Container Registry 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you are using an authenticated (private) GitLab Container Registry 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want your BinderHub to push and pull images from a GitLab Container Registry, then your `config.yaml` file will look as follows::
+If you want your BinderHub to push and pull images from an authenticated (private) GitLab Container Registry, then your `config.yaml` file will look as follows::
 
     config:
       BinderHub:
@@ -186,12 +186,17 @@ If you want your BinderHub to push and pull images from a GitLab Container Regis
       DockerRegistry:
         token_url: "https://gitlab.com/jwt/auth?service=container_registry"
         url: "https://registry.gitlab.com"
+        username: <deploy-token-username>
+        password: <deploy-token-pw>
     registry:
       url: https://registry.gitlab.com
+      username: <deploy-token-username>
+      password: <deploy-token-pw>
 
 where:
 
 * `<gitlab-user>` is your gitlab username,
+* `<deploy-token-username>` and `<deploy-token-pw>` are valid GitLab credentials.  (Passwords may be moved to `secret.yaml`.)
 * `<project-name>` is an arbitrary name that is required due to BinderHub assuming that `image_prefix` contains an extra level for the project name.
   See `this issue <https://github.com/jupyterhub/binderhub/issues/800>`_ for futher discussion.
   If this is not provided, you may find BinderHub rebuilds images every launch instead of pulling them from the GitLab container registry.


### PR DESCRIPTION
Proposed fix for https://github.com/jupyterhub/binderhub/issues/1620

This supersedes a single line change of PR https://github.com/jupyterhub/binderhub/pull/1283 ... and provides documentation (like already exists for ACR) to maintain GitLab compatibility (but the documented instructions have not been validated).