### PR TITLE
ci: fix for redirect to hub.jupyter.org

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: "Install latest released dev chart"
         run: |
-          UPGRADE_FROM_VERSION=$(curl -sS https://jupyterhub.github.io/helm-chart/info.json | jq -er '.binderhub.dev')
+          UPGRADE_FROM_VERSION=$(curl -sSL https://jupyterhub.github.io/helm-chart/info.json | jq -er '.binderhub.dev')
 
           # NOTE: We change the directory so binderhub the chart name won't be
           #       misunderstood as the local folder name.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,7 +237,7 @@ jobs:
         if: matrix.test-variation == 'upgrade'
         run: |
           . ./ci/common
-          UPGRADE_FROM_VERSION=$(curl -sS https://jupyterhub.github.io/helm-chart/info.json | jq -er '.binderhub.${{ matrix.upgrade-from }}')
+          UPGRADE_FROM_VERSION=$(curl -sSL https://jupyterhub.github.io/helm-chart/info.json | jq -er '.binderhub.${{ matrix.upgrade-from }}')
           echo "UPGRADE_FROM_VERSION=$UPGRADE_FROM_VERSION" >> $GITHUB_ENV
 
           echo ""


### PR DESCRIPTION
See https://github.com/jupyterhub/team-compass/issues/444#issuecomment-1420350287.

Note that I don't want to update all links to hub.jupyter.org/helm-chart as part of this so that such change becomes consistent and something we discuss first.