### PR TITLE
switch default server to jupyter-server-based jupyter-lab

### DIFF
--- a/binderhub/binderspawner_mixin.py
+++ b/binderhub/binderspawner_mixin.py
@@ -84,6 +84,10 @@ class BinderSpawnerMixin(Configurable):
             if self.cors_allow_origin == "*":
                 args.append("--NotebookApp.allow_origin_pat=.*")
             args += self.args
+            # ServerApp compatibility: duplicate NotebookApp args
+            for arg in list(args):
+                if arg.startswith("--NotebookApp."):
+                    args.append(arg.replace("--NotebookApp.", "--ServerApp."))
         return args
 
     def start(self):

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -169,6 +169,10 @@ jupyterhub:
                     if self.cors_allow_origin == "*":
                         args.append("--NotebookApp.allow_origin_pat=.*")
                     args += self.args
+                    # ServerApp compatibility: duplicate NotebookApp args
+                    for arg in list(args):
+                        if arg.startswith("--NotebookApp."):
+                            args.append(arg.replace("--NotebookApp.", "--ServerApp."))
                 return args
 
             def start(self):

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -224,12 +224,14 @@ jupyterhub:
         else:
             have_lab = major >= 3
 
-        if have_lab and "NotebookApp.default_url" not in " ".join(sys.argv):
-            # if recent-enough lab is available, make it the default UI
-            sys.argv.insert(1, "--NotebookApp.default_url=/lab/")
+        if have_lab:
+          # technically, we could accept another jupyter-server-based frontend
+          exe = "jupyter-lab"
+        else:
+          exe = "jupyter-notebook"
 
         # launch the notebook server
-        os.execvp("jupyter-notebook", sys.argv)
+        os.execvp(exe, sys.argv)
     events: true
     storage:
       type: none


### PR DESCRIPTION
This will launch jupyter-server, and be far more likely to be compatible with current repos than launching the old jupyter-notebook server.

It also makes the behavior of unauthenticated binderhub more similar to authenticated binderhub, which already does this same thing via `jupyterhub-singleuser`.

more detail in #1634 

This is a breaking change, in that anything that _relied_ on running the old server (mostly legacy extensions, which _often_, but do not _always_ work) may break. But it's also a big fix, because now anything that relies on the _current_ server is not broken (i.e. JupyterLab itself). I think this will result in a _reduction_ of broken repos, but since it's a _change_, not a pure improvement, it's still a backward-incompatibility issue. It's also not great that repos cannot pick this, really, other than uninstalling jupyterlab, given how this works.

I can't seem to find it now, but I feel like we had a discussion and decided on switching the UI first (which we did a long time ago), and then switching the server at some later point, which is what's happening here. That was a long time ago, and I can't find it.

closes #1634 

xref https://github.com/jupyter-server/jupyter_server/issues/1038 - this should fix issues with jupyter-server 2.