### PR TITLE
Ensure hub_url is configured before use

### DIFF
--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -55,6 +55,8 @@ if imageBuilderType in ["dind", "pink"]:
         c.BinderHub.build_docker_host = f"unix://{hostSocketDir}/{socketname}.sock"
 
 if c.BinderHub.auth_enabled:
+    if "hub_url" not in c.BinderHub:
+        c.BinderHub.hub_url = ""
     hub_url = urlparse(c.BinderHub.hub_url)
     c.HubOAuth.hub_host = f"{hub_url.scheme}://{hub_url.netloc}"
     if "base_url" in c.BinderHub:

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -45,7 +45,7 @@ config:
     # auth_enabled:
     base_url: /
     build_node_selector: {}
-    hub_url: ""
+    # hub_url:
     # hub_url_local:
     use_registry: true
   KubernetesBuildExecutor: {}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -45,7 +45,7 @@ config:
     # auth_enabled:
     base_url: /
     build_node_selector: {}
-    # hub_url:
+    hub_url: ""
     # hub_url_local:
     use_registry: true
   KubernetesBuildExecutor: {}


### PR DESCRIPTION
This PR follows the discussion in discourse post [18215](https://discourse.jupyter.org/t/podman-inside-kubernetes-pink-or-docker-inside-docker-dind-to-build-repositories/18215).

Problem: the configuration of BinderHub fails if hub_url is not set.

Solution: set a default value for the `hub_url` in the helm chart. Check that `hub_url` is set before use.

I tested the helm chart (as per the documentation), but am unsure how to test the change to `binderhub_config.py` properly.