### PR TITLE
maint: refactoring around pycurl as an optional dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -409,7 +409,7 @@ jobs:
       - name: Setup Python package dependencies
         run: |
           pip install -r dev-requirements.txt -r testing/local-binder-local-hub/requirements.txt
-          pip install .
+          pip install ".[pycurl]"
 
       - name: Setup JupyterHub NPM dependencies
         run: npm install -g configurable-http-proxy

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,6 @@ jsonschema
 jupyter-repo2docker>=2021.08.0
 jupyter_packaging>=0.10.4,<2
 jupyterhub
-pycurl
 pytest
 pytest-asyncio
 pytest-cov

--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -123,7 +123,7 @@ continue.
    requirements locally.
 
    ```bash
-   python3 -m pip install -e . -r dev-requirements.txt
+   python3 -m pip install -e ".[pycurl]" -r dev-requirements.txt
    ```
 
 1. Install the JupyterHub Helm chart by itself into your Kubernetes cluster

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -29,9 +29,8 @@ ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     pip install build \
  && pip wheel --wheel-dir=/tmp/wheels \
-        . \
-        pycurl \
-        -r helm-chart/images/binderhub/requirements.txt
+        -r helm-chart/images/binderhub/requirements.txt \
+        .
 
 
 # The final stage
@@ -63,9 +62,8 @@ ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
     pip install --find-links=/tmp/wheels/ \
-        binderhub \
-        pycurl \
-        -r /tmp/requirements.txt
+        -r /tmp/requirements.txt \
+        binderhub
 
 # verify success of previous step
 RUN python -c "import pycurl, binderhub.app"

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -16,4 +16,10 @@ jupyterhub==3.*
 kubernetes==9.*
 
 # binderhub's dependencies
+#
+# We can't put ".[pycurl]" here directly as when we freeze this into
+# requirements.txt using ci/refreeze, its declaring "binderhub @ file:///io"
+# which is a problem as its an absolute path.
+#
+pycurl
 -r ../../../requirements.txt

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    Use the "Run workflow" button at https://github.com/jupyterhub/binderhub/actions/workflows/watch-dependencies.yaml
 #
-alembic==1.9.4
+alembic==1.10.2
     # via jupyterhub
 async-generator==1.10
     # via jupyterhub
@@ -20,9 +20,9 @@ certipy==0.1.3
     # via jupyterhub
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
-cryptography==39.0.1
+cryptography==40.0.0
     # via pyopenssl
 docker==6.0.1
     # via -r helm-chart/images/binderhub/../../../requirements.txt
@@ -33,7 +33,7 @@ google-api-core[grpc]==2.11.0
     #   google-cloud-appengine-logging
     #   google-cloud-core
     #   google-cloud-logging
-google-auth==2.16.1
+google-auth==2.16.3
     # via
     #   google-api-core
     #   google-cloud-core
@@ -46,7 +46,7 @@ google-cloud-core==2.3.2
     # via google-cloud-logging
 google-cloud-logging==3.5.0
     # via -r helm-chart/images/binderhub/requirements.in
-googleapis-common-protos[grpc]==1.58.0
+googleapis-common-protos[grpc]==1.59.0
     # via
     #   google-api-core
     #   google-cloud-audit-log
@@ -108,7 +108,7 @@ proto-plus==1.22.2
     # via
     #   google-cloud-appengine-logging
     #   google-cloud-logging
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   google-api-core
     #   google-cloud-appengine-logging
@@ -126,9 +126,11 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
+pycurl==7.45.2
+    # via -r helm-chart/images/binderhub/requirements.in
 pyjwt==2.6.0
     # via -r helm-chart/images/binderhub/../../../requirements.txt
-pyopenssl==23.0.0
+pyopenssl==23.1.0
     # via certipy
 pyrsistent==0.19.3
     # via jsonschema
@@ -160,7 +162,7 @@ six==1.16.0
     #   google-auth
     #   kubernetes
     #   python-dateutil
-sqlalchemy==2.0.4
+sqlalchemy==2.0.7
     # via
     #   alembic
     #   jupyterhub
@@ -174,8 +176,10 @@ traitlets==5.9.0
     #   jupyter-telemetry
     #   jupyterhub
 typing-extensions==4.5.0
-    # via sqlalchemy
-urllib3==1.26.14
+    # via
+    #   alembic
+    #   sqlalchemy
+urllib3==1.26.15
     # via
     #   docker
     #   kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-# About pycurl:
-# - pycurl is an optional dependency which improves performance
-# - pycurl requires both `curl-config` and `gcc` to be available when installing
-#   it from source.
-# - the reason we do not list pycurl here is that it is not needed when our
-#   code is imported to generate the documentation and it is tricky to install
-#   in the ReadTheDocs build environment.
 docker
 escapism
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,13 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        # optional dependency which improves performance
+        # pycurl is an optional dependency which improves performance
+        #
+        # - pycurl requires both `curl-config` and `gcc` to be available when
+        #   installing it from source.
+        # - pycurl should always be used in production, but it's not relevant
+        #   for building documentation which inspects the source code.
+        #
         "pycurl": ["pycurl"],
     },
 )


### PR DESCRIPTION
I saw an opportunity to reduce the complexity a bit by relying more on the optional dependency declared in setup.py on `pycurl` over specifying it separately. This would be especially relevant if we would enforce a version constraint on pycurl in setup.py.

We couldn't reduce the complexity that much since binderhub is installed locally. This is always tricky since requirements.in freezes into requirements.txt using `pip-compile` via the `ci/refreeze` script, and when it does we get an absolute path to install binderhub. And with that, I think we can't avoid issues when we are to install pre-built wheels in the Dockerfile.