### PR TITLE
maint: bump xterm and xterm-addon-fit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,28 @@
 {
   "name": "binderhub",
-  "version": "0.1.0",
-  "description": "`BinderHub`",
-  "devDependencies": {
-    "@babel/cli": "^7.15.7",
-    "@babel/core": "^7.15.5",
-    "@babel/preset-env": "^7.15.6",
-    "babel-loader": "^8.2.2",
-    "css-loader": "^6.2.0",
-    "eslint": "^7.32.0",
-    "mini-css-extract-plugin": "^2.3.0",
-    "webpack": "^5.52.1",
-    "webpack-cli": "^4.8.0"
-  },
+  "description": "BinderHub's web user interface involves javascript built by this node package.",
   "dependencies": {
-    "bootstrap": "^3.4.0",
-    "clipboard": "^2.0.8",
-    "event-source-polyfill": "^1.0.25",
-    "jquery": "^3.6.0",
-    "xterm": "^4.14.1",
-    "xterm-addon-fit": "^0.5.0"
+    "bootstrap": "^3.4.1",
+    "clipboard": "^2.0.11",
+    "event-source-polyfill": "^1.0.31",
+    "jquery": "^3.6.4",
+    "xterm": "^5.1.0",
+    "xterm-addon-fit": "^0.7.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.21.0",
+    "@babel/core": "^7.21.4",
+    "@babel/preset-env": "^7.21.4",
+    "babel-loader": "^9.1.2",
+    "css-loader": "^6.7.3",
+    "eslint": "^8.38.0",
+    "mini-css-extract-plugin": "^2.7.5",
+    "webpack": "^5.78.0",
+    "webpack-cli": "^5.0.1"
   },
   "scripts": {
     "webpack": "webpack",
     "webpack:watch": "webpack --watch",
     "lint": "eslint binderhub/static/js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jupyterhub/binderhub.git"
-  },
-  "author": "",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterhub/binderhub/issues"
-  },
-  "homepage": "https://github.com/jupyterhub/binderhub#readme"
+  }
 }


### PR DESCRIPTION
This PR bumps the `package.json`'s dependencies and devDependencies. Since we don't have a package-lock.json, the `^` means that in practice we are using the latest major version before and after this change for all packages except for those listed below. I've manually read through these changelogs and searched our code base for something breaking without finding anything.

**dependencies:**
- xterm, from v4 to v5, [related docs](https://github.com/xtermjs/xterm.js/releases/tag/5.0.0)
- xterm-addon-fit, from 0.5 to 0.7, related docs same as xterm above
- Unchanged: bootstrap, see #1395

**devDependencies:**
- eslint, from v7 to v8, [related docs](https://eslint.org/docs/latest/use/migrate-to-8.0.0)
- babel-loader, from v8 to v9, [related docs](https://github.com/babel/babel-loader/releases/tag/v9.0.0)
- webpack-cli, from v4 to v5, [related docs](https://github.com/webpack/webpack-cli/blob/master/CHANGELOG.md#500-2022-11-17)

---

- Test failure unrelated, reported in #1656