### PR TITLE
maint: Prompt check of public repo during ref resolution

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -297,7 +297,9 @@ class BuildHandler(BaseHandler):
             return
 
         if ref is None:
-            error_message = [f"Could not resolve ref for {key}. Double check your URL."]
+            error_message = [
+                f"Could not resolve ref for {key}. Double check your URL and that your repo is public."
+            ]
 
             if provider.name == "GitHub":
                 error_message.append(
@@ -333,9 +335,6 @@ class BuildHandler(BaseHandler):
                         )
                         # artificial delay for what should be broken links
                         await asyncio.sleep(10)
-
-            else:
-                error_message.append("Is your repo public?")
 
             if ref is None:
                 # ref can become non-None if redirected to HEAD


### PR DESCRIPTION
Resolves #1658

Instead of prompting the user to check if the URL for their repo is public only if it is not on GitHub and if all other resolution has failed, escalate prompting the user to check if the repo is public as soon as there are ref resolution problems.