### PR TITLE
Docker Hub now returns 401 for missing repos

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -391,7 +391,7 @@ class BuildHandler(BaseHandler):
                     break
                 except HTTPClientError:
                     app_log.exception(
-                        "Tornado HTTP Timeout error: Failed to get image manifest for %s",
+                        "Failed to get image manifest for %s",
                         image_name,
                     )
                     image_found = False


### PR DESCRIPTION
adds a `DockerRegistry.not_found_401` boolean to treat 401 as not found, in addition to 404. Only used if a token was successfully issued, which at least validates that _some_ valid credentials are held, even if they might not have the necessary permissions for private repos.

It is now impossible to distinguish between a repo not existing and not having access to the repo on Docker Hub.

From GESIS health logs, this appears to have changed at 22:20 CEST last night, a truly wild coincidence with the readmission of GESIS to the federation earlier that day.

@rgaiacs 