### PR TITLE
build binderhub wheel outside docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,9 +39,15 @@ jobs:
         with:
           # chartpress requires the full history
           fetch-depth: 0
+
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+
+      - uses: actions/setup-node@v3
+        # node required to build wheel
+        with:
+          node-version: "16"
 
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@v2
@@ -53,7 +59,10 @@ jobs:
         run: |
           . ./ci/common
           setup_helm v3.5.4
-          pip install --no-cache-dir chartpress>=2.1 pyyaml
+          pip install --no-cache-dir chartpress>=2.1 pyyaml build
+
+      - name: Build binderhub wheel
+        run: python3 -m build --wheel .
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -40,8 +40,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      - uses: actions/setup-node@v3
+        # node required to build wheel
+        with:
+          node-version: "16"
+
       - name: Install chartpress
-        run: pip install chartpress
+        run: pip install chartpress build
+
+      - name: Build binderhub wheel
+        run: python3 -m build --wheel .
 
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,6 +182,11 @@ jobs:
         run: |
           ./testing/local-binder-k8s-hub/install-jupyterhub-chart --auth
 
+      - name: Build binderhub wheel
+        if: matrix.test == 'helm'
+        run: |
+          python3 -m build .
+
       - name: Use chartpress to create the helm chart
         if: matrix.test == 'helm'
         run: |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
+build
 chartpress>=2.1
 click
 codecov

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -26,7 +26,7 @@ charts:
         # We manually specify the paths which chartpress should monitor for
         # changes that should trigger a rebuild of this image.
         paths:
-          - images/binderhub/requirements.txt
+          - images/binderhub
           - ../setup.py
           - ../binderhub
           - ../package.json

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -56,12 +56,11 @@ COPY helm-chart/images/binderhub/requirements.txt /tmp/requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
-    pip install --find-links=/tmp/wheels/ \
-        -r /tmp/requirements.txt \
-        binderhub
-
-# verify success of previous step
-RUN python -c "import pycurl, binderhub.app"
+    pip install --no-deps /tmp/wheels/* \
+    # validate pip install since it's not resolving dependencies
+ && pip check \
+    # verify success of previous step
+ && python -c "import pycurl, binderhub.app"
 
 EXPOSE 8585
 ENTRYPOINT ["tini", "--", "python", "-m", "binderhub"]

--- a/helm-chart/images/binderhub/Dockerfile
+++ b/helm-chart/images/binderhub/Dockerfile
@@ -10,27 +10,22 @@
 #
 FROM python:3.11-bullseye as build-stage
 
-# install node as required to build a binderhub wheel
-RUN echo "deb https://deb.nodesource.com/node_18.x bullseye main" > /etc/apt/sources.list.d/nodesource.list \
- && curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN apt-get update \
- && apt-get install --yes \
-        nodejs \
- && rm -rf /var/lib/apt/lists/*
-
 # Build wheels
 #
 # We set pip's cache directory and expose it across build stages via an
 # ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}). We use
 # the same technique for the directory /tmp/wheels.
 #
-COPY . .
+# assumes `python3 -m build .` has been run to create the wheel
+# in the top-level dist directory
+COPY helm-chart/images/binderhub/requirements.txt ./
+COPY dist .
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     pip install build \
  && pip wheel --wheel-dir=/tmp/wheels \
-        -r helm-chart/images/binderhub/requirements.txt \
-        .
+        -r ./requirements.txt \
+        ./binderhub*.whl
 
 
 # The final stage


### PR DESCRIPTION
with `python3 -m build .`

Avoids rebuilding the binderhub wheel in each Docker build stage, which takes ~10 minutes for each arm build on GHA.


emulated webpack takes ~10 minutes on GHA, so this should save quite a bit of time in the publish action, which is currently taking more than 20 minutes.