### PR TITLE
Use launch_quota.total_pods in health check

### DIFF
--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -251,7 +251,7 @@ class KubernetesHealthHandler(HealthHandler):
         n_user_pods = len(user_pods)
         n_build_pods = len(build_pods)
 
-        quota = self.settings["pod_quota"]
+        quota = self.settings["launch_quota"].total_pods
         total_pods = n_user_pods + n_build_pods
         usage = {
             "total_pods": total_pods,


### PR DESCRIPTION
not deprecated pod_quota

otherwise, health check reports the wrong value unless the deprecated value is specified