### PR TITLE
launch_quota.total_quota

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,7 +309,7 @@ jobs:
           await_jupyterhub
 
           echo curl http://localhost:30902/hub/api/ should print the JupyterHub version
-          curl http://localhost:30902/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body
+          curl http://localhost:30902/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body --retry-all-errors
 
       - name: Await and curl BinderHub
         if: matrix.test == 'helm'
@@ -318,7 +318,7 @@ jobs:
           await_binderhub binderhub-test
 
           echo curl http://localhost:30901/health to check BinderHub\'s health
-          curl http://localhost:30901/health --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body
+          curl http://localhost:30901/health --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body --retry-all-errors
 
       - name: Run main tests
         if: matrix.test == 'main'
@@ -426,7 +426,7 @@ jobs:
           sleep 5
 
           echo curl http://localhost:8000/hub/api/ should print the JupyterHub version
-          curl http://localhost:8000/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body
+          curl http://localhost:8000/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body --retry-all-errors
 
       - name: Run remote tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -309,7 +309,7 @@ jobs:
           await_jupyterhub
 
           echo curl http://localhost:30902/hub/api/ should print the JupyterHub version
-          curl http://localhost:30902/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused
+          curl http://localhost:30902/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body
 
       - name: Await and curl BinderHub
         if: matrix.test == 'helm'
@@ -318,7 +318,7 @@ jobs:
           await_binderhub binderhub-test
 
           echo curl http://localhost:30901/health to check BinderHub\'s health
-          curl http://localhost:30901/health --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused
+          curl http://localhost:30901/health --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body
 
       - name: Run main tests
         if: matrix.test == 'main'
@@ -342,7 +342,7 @@ jobs:
           if [ "${{ matrix.test }}" = "helm" ]; then
             for endpoint in versions health metrics; do
               echo -e "\n${endpoint}"
-              curl http://localhost:30901/$endpoint
+              curl http://localhost:30901/$endpoint --fail-with-body
             done
           fi
 
@@ -426,7 +426,7 @@ jobs:
           sleep 5
 
           echo curl http://localhost:8000/hub/api/ should print the JupyterHub version
-          curl http://localhost:8000/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused
+          curl http://localhost:8000/hub/api/ --max-time 5 --retry 5 --retry-delay 1 --retry-connrefused --fail-with-body
 
       - name: Run remote tests
         run: |

--- a/binderhub/health.py
+++ b/binderhub/health.py
@@ -251,7 +251,7 @@ class KubernetesHealthHandler(HealthHandler):
         n_user_pods = len(user_pods)
         n_build_pods = len(build_pods)
 
-        quota = self.settings["launch_quota"].total_pods
+        quota = self.settings["launch_quota"].total_quota
         total_pods = n_user_pods + n_build_pods
         usage = {
             "total_pods": total_pods,


### PR DESCRIPTION
Fix for https://github.com/jupyterhub/binderhub/pull/1682#issuecomment-1530106672
(and therefore https://github.com/jupyterhub/mybinder.org-deploy/issues/2617)

This should be `total_quota` since `LaunchQuota` is platform agnostic
https://github.com/jupyterhub/binderhub/blob/0c3d8b23d396f1d0d276605356c8c329b2cc1376/binderhub/quota.py#L43-L54
