### PR TITLE
JS: Move the binderhub API client to its own npm package

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,12 +11,14 @@ on:
       - ".eslintrc.js"
       - "package.json"
       - "binderhub/static/js/**"
+      - "js/**"
   push:
     paths:
       - ".github/workflows/eslint.yml"
       - ".eslintrc.js"
       - "package.json"
       - "binderhub/static/js/**"
+      - "js/**"
     branches-ignore:
       - "dependabot/**"
       - "pre-commit-ci-update-config"

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -15,7 +15,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import ClipboardJS from 'clipboard';
 import 'event-source-polyfill';
 
-import BinderImage from './src/image';
+import BinderImage from '@jupyterhub/binderhub-client';
 import { makeBadgeMarkup } from './src/badge';
 import { getPathType, updatePathText } from './src/path';
 import { nextHelpText } from './src/loading';

--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@jupyterhub/binderhub-client",
+  "version": "0.3.0",
+  "description": "Simple API client for the BinderHub EventSource API",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jupyterhub/binderhub.git"
+  },
+  "author": "Project Jupyter Contributors",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/jupyterhub/binderhub/issues"
+  },
+  "homepage": "https://github.com/jupyterhub/binderhub.js#readme",
+  "dependencies": {
+    "event-source-polyfill": "^1.0.31"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "webpack": "^5.78.0",
     "webpack-cli": "^5.0.1"
   },
+  "workspaces": [
+    "js/packages/binderhub-client"
+  ],
   "scripts": {
     "webpack": "webpack",
     "webpack:watch": "webpack --watch",


### PR DESCRIPTION
Many projects want / need to connect to the BinderHub API:

- [thebe](https://thebe.readthedocs.io)
- [prototype UI for connecting to a private binderhub from profile_list](https://github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui)

These all need to recreate a JS client interface to the BinderHub API.

This PR splits out the *existing* client API we have in the BinderHub JS codebase into its own package, and refers to that from the existing codebase. This has several advantages:

- Multiple projects can re-use this client code easily, without having to copy-paste.
- Separation of concerns allows us to eventually do wonderful things like **add unit tests** for the JS code.
- By using the npm [workspaces](https://docs.npmjs.com/cli/v9/using-npm/workspaces?v=true) feature, extra complexity overhead is very minimal. Note how small this PR actually is.

As added incentive, I've added doc strings for the methods in `BinderImage`. I will work on refactoring the JS code in there as well, but as a separate PR.