### PR TITLE
Add simple README for @jupyterhub/binderhub-client

### DIFF
--- a/js/packages/binderhub-client/README.md
+++ b/js/packages/binderhub-client/README.md
@@ -1,0 +1,3 @@
+# `binderhub-client`
+
+A simple way to access the [BinderHub API](https://binderhub.readthedocs.io/en/latest/api.html)


### PR DESCRIPTION
No README is shown in
https://www.npmjs.com/package/@jupyterhub/binderhub-client otherwise