### PR TITLE
JS: Rename BinderImage to BinderRepository

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -15,7 +15,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import ClipboardJS from 'clipboard';
 import 'event-source-polyfill';
 
-import BinderImage from '@jupyterhub/binderhub-client';
+import { BinderRepository } from '@jupyterhub/binderhub-client';
 import { makeBadgeMarkup } from './src/badge';
 import { getPathType, updatePathText } from './src/path';
 import { nextHelpText } from './src/loading';
@@ -167,7 +167,7 @@ function build(providerSpec, log, fitAddon, path, pathType) {
   $('.on-build').removeClass('hidden');
 
   const buildToken = $("#build-token").data('token');
-  const image = new BinderImage(providerSpec, BASE_URL, buildToken);
+  const image = new BinderRepository(providerSpec, BASE_URL, buildToken);
 
   image.onStateChange('*', function(oldState, newState, data) {
     if (data.message !== undefined) {

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -6,7 +6,7 @@ const EventSource = NativeEventSource || EventSourcePolyfill;
 /**
  * Build and launch a repository by talking to a BinderHub API endpoint
  */
-export default class BinderImage {
+export class BinderRepository {
   /**
    *
    * @param {string} providerSpec Spec of the form <provider>/<repo>/<ref> to pass to the binderhub API.


### PR DESCRIPTION
- Makes more sense, as we're representing a repository and then building it.
- Moves away from this being a default export, so we could export other functions and classes in the future. This is a 'breaking' change but nobody else uses this for now.

Ref https://github.com/jupyterhub/binderhub/issues/1373