### PR TITLE
refactor: pytest/coverage config to pyproject.toml, set --maxfail to 2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[run]
-omit =
-    binderhub/tests/*
-    binderhub/_version.py
-    versioneer.py
-parallel = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -324,18 +324,18 @@ jobs:
       - name: Run main tests
         if: matrix.test == 'main'
         # running the "main" tests means "all tests that aren't auth"
-        run: pytest -m "not auth" -v --maxfail=10 --cov binderhub --durations=10 --color=yes
+        run: pytest -m "not auth" --cov=binderhub
 
       - name: Run auth tests
         if: matrix.test == 'auth'
         # running the "auth" tests means "all tests that are marked as auth"
-        run: pytest -m "auth" -v --maxfail=10 --cov binderhub --durations=10 --color=yes
+        run: pytest -m "auth" --cov=binderhub
 
       - name: Run helm tests
         if: matrix.test == 'helm'
         run: |
           export BINDER_URL=http://localhost:30901
-          pytest --helm -m "remote" -v --maxfail=10 --cov binderhub --durations=10 --color=yes
+          pytest --helm -m "remote" --cov=binderhub
 
       - name: Get BinderHub health and metrics outputs
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ profile = "black"
 # ref: https://docs.pytest.org/en/stable/
 #
 [tool.pytest.ini_options]
-addopts = "--verbose --color=yes --durations=10 --maxfail=10"
+addopts = "--verbose --color=yes --durations=10 --maxfail=2"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 timeout = "60"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[tool.black]
-# target-version should be all supported versions
-target-version = ["py38", "py39", "py310", "py311"]
-
-[tool.isort]
-profile = "black"
-
 [build-system]
 requires = [
   "jupyter-packaging >= 0.10",
@@ -13,9 +6,31 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+
+# black is used for autoformatting Python code
+#
+# ref: https://black.readthedocs.io/en/stable/
+#
+[tool.black]
+# target-version should be all supported versions, see
+# https://github.com/psf/black/issues/751#issuecomment-473066811
+target-version = ["py38", "py39", "py310", "py311"]
+
+
+# isort is used for autoformatting Python code
+#
+# ref: https://pycqa.github.io/isort/
+#
+[tool.isort]
+profile = "black"
+
+
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
 [tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10 --maxfail=10"
 asyncio_mode = "auto"
+testpaths = ["tests"]
 timeout = "60"
-addopts = [
-  "--durations=10"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,15 @@ addopts = "--verbose --color=yes --durations=10 --maxfail=10"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 timeout = "60"
+
+# pytest-cov / coverage is used to measure code coverage of tests
+#
+# ref: https://coverage.readthedocs.io/en/stable/config.html
+#
+[tool.coverage.run]
+omit = [
+  "binderhub/tests/*",
+  "binderhub/_version.py",
+  "versioneer.py",
+]
+parallel = true


### PR DESCRIPTION
This is pure refactoring besides `--maxfail=2`, which I think is a bit better than having 10 failures before reporting the summary - which takes longer time. Also, with ten failures, its abit harder to sift through the logs to whats interesting to focus on between test run attempts.