### PR TITLE
maint: fix ruamel.yaml issue, flush needed now but not before

### DIFF
--- a/ci/check_embedded_chart_code.py
+++ b/ci/check_embedded_chart_code.py
@@ -17,7 +17,7 @@ import sys
 
 from ruamel.yaml import YAML
 
-yaml = YAML(typ="rt")
+yaml = YAML()
 yaml.preserve_quotes = True
 yaml.indent(mapping=2, sequence=4, offset=2)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,4 +13,4 @@ pytest-asyncio
 pytest-cov
 pytest-timeout
 requests
-ruamel.yaml>=0.15
+ruamel.yaml>=0.17.30

--- a/helm-chart/binderhub/files/binderhub_config.py
+++ b/helm-chart/binderhub/files/binderhub_config.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 
 from ruamel.yaml import YAML
 
-yaml = YAML(typ="safe")
+yaml = YAML()
 
 
 # memoize so we only load config once

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -155,7 +155,7 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.17.26
+ruamel-yaml==0.17.30
     # via jupyter-telemetry
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml

--- a/testing/local-binder-k8s-hub/install-jupyterhub-chart
+++ b/testing/local-binder-k8s-hub/install-jupyterhub-chart
@@ -12,7 +12,7 @@ from tempfile import NamedTemporaryFile
 
 from ruamel.yaml import YAML
 
-yaml = YAML(typ="safe")
+yaml = YAML()
 
 here = os.path.abspath(os.path.dirname(__file__))
 helm_chart = os.path.join(here, os.pardir, os.pardir, "helm-chart")
@@ -38,7 +38,9 @@ def _get_jupyterhub_dependency_version():
 
 with NamedTemporaryFile(mode="w") as tmp:
     with open(os.path.join(helm_chart, "binderhub", "values.yaml")) as values_in:
-        yaml.dump(yaml.load(values_in)["jupyterhub"], tmp.file)
+        jupyterhub_chart_config = yaml.load(values_in)["jupyterhub"]
+    yaml.dump(jupyterhub_chart_config, tmp.file)
+    tmp.flush()
 
     cmd = ["helm", "upgrade", "--install", "binderhub-test"]
     cmd.extend(

--- a/tools/generate-json-schema.py
+++ b/tools/generate-json-schema.py
@@ -15,7 +15,7 @@ from collections.abc import MutableMapping
 
 from ruamel.yaml import YAML
 
-yaml = YAML(typ="safe")
+yaml = YAML()
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
 schema_yaml = os.path.join(here_dir, os.pardir, "helm-chart/binderhub", "schema.yaml")

--- a/tools/validate-against-schema.py
+++ b/tools/validate-against-schema.py
@@ -4,7 +4,7 @@ import os
 import jsonschema
 from ruamel.yaml import YAML
 
-yaml = YAML(typ="safe")
+yaml = YAML()
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
 schema_yaml = os.path.join(here_dir, os.pardir, "helm-chart/binderhub", "schema.yaml")


### PR DESCRIPTION
Not sure why, but it seems now ruamel.yaml require us to flush content written to a file while we didn't before. Or? I'm quite confused, but our [test suite started failing](https://github.com/jupyterhub/binderhub/actions/workflows/test.yml?query=branch%3Amain), and now its resolved with this PR.