### PR TITLE
Update to jupyterhub 3.0.0-alpha.1, test k8s 1.27, require k8s 1.23+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         k3s-channel:
           # Available channels: https://github.com/k3s-io/k3s/blob/HEAD/channel.yaml
           # Don't use "latest", instead bump it using a PR so we know when a new version breaks BinderHub
-          - v1.26
+          - v1.27
         test:
           - main
           - auth
@@ -69,7 +69,7 @@ jobs:
           # which isn't documented anywhere, but is currently at 3.5.0. We also
           # test with the latest k8s and helm versions.
           #
-          - k3s-channel: v1.21
+          - k3s-channel: v1.23
             helm-version: v3.5.0
             test: helm
             test-variation: dind
@@ -77,14 +77,14 @@ jobs:
               --values testing/k8s-binder-k8s-hub/binderhub-chart+dind.yaml
               --set config.BinderHub.image_prefix=$REGISTRY_HOST/test/
               --set registry.url=http://$REGISTRY_HOST
-          - k3s-channel: v1.26
+          - k3s-channel: v1.27
             test: helm
             test-variation: pink
             local-chart-extra-args: >-
               --values testing/k8s-binder-k8s-hub/binderhub-chart+pink.yaml
               --set config.BinderHub.image_prefix=$REGISTRY_HOST/test/
               --set registry.url=http://$REGISTRY_HOST
-          - k3s-channel: v1.26
+          - k3s-channel: v1.27
             test: helm
             test-variation: upgrade
             # upgrade-from represents a release channel, see: https://jupyterhub.github.io/helm-chart/info.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,11 +27,12 @@ If you have custom configuration you should add it using the `extraConfig` Helm 
 - `cors.allowedOrigin` ➡️ `config.BinderHub.cors_allow_origin`
 - `jupyterhub.custom.cors.allowedOrigin` ➡️ `jupyterhub.hub.config.BinderSpawner.cors_allow_origin`
 
-### Kubernetes 1.21+ is required
+### Kubernetes 1.23+ is required
 
 Older versions of Kubernetes are no longer supported
 [#1493](https://github.com/jupyterhub/binderhub/pull/1493)
-[#1609](https://github.com/jupyterhub/binderhub/pull/1609).
+[#1609](https://github.com/jupyterhub/binderhub/pull/1609)
+[#1714](https://github.com/jupyterhub/binderhub/pull/1714).
 
 ### `dind.enabled` replaced by `imageBuilderType: dind`
 
@@ -75,11 +76,14 @@ The following build configuration properties should be set using Traitlets in th
 If you have subclassed `binderhub.build.Build` you must update your subclass (including `__init__()` if defined) to inherit from `binderhub.build.KubernetesBuildExecutor`.
 The behaviour of the class is otherwise unchanged.
 
-### Z2JH 2 and JupyterHub 3
+### Z2JH 3 and JupyterHub 4
 
-The Z2JH dependency has been updated to 2.0.0 which includes JupyterHub 3
-[#1544](https://github.com/jupyterhub/binderhub/pull/1544).
-See https://z2jh.jupyter.org/en/stable/administrator/upgrading/upgrade-1-to-2.html for breaking changes.
+The Z2JH dependency has been updated from 1.2.0 to 3.0.0 which includes JupyterHub 4
+[#1544](https://github.com/jupyterhub/binderhub/pull/1544) [#1714](https://github.com/jupyterhub/binderhub/pull/1714).
+
+See [Z2JH's upgrade notes](https://z2jh.jupyter.org/en/stable/administrator/upgrading/index.html)
+and [changelog](https://z2jh.jupyter.org/en/latest/changelog.html) for breaking
+changes in the upgrade from 1.2.0 to 2.0.0, and then from 2.0.0 to 3.0.0.
 
 ### Python versions have been increased
 

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   #            and run "./dependencies freeze --upgrade".
   #
   - name: jupyterhub
-    version: "3.0.0-alpha.1"
+    version: "3.0.0-beta.1"
     repository: "https://jupyterhub.github.io/helm-chart"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the

--- a/helm-chart/binderhub/Chart.yaml
+++ b/helm-chart/binderhub/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   #            and run "./dependencies freeze --upgrade".
   #
   - name: jupyterhub
-    version: "2.0.0"
+    version: "3.0.0-alpha.1"
     repository: "https://jupyterhub.github.io/helm-chart"
 description: |-
   BinderHub is like a JupyterHub that automatically builds environments for the
@@ -22,7 +22,7 @@ keywords: [jupyter, jupyterhub, binderhub]
 home: https://binderhub.readthedocs.io/en/latest/
 sources: [https://github.com/jupyterhub/binderhub]
 icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.23.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team

--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -10,7 +10,7 @@ google-cloud-logging==3.*
 # jupyterhub's major version should be matched with the JupyterHub Helm chart's
 # used version of JupyterHub.
 #
-jupyterhub==3.*
+jupyterhub==4.*
 
 # https://github.com/kubernetes-client/python
 kubernetes==9.*

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -76,7 +76,7 @@ jsonschema==4.17.3
     #   jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==4.0.0
+jupyterhub==4.0.1
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -76,7 +76,7 @@ jsonschema==4.17.3
     #   jupyter-telemetry
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==3.1.1
+jupyterhub==4.0.0
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in


### PR DESCRIPTION
I hope z2jh 3.0.0 can include unreleased oauthenticator 16, but bumping from 3.0.0-alpha.1 to that shouldn't be additionally breaking I think because binderhub won't rely on it - unless configured with auth, and then its the person configuring auth that need to look in oauthenticators changelog.

Should we go for a bump here of z2jh?

### Related

- Closes #1681
- #1667 
