### PR TITLE
add position: relative to the banner message div

### DIFF
--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -56,6 +56,7 @@ p > a:hover {
     padding: 16px;
     width: 100%;
     background-color: rgb(235, 236, 237);
+    position: relative;
 }
 
 #logo-container {


### PR DESCRIPTION
enables vertical-centering of elements within it via `margin: auto`

I'm thinking of the donate button on mybinder.org, which I'm trying to float on the right without messing up centering of the text message, and changing the number of lines in the banner makes it wonky: https://github.com/jupyterhub/mybinder.org-deploy/pull/2665
