### PR TITLE
Support dynamic push credentials obtained from registry

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -91,16 +91,16 @@ class BuildExecutor(LoggingConfigurable):
         config=True,
     )
 
-    registry_credentials = Unicode(
-        "",
+    registry_credentials = Dict(
+        {},
         help=(
             "Implementation dependent credentials for pushing image to a registry. "
             "For example, if push tokens are temporary this could be used to pass "
-            "dynamically created credentials as an encoded JSON blob "
-            '`{"registry": "docker.io", "username":"user", "password":"password"}` '
-            "in the environment variable `CONTAINER_ENGINE_REGISTRY_CREDENTIALS` to "
-            "repo2docker. "
-            "If provided this will be used instead of push_secret. "
+            "dynamically created credentials "
+            '`{"registry": "docker.io", "username":"user", "password":"password"}`. '
+            "This will be JSON encoded and passed in the environment variable "
+            "CONTAINER_ENGINE_REGISTRY_CREDENTIALS` to repo2docker. "
+            "If provided this will be used instead of push_secret."
         ),
         config=True,
     )
@@ -252,17 +252,17 @@ class KubernetesBuildExecutor(BuildExecutor):
         config=True,
     )
 
-    registry_credentials = Unicode(
-        "",
+    registry_credentials = Dict(
+        {},
         help=(
             "Implementation dependent credentials for pushing image to a registry. "
             "For example, if push tokens are temporary this could be used to pass "
-            "dynamically created credentials as an encoded JSON blob "
-            '`{"registry": "docker.io", "username":"user", "password":"password"}` '
-            "in the environment variable `CONTAINER_ENGINE_REGISTRY_CREDENTIALS` to "
-            "repo2docker. "
+            "dynamically created credentials "
+            '`{"registry": "docker.io", "username":"user", "password":"password"}`. '
+            "This will be JSON encoded and passed in the environment variable "
+            "CONTAINER_ENGINE_REGISTRY_CREDENTIALS` to repo2docker. "
             "If provided this will be used instead of push_secret. "
-            "Currently this is passed to the build pod as a plan text environment "
+            "Currently this is passed to the build pod as a plain text environment "
             "variable, though future implementations may use a Kubernetes secret."
         ),
         config=True,
@@ -440,7 +440,7 @@ class KubernetesBuildExecutor(BuildExecutor):
             env.append(
                 client.V1EnvVar(
                     name="CONTAINER_ENGINE_REGISTRY_CREDENTIALS",
-                    value=self.registry_credentials,
+                    value=json.dumps(self.registry_credentials),
                 )
             )
         elif self.push_secret:

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -463,7 +463,7 @@ class BuildHandler(BaseHandler):
                 image_without_tag, image_tag
             )
             if push_token:
-                build.push_secret_content = json.dumps(push_token)
+                build.registry_credentials = json.dumps(push_token)
         else:
             build.push_secret = ""
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -463,7 +463,7 @@ class BuildHandler(BaseHandler):
                 image_without_tag, image_tag
             )
             if push_token:
-                build.registry_credentials = json.dumps(push_token)
+                build.registry_credentials = push_token
         else:
             build.push_secret = ""
 

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -329,6 +329,14 @@ class DockerRegistry(LoggingConfigurable):
                 raise
         return json.loads(resp.body.decode("utf-8"))
 
+    async def get_credentials(self, image, tag):
+        """
+        If a dynamic token is required for pushing an image to the registry
+        return a dictionary of login credentials, otherwise return None
+        (caller should get credentials from some other source)
+        """
+        return None
+
 
 class FakeRegistry(DockerRegistry):
     """


### PR DESCRIPTION
Extracted from https://github.com/jupyterhub/binderhub/pull/1637
This is required to support time-limited registry credentials, as required by AWS ECR.

Required for https://github.com/jupyterhub/mybinder.org-deploy/issues/2629