### PR TITLE
Bump and publish @jupyterhub/binderhub-client

### DIFF
--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterhub/binderhub-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Simple API client for the BinderHub EventSource API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
Brings in https://github.com/jupyterhub/binderhub/pull/1694

There are currently no real external users of this package, except for
github.com/yuvipanda/prototype-kubespawner-dynamic-building-ui (which
I'm working on again now). I think the API will change around a bit as this gets
worked on.