### PR TITLE
Use URLSearchParams() to construct query strings

### DIFF
--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -25,10 +25,13 @@ export class BinderRepository {
    * Call the BinderHub API
    */
   fetch() {
-    let apiUrl = this.baseUrl + "build/" + this.providerSpec;
+    let apiUrl =  new URL(this.baseUrl + "build/" + this.providerSpec);
+    let params = new URLSearchParams();
     if (this.buildToken) {
-        apiUrl = apiUrl + `?build_token=${this.buildToken}`;
+        params.append('build_token', this.buildToken);
     }
+
+    apiUrl.search = params.toString();
 
     this.eventSource = new EventSource(apiUrl);
     this.eventSource.onerror = (err) => {


### PR DESCRIPTION
This is cleaner, and also allows us to support more query parameters in the future (when
https://github.com/jupyterhub/binderhub/pull/1647
lands)