### PR TITLE
local-binder-local-hub: Set min versions in requirements

### DIFF
--- a/testing/local-binder-local-hub/jupyterhub_config.py
+++ b/testing/local-binder-local-hub/jupyterhub_config.py
@@ -28,7 +28,7 @@ c.LocalContainerSpawner.cmd = "jupyter-notebook"
 
 c.Application.log_level = "DEBUG"
 c.Spawner.debug = True
-c.JupyterHub.authenticator_class = "nullauthenticator.NullAuthenticator"
+c.JupyterHub.authenticator_class = "null"
 
 c.JupyterHub.hub_ip = "0.0.0.0"
 c.JupyterHub.hub_connect_ip = hostip

--- a/testing/local-binder-local-hub/requirements.txt
+++ b/testing/local-binder-local-hub/requirements.txt
@@ -1,4 +1,3 @@
-dockerspawner
-jupyter-repo2docker
-jupyterhub
-nullauthenticator
+dockerspawner>=12
+jupyter-repo2docker>=2023.06.0
+jupyterhub>=3


### PR DESCRIPTION
NullAuthenticator is replaced by the built-in `null`.

I've set minimum versions of the requirements to more closely reflect what's we're likely to test locally.