### PR TITLE
Revert "Use URLSearchParams() to construct query strings"

### DIFF
--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -25,13 +25,10 @@ export class BinderRepository {
    * Call the BinderHub API
    */
   fetch() {
-    let apiUrl =  new URL(this.baseUrl + "build/" + this.providerSpec);
-    let params = new URLSearchParams();
+    let apiUrl = this.baseUrl + "build/" + this.providerSpec;
     if (this.buildToken) {
-        params.append('build_token', this.buildToken);
+        apiUrl = apiUrl + `?build_token=${this.buildToken}`;
     }
-
-    apiUrl.search = params.toString();
 
     this.eventSource = new EventSource(apiUrl);
     this.eventSource.onerror = (err) => {


### PR DESCRIPTION
Reverts jupyterhub/binderhub#1741

This code isn't tested by our CI, and resulted in a failure on mybinder.org: https://github.com/jupyterhub/binderhub/issues/1747 which now blocks further BinderHub updates.

This syntax can be seen to be invalid in a browser javascript console:
```
>> new URL("/" + "build/")
Uncaught TypeError: URL constructor: /build/ is not a valid URL.
```
