### PR TITLE
Enable prettier on JS & CSS as well

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,12 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "jquery": true,
-        "es6": true
-    },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "sourceType": "module"
-    },
-    "rules": {
-    }
+  env: {
+    browser: true,
+    jquery: true,
+    es6: true,
+  },
+  extends: "eslint:recommended",
+  parserOptions: {
+    sourceType: "module",
+  },
+  rules: {},
 };

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,9 @@ repos:
     hooks:
       - id: prettier
         exclude_types:
-          # These are excluded initially as pre-commit was added but can
-          # absolutely be enabled later. If so, we should consider having a
-          # separate run of pre-commit where we configure a line spacing of 4
-          # for these file formats.
+          # This was excluded initially as pre-commit was added but can
+          # absolutely be enabled later.
           - html
-          - javascript
-          - css
 
   # Misc autoformatting and linting
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/binderhub/static/index.css
+++ b/binderhub/static/index.css
@@ -1,282 +1,281 @@
 /* custom fonts we are going to be using. */
 
 @font-face {
-    font-family: ClearSans-Thin;
-    src: url('../static/fonts/clearsans/WOFF/ClearSans-Thin.woff');
+  font-family: ClearSans-Thin;
+  src: url("../static/fonts/clearsans/WOFF/ClearSans-Thin.woff");
 }
 
 @font-face {
-    font-family: ClearSans-Light;
-    src: url('../static/fonts/clearsans/WOFF/ClearSans-Light.woff');
+  font-family: ClearSans-Light;
+  src: url("../static/fonts/clearsans/WOFF/ClearSans-Light.woff");
 }
 
 @font-face {
-    font-family: ClearSans-Bold;
-    src: url('../static/fonts/clearsans/WOFF/ClearSans-Bold.woff');
+  font-family: ClearSans-Bold;
+  src: url("../static/fonts/clearsans/WOFF/ClearSans-Bold.woff");
 }
 
 .hidden {
-    display: none;
+  display: none;
 }
 
 body {
-    font-family: "ClearSans-Thin", sans-serif;
+  font-family: "ClearSans-Thin", sans-serif;
 }
 
 form {
-    font-family: "ClearSans-Light", sans-serif;
+  font-family: "ClearSans-Light", sans-serif;
 }
 
 p > a {
-    cursor: pointer;
-    color: rgb(120,120,120);
-    border-bottom: dotted 2px rgb(120,120,120);
-    transition: all 0.1s;
-    text-decoration: non
+  cursor: pointer;
+  color: rgb(120, 120, 120);
+  border-bottom: dotted 2px rgb(120, 120, 120);
+  transition: all 0.1s;
+  text-decoration: non;
 }
 
 p > a:hover {
-    color: rgb(30,30,30);
-    border-bottom: dotted 2px rgb(30,30,30);
-    text-decoration: none;
+  color: rgb(30, 30, 30);
+  border-bottom: dotted 2px rgb(30, 30, 30);
+  text-decoration: none;
 }
 
 #build-form {
-    color: rgb(50,50,50);
-    background: rgb(235, 236, 237);
-    padding: 55px;
-    padding-top: 25px;
-    padding-bottom: 20px;
+  color: rgb(50, 50, 50);
+  background: rgb(235, 236, 237);
+  padding: 55px;
+  padding-top: 25px;
+  padding-bottom: 20px;
 }
 
-
 #banner-container {
-    text-align: left;
-    color: black;
-    padding: 16px;
-    width: 100%;
-    background-color: rgb(235, 236, 237);
-    position: relative;
+  text-align: left;
+  color: black;
+  padding: 16px;
+  width: 100%;
+  background-color: rgb(235, 236, 237);
+  position: relative;
 }
 
 #logo-container {
-    text-align: center;
-    color: black;
-    padding: 16px;
+  text-align: center;
+  color: black;
+  padding: 16px;
 }
 
 #logo {
-    padding: 8px;
-    padding-bottom: 22px;
-    padding-top: 10px;
+  padding: 8px;
+  padding-bottom: 22px;
+  padding-top: 10px;
 }
 
 #header {
-    margin-left: 5%;
-    width: 90%;
-    padding-bottom: 24px;
+  margin-left: 5%;
+  width: 90%;
+  padding-bottom: 24px;
 }
 
-.btn-submit{
-    background-color:rgb(223, 132, 41);
-    box-shadow: 1px 1px rgba(0,0,0,.075);
-    color:white;
-    border:none;
-    height:35px;
-    width: 100%;
-    border-radius: 4px;
+.btn-submit {
+  background-color: rgb(223, 132, 41);
+  box-shadow: 1px 1px rgba(0, 0, 0, 0.075);
+  color: white;
+  border: none;
+  height: 35px;
+  width: 100%;
+  border-radius: 4px;
 }
 
 .jumbotron {
-    background: rgb(235, 236, 237);
+  background: rgb(235, 236, 237);
 }
 
 h3 {
-    color: rgb(70, 70, 70);
-    font-size: 42px;
-    line-height: 1.3;
+  color: rgb(70, 70, 70);
+  font-size: 42px;
+  line-height: 1.3;
 }
 
 h4 {
-    font-size: 20px;
-    color: rgb(70, 70, 70);
+  font-size: 20px;
+  color: rgb(70, 70, 70);
 }
 
 #form-header {
-    padding-bottom: 5px;
+  padding-bottom: 5px;
 }
 
 #build-progress {
-    font-family: ClearSans-Bold, sans-serif;
-    font-size: 16px;
-    height: 28px;
-    text-shadow: black 1px 1px 1px;
+  font-family: ClearSans-Bold, sans-serif;
+  font-size: 16px;
+  height: 28px;
+  text-shadow: black 1px 1px 1px;
 }
 
 #build-progress .progress-bar {
-    padding-top: 4px;
-
+  padding-top: 4px;
 }
 
 #explanation {
-    color: rgb(40, 40, 40);
-    font-size: 20px;
-    line-height: 1.5;
-    font-weight: bold
+  color: rgb(40, 40, 40);
+  font-size: 20px;
+  line-height: 1.5;
+  font-weight: bold;
 }
 
 #log-container .panel-body {
-    /* match color of terminal! */
-    background-color: black;
+  /* match color of terminal! */
+  background-color: black;
 }
 
 #launch-buttons {
-    margin-top: 24px;
-    width: 100%;
+  margin-top: 24px;
+  width: 100%;
 }
 
 #log {
-    height: 400px;
+  height: 400px;
 }
 
 #log .terminal {
-    font-family: "Roboto Mono", monospace;
+  font-family: "Roboto Mono", monospace;
 }
 
-.url, .badges{
-    background-color: #ffffff;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    border: 1px solid #ccc;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    border-radius: 4px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
+.url,
+.badges {
+  background-color: #ffffff;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  border: 1px solid #ccc;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
 }
 
-
-.url{
-    margin-bottom:20px;
+.url {
+  margin-bottom: 20px;
 }
 
-.badges{
-    margin-bottom:40px;
+.badges {
+  margin-bottom: 40px;
 }
 
-.dropdownmenu{
-    background-color:#DDDDDD;
-    border-radius: 3px 3px 0px 0px;
-    height:35px;
-    width: 100%;
+.dropdownmenu {
+  background-color: #dddddd;
+  border-radius: 3px 3px 0px 0px;
+  height: 35px;
+  width: 100%;
 }
 
-.dropdownmenu label{
-    color:black;
-    padding: 6px 12px;
-    margin:0px;
-    width: 95%;
+.dropdownmenu label {
+  color: black;
+  padding: 6px 12px;
+  margin: 0px;
+  width: 95%;
 }
 
-
-.badge-snippet-row, .url-row {
-    width: 100%;
-    display: flex;
-    flex-direction: reverse;
-    border-bottom: 1px #ccc solid;
-    padding: 10px;
+.badge-snippet-row,
+.url-row {
+  width: 100%;
+  display: flex;
+  flex-direction: reverse;
+  border-bottom: 1px #ccc solid;
+  padding: 10px;
 }
 
-.badge-snippet-row .icon, .url-row .icon {
-    order: 0;
-    max-width: 30px;
-    max-height: 40px;
-    padding:3px;
-    /* margin-top: 13px; */
-    /*margin-left: 4px; */
+.badge-snippet-row .icon,
+.url-row .icon {
+  order: 0;
+  max-width: 30px;
+  max-height: 40px;
+  padding: 3px;
+  /* margin-top: 13px; */
+  /*margin-left: 4px; */
 }
 
 .input-group-btn .btn {
-    border: solid #ccc 1px;
+  border: solid #ccc 1px;
 }
 
-.badge-snippet-row pre, .url-row pre {
-    order: 1;
-    margin: 0;
-    flex-grow: 1;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+.badge-snippet-row pre,
+.url-row pre {
+  order: 1;
+  margin: 0;
+  flex-grow: 1;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
-
 
 #how-it-works {
-    line-height: 1.5;
-    font-weight: bold;
-    font-size: 18px;
+  line-height: 1.5;
+  font-weight: bold;
+  font-size: 18px;
 }
 
 #how-it-works div.row {
-    margin: 32px;
-    display: flex;
-    flex-direction: row;
-    align-items: baseline;
+  margin: 32px;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
 }
 
 .point {
-    border-radius: 50%;
-    border-width: 5px;
-    border-style: solid;
-    width: 40px;
-    height: 40px;
-    padding: 2px 9px;
-    font-weight: 800;
-    font-family: 'ClearSans-Bold';
+  border-radius: 50%;
+  border-width: 5px;
+  border-style: solid;
+  width: 40px;
+  height: 40px;
+  padding: 2px 9px;
+  font-weight: 800;
+  font-family: "ClearSans-Bold";
 }
 
 .point-container {
-    padding-top: 4px;
+  padding-top: 4px;
 }
 
 .point-orange {
-    border-color: rgb(247, 144, 42);
-    color: rgb(247, 144, 42);
+  border-color: rgb(247, 144, 42);
+  color: rgb(247, 144, 42);
 }
 
 .point-red {
-    border-color: rgb(204, 67, 101);
-    color: rgb(204, 67, 101);
+  border-color: rgb(204, 67, 101);
+  color: rgb(204, 67, 101);
 }
 
 .point-blue {
-    border-color: rgb(41, 124, 184);
-    color: rgb(41, 124, 184);
+  border-color: rgb(41, 124, 184);
+  color: rgb(41, 124, 184);
 }
 
 /*reduce font size of h1 and h2 so the initial design when h3 and h4 tags were used respectively is retained*/
-h1{
-    font-size:1.25em;
+h1 {
+  font-size: 1.25em;
 }
 
-h2{
-    font-size:1.125em;
+h2 {
+  font-size: 1.125em;
 }
 
 span.front-em {
-    font-size: 1.5em;
+  font-size: 1.5em;
 }
 
 div.front {
-    font-size: .9em;
+  font-size: 0.9em;
 }
 
 h4.logo-subtext {
   margin-top: -60px;
 }
 
-.form-row .form-group:first-child{
+.form-row .form-group:first-child {
   padding-left: 0;
 }
 
-.form-row .form-group:last-child{
+.form-row .form-group:last-child {
   padding-right: 0;
 }
 
@@ -286,31 +285,30 @@ h4.logo-subtext {
 
 /**/
 
-@media (max-width: 991px){
-    .form-row .form-group {
-        padding: 0;
-    }
+@media (max-width: 991px) {
+  .form-row .form-group {
+    padding: 0;
+  }
 
-    #launch-buttons {
-        margin-top: inherit;
-    }
-
+  #launch-buttons {
+    margin-top: inherit;
+  }
 }
 
 /*Clipboard styling*/
 
-img.icon.clipboard{
-    order: 1;
-    border: thin solid silver;
-    border-radius: 5px;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    border-left: none;
+img.icon.clipboard {
+  order: 1;
+  border: thin solid silver;
+  border-radius: 5px;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-left: none;
 }
 img.icon.clipboard:hover {
-    background: #f5f5f5;
+  background: #f5f5f5;
 }
 
 img.icon.clipboard:active {
-    background: #ddd;
+  background: #ddd;
 }

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -10,35 +10,37 @@
   pushing -> built
   pushing -> failed
 */
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import ClipboardJS from 'clipboard';
-import 'event-source-polyfill';
+import { Terminal } from "xterm";
+import { FitAddon } from "xterm-addon-fit";
+import ClipboardJS from "clipboard";
+import "event-source-polyfill";
 
-import { BinderRepository } from '@jupyterhub/binderhub-client';
-import { makeBadgeMarkup } from './src/badge';
-import { getPathType, updatePathText } from './src/path';
-import { nextHelpText } from './src/loading';
+import { BinderRepository } from "@jupyterhub/binderhub-client";
+import { makeBadgeMarkup } from "./src/badge";
+import { getPathType, updatePathText } from "./src/path";
+import { nextHelpText } from "./src/loading";
 
-import 'xterm/css/xterm.css';
+import "xterm/css/xterm.css";
 
 // Include just the bootstrap components we use
-import 'bootstrap/js/dropdown';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap/dist/css/bootstrap-theme.min.css';
+import "bootstrap/js/dropdown";
+import "bootstrap/dist/css/bootstrap.min.css";
+import "bootstrap/dist/css/bootstrap-theme.min.css";
 
-import '../index.css';
+import "../index.css";
 
-const BASE_URL = $('#base-url').data().url;
-const BADGE_BASE_URL = $('#badge-base-url').data().url;
+const BASE_URL = $("#base-url").data().url;
+const BADGE_BASE_URL = $("#badge-base-url").data().url;
 let config_dict = {};
 
 function update_favicon(path) {
-    let link = document.querySelector("link[rel*='icon']") || document.createElement('link');
-    link.type = 'image/x-icon';
-    link.rel = 'shortcut icon';
-    link.href = path;
-    document.getElementsByTagName('head')[0].appendChild(link);
+  let link =
+    document.querySelector("link[rel*='icon']") ||
+    document.createElement("link");
+  link.type = "image/x-icon";
+  link.rel = "shortcut icon";
+  link.href = path;
+  document.getElementsByTagName("head")[0].appendChild(link);
 }
 
 function v2url(providerPrefix, repository, ref, path, pathType) {
@@ -49,25 +51,32 @@ function v2url(providerPrefix, repository, ref, path, pathType) {
   }
   let url;
   if (BADGE_BASE_URL) {
-    url = BADGE_BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
-  }
-  else {
-    url = window.location.origin + BASE_URL + 'v2/' + providerPrefix + '/' + repository + '/' + ref;
+    url =
+      BADGE_BASE_URL + "v2/" + providerPrefix + "/" + repository + "/" + ref;
+  } else {
+    url =
+      window.location.origin +
+      BASE_URL +
+      "v2/" +
+      providerPrefix +
+      "/" +
+      repository +
+      "/" +
+      ref;
   }
   if (path && path.length > 0) {
     // encode the path, it will be decoded in loadingMain
-    url = url + '?' + pathType + 'path=' + encodeURIComponent(path);
+    url = url + "?" + pathType + "path=" + encodeURIComponent(path);
   }
   return url;
 }
 
 function loadConfig(callback) {
   const req = new XMLHttpRequest();
-  req.onreadystatechange = function() {
-    if (req.readyState == 4 && req.status == 200)
-      callback(req.responseText)
+  req.onreadystatechange = function () {
+    if (req.readyState == 4 && req.status == 200) callback(req.responseText);
   };
-  req.open('GET', BASE_URL + "_config", true);
+  req.open("GET", BASE_URL + "_config", true);
   req.send(null);
 }
 
@@ -79,15 +88,17 @@ function setLabels() {
   const label_prop_disabled = config_dict[provider]["label_prop_disabled"];
   const placeholder = "HEAD";
 
-  $("#ref").attr('placeholder', placeholder).prop("disabled", ref_prop_disabled);
+  $("#ref")
+    .attr("placeholder", placeholder)
+    .prop("disabled", ref_prop_disabled);
   $("label[for=ref]").text(tag_text).prop("disabled", label_prop_disabled);
-  $("#repository").attr('placeholder', text);
+  $("#repository").attr("placeholder", text);
   $("label[for=repository]").text(text);
 }
 
 function updateRepoText() {
-  if (Object.keys(config_dict).length === 0){
-    loadConfig(function(res) {
+  if (Object.keys(config_dict).length === 0) {
+    loadConfig(function (res) {
       config_dict = JSON.parse(res);
       setLabels();
     });
@@ -97,79 +108,92 @@ function updateRepoText() {
 }
 
 function getBuildFormValues() {
-  const providerPrefix = $('#provider_prefix').val().trim();
-  let repo = $('#repository').val().trim();
-  if (providerPrefix !== 'git') {
-    repo = repo.replace(/^(https?:\/\/)?gist.github.com\//, '');
-    repo = repo.replace(/^(https?:\/\/)?github.com\//, '');
-    repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, '');
+  const providerPrefix = $("#provider_prefix").val().trim();
+  let repo = $("#repository").val().trim();
+  if (providerPrefix !== "git") {
+    repo = repo.replace(/^(https?:\/\/)?gist.github.com\//, "");
+    repo = repo.replace(/^(https?:\/\/)?github.com\//, "");
+    repo = repo.replace(/^(https?:\/\/)?gitlab.com\//, "");
   }
   // trim trailing or leading '/' on repo
-  repo = repo.replace(/(^\/)|(\/?$)/g, '');
+  repo = repo.replace(/(^\/)|(\/?$)/g, "");
   // git providers encode the URL of the git repository as the repo
   // argument.
-  if (repo.includes("://") || providerPrefix === 'gl') {
+  if (repo.includes("://") || providerPrefix === "gl") {
     repo = encodeURIComponent(repo);
   }
 
-  let ref = $('#ref').val().trim() || $("#ref").attr("placeholder");
-  if (providerPrefix === 'zenodo' || providerPrefix === 'figshare' || providerPrefix === 'dataverse' ||
-      providerPrefix === 'hydroshare') {
+  let ref = $("#ref").val().trim() || $("#ref").attr("placeholder");
+  if (
+    providerPrefix === "zenodo" ||
+    providerPrefix === "figshare" ||
+    providerPrefix === "dataverse" ||
+    providerPrefix === "hydroshare"
+  ) {
     ref = "";
   }
-  const path = $('#filepath').val().trim();
-  return {'providerPrefix': providerPrefix, 'repo': repo,
-          'ref': ref, 'path': path, 'pathType': getPathType()}
+  const path = $("#filepath").val().trim();
+  return {
+    providerPrefix: providerPrefix,
+    repo: repo,
+    ref: ref,
+    path: path,
+    pathType: getPathType(),
+  };
 }
 
 function updateUrls(formValues) {
   if (typeof formValues === "undefined") {
-      formValues = getBuildFormValues();
+    formValues = getBuildFormValues();
   }
   const url = v2url(
-               formValues.providerPrefix,
-               formValues.repo,
-               formValues.ref,
-               formValues.path,
-               formValues.pathType
-            );
+    formValues.providerPrefix,
+    formValues.repo,
+    formValues.ref,
+    formValues.path,
+    formValues.pathType,
+  );
 
-  if ((url||'').trim().length > 0){
+  if ((url || "").trim().length > 0) {
     // update URLs and links (badges, etc.)
-    $("#badge-link").attr('href', url);
-    $('#basic-url-snippet').text(url);
-    $('#markdown-badge-snippet').text(
-      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, 'markdown')
+    $("#badge-link").attr("href", url);
+    $("#basic-url-snippet").text(url);
+    $("#markdown-badge-snippet").text(
+      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, "markdown"),
     );
-    $('#rst-badge-snippet').text(
-      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, 'rst')
+    $("#rst-badge-snippet").text(
+      makeBadgeMarkup(BADGE_BASE_URL, BASE_URL, url, "rst"),
     );
   } else {
-    ['#basic-url-snippet', '#markdown-badge-snippet', '#rst-badge-snippet' ].map(function(item){
-      const el = $(item);
-      el.text(el.attr('data-default'));
-    })
+    ["#basic-url-snippet", "#markdown-badge-snippet", "#rst-badge-snippet"].map(
+      function (item) {
+        const el = $(item);
+        el.text(el.attr("data-default"));
+      },
+    );
   }
 }
 
 function build(providerSpec, log, fitAddon, path, pathType) {
   update_favicon(BASE_URL + "favicon_building.ico");
   // split provider prefix off of providerSpec
-  const spec = providerSpec.slice(providerSpec.indexOf('/') + 1);
+  const spec = providerSpec.slice(providerSpec.indexOf("/") + 1);
   // Update the text of the loading page if it exists
-  if ($('div#loader-text').length > 0) {
-    $('div#loader-text p.launching').text("Starting repository: " + decodeURIComponent(spec))
+  if ($("div#loader-text").length > 0) {
+    $("div#loader-text p.launching").text(
+      "Starting repository: " + decodeURIComponent(spec),
+    );
   }
 
-  $('#build-progress .progress-bar').addClass('hidden');
+  $("#build-progress .progress-bar").addClass("hidden");
   log.clear();
 
-  $('.on-build').removeClass('hidden');
+  $(".on-build").removeClass("hidden");
 
-  const buildToken = $("#build-token").data('token');
+  const buildToken = $("#build-token").data("token");
   const image = new BinderRepository(providerSpec, BASE_URL, buildToken);
 
-  image.onStateChange('*', function(oldState, newState, data) {
+  image.onStateChange("*", function (oldState, newState, data) {
     if (data.message !== undefined) {
       log.writeAndStore(data.message);
       fitAddon.fit();
@@ -178,45 +202,47 @@ function build(providerSpec, log, fitAddon, path, pathType) {
     }
   });
 
-  image.onStateChange('waiting', function() {
-    $('#phase-waiting').removeClass('hidden');
+  image.onStateChange("waiting", function () {
+    $("#phase-waiting").removeClass("hidden");
   });
 
-  image.onStateChange('building', function() {
-    $('#phase-building').removeClass('hidden');
+  image.onStateChange("building", function () {
+    $("#phase-building").removeClass("hidden");
     log.show();
   });
 
-  image.onStateChange('pushing', function() {
-    $('#phase-pushing').removeClass('hidden');
+  image.onStateChange("pushing", function () {
+    $("#phase-pushing").removeClass("hidden");
   });
 
-  image.onStateChange('failed', function() {
-    $('#build-progress .progress-bar').addClass('hidden');
-    $('#phase-failed').removeClass('hidden');
+  image.onStateChange("failed", function () {
+    $("#build-progress .progress-bar").addClass("hidden");
+    $("#phase-failed").removeClass("hidden");
 
     $("#loader").addClass("paused");
 
     // If we fail for any reason, show an error message and logs
     update_favicon(BASE_URL + "favicon_fail.ico");
     log.show();
-    if ($('div#loader-text').length > 0) {
-      $('#loader').addClass("error");
-      $('div#loader-text p.launching').html('Error loading ' + spec + '!<br /> See logs below for details.');
+    if ($("div#loader-text").length > 0) {
+      $("#loader").addClass("error");
+      $("div#loader-text p.launching").html(
+        "Error loading " + spec + "!<br /> See logs below for details.",
+      );
     }
     image.close();
   });
 
-  image.onStateChange('built', function(oldState) {
+  image.onStateChange("built", function (oldState) {
     if (oldState === null) {
-      $('#phase-already-built').removeClass('hidden');
-      $('#phase-launching').removeClass('hidden');
+      $("#phase-already-built").removeClass("hidden");
+      $("#phase-launching").removeClass("hidden");
     }
-    $('#phase-launching').removeClass('hidden');
+    $("#phase-launching").removeClass("hidden");
     update_favicon(BASE_URL + "favicon_success.ico");
   });
 
-  image.onStateChange('ready', function(oldState, newState, data) {
+  image.onStateChange("ready", function (oldState, newState, data) {
     image.close();
     // user server is ready, redirect to there
     image.launch(data.url, data.token, path, pathType);
@@ -229,113 +255,122 @@ function build(providerSpec, log, fitAddon, path, pathType) {
 function setUpLog() {
   const log = new Terminal({
     convertEol: true,
-    disableStdin: true
+    disableStdin: true,
   });
 
   const fitAddon = new FitAddon();
   log.loadAddon(fitAddon);
   const logMessages = [];
 
-  log.open(document.getElementById('log'), false);
+  log.open(document.getElementById("log"), false);
   fitAddon.fit();
 
-  $(window).resize(function() {
+  $(window).resize(function () {
     fitAddon.fit();
   });
 
   const $panelBody = $("div.panel-body");
   log.show = function () {
-    $('#toggle-logs button.toggle').text('hide');
-    $panelBody.removeClass('hidden');
+    $("#toggle-logs button.toggle").text("hide");
+    $panelBody.removeClass("hidden");
   };
 
   log.hide = function () {
-    $('#toggle-logs button.toggle').text('show');
-    $panelBody.addClass('hidden');
+    $("#toggle-logs button.toggle").text("show");
+    $panelBody.addClass("hidden");
   };
 
   log.toggle = function () {
-    if ($panelBody.hasClass('hidden')) {
+    if ($panelBody.hasClass("hidden")) {
       log.show();
     } else {
       log.hide();
     }
   };
 
-  $('#view-raw-logs').on('click', function(ev) {
-    const blob = new Blob([logMessages.join('')], { type: 'text/plain' });
+  $("#view-raw-logs").on("click", function (ev) {
+    const blob = new Blob([logMessages.join("")], { type: "text/plain" });
     this.href = window.URL.createObjectURL(blob);
     // Prevent the toggle action from firing
     ev.stopPropagation();
   });
 
-  $('#toggle-logs').click(log.toggle);
+  $("#toggle-logs").click(log.toggle);
 
   log.writeAndStore = function (msg) {
     logMessages.push(msg);
     log.write(msg);
-  }
+  };
 
   return [log, fitAddon];
 }
 
 function indexMain() {
-    const [log, fitAddon] = setUpLog();
+  const [log, fitAddon] = setUpLog();
 
-    // setup badge dropdown and default values.
+  // setup badge dropdown and default values.
+  updateUrls();
+
+  $("#provider_prefix_sel li").click(function (event) {
+    event.preventDefault();
+
+    $("#provider_prefix-selected").text($(this).text());
+    $("#provider_prefix").val($(this).attr("value"));
+    updateRepoText();
     updateUrls();
+  });
 
-    $("#provider_prefix_sel li").click(function(event){
-      event.preventDefault();
-
-      $("#provider_prefix-selected").text($(this).text());
-      $("#provider_prefix").val($(this).attr("value"));
-      updateRepoText();
-      updateUrls();
-    });
-
-    $("#url-or-file-btn").find("a").click(function (evt) {
+  $("#url-or-file-btn")
+    .find("a")
+    .click(function (evt) {
       evt.preventDefault();
 
       $("#url-or-file-selected").text($(this).text());
       updatePathText();
       updateUrls();
     });
-    updatePathText();
-    updateRepoText();
+  updatePathText();
+  updateRepoText();
 
-    $('#repository').on('keyup paste change', function() {updateUrls();});
+  $("#repository").on("keyup paste change", function () {
+    updateUrls();
+  });
 
-    $('#ref').on('keyup paste change', function() {updateUrls();});
+  $("#ref").on("keyup paste change", function () {
+    updateUrls();
+  });
 
-    $('#filepath').on('keyup paste change', function() {updateUrls();});
+  $("#filepath").on("keyup paste change", function () {
+    updateUrls();
+  });
 
-    $('#toggle-badge-snippet').on('click', function() {
-        const badgeSnippets = $('#badge-snippets');
-        if (badgeSnippets.hasClass('hidden')) {
-            badgeSnippets.removeClass('hidden');
-            $("#badge-snippet-caret").removeClass("glyphicon-triangle-right");
-            $("#badge-snippet-caret").addClass("glyphicon-triangle-bottom");
-        } else {
-            badgeSnippets.addClass('hidden');
-            $("#badge-snippet-caret").removeClass("glyphicon-triangle-bottom");
-            $("#badge-snippet-caret").addClass("glyphicon-triangle-right");
-        }
+  $("#toggle-badge-snippet").on("click", function () {
+    const badgeSnippets = $("#badge-snippets");
+    if (badgeSnippets.hasClass("hidden")) {
+      badgeSnippets.removeClass("hidden");
+      $("#badge-snippet-caret").removeClass("glyphicon-triangle-right");
+      $("#badge-snippet-caret").addClass("glyphicon-triangle-bottom");
+    } else {
+      badgeSnippets.addClass("hidden");
+      $("#badge-snippet-caret").removeClass("glyphicon-triangle-bottom");
+      $("#badge-snippet-caret").addClass("glyphicon-triangle-right");
+    }
 
-        return false;
-    });
+    return false;
+  });
 
-    $('#build-form').submit(function() {
-        const formValues = getBuildFormValues();
-        updateUrls(formValues);
-        build(
-          formValues.providerPrefix + '/' + formValues.repo + '/' + formValues.ref,
-          log, fitAddon,
-          formValues.path,
-          formValues.pathType
-        );
-        return false;
-    });
+  $("#build-form").submit(function () {
+    const formValues = getBuildFormValues();
+    updateUrls(formValues);
+    build(
+      formValues.providerPrefix + "/" + formValues.repo + "/" + formValues.ref,
+      log,
+      fitAddon,
+      formValues.path,
+      formValues.pathType,
+    );
+    return false;
+  });
 }
 
 function loadingMain(providerSpec) {
@@ -345,32 +380,32 @@ function loadingMain(providerSpec) {
   // that is good because it is the real value and '/'s will be trimmed in `launch`
   const params = new URL(location.href).searchParams;
   let pathType, path;
-  path = params.get('urlpath');
+  path = params.get("urlpath");
   if (path) {
-    pathType = 'url';
+    pathType = "url";
   } else {
-    path = params.get('labpath');
+    path = params.get("labpath");
     if (path) {
-      pathType = 'lab';
+      pathType = "lab";
     } else {
-      path = params.get('filepath');
+      path = params.get("filepath");
       if (path) {
-        pathType = 'file';
+        pathType = "file";
       }
     }
   }
   build(providerSpec, log, fitAddon, path, pathType);
 
   // Looping through help text every few seconds
-  const launchMessageInterval = 6 * 1000
+  const launchMessageInterval = 6 * 1000;
   setInterval(nextHelpText, launchMessageInterval);
 
   // If we have a long launch, add a class so we display a long launch msg
-  const launchTimeout = 120 * 1000
+  const launchTimeout = 120 * 1000;
   setTimeout(() => {
-    $('div#loader-links p.text-center').addClass("longLaunch");
+    $("div#loader-links p.text-center").addClass("longLaunch");
     nextHelpText();
-  }, launchTimeout)
+  }, launchTimeout);
 
   return false;
 }
@@ -380,6 +415,6 @@ window.loadingMain = loadingMain;
 window.indexMain = indexMain;
 
 // Load the clipboard after the page loads so it can find the buttons it needs
-window.onload = function() {
-  new ClipboardJS('.clipboard');
+window.onload = function () {
+  new ClipboardJS(".clipboard");
 };

--- a/binderhub/static/js/src/badge.js
+++ b/binderhub/static/js/src/badge.js
@@ -7,10 +7,9 @@ export function makeBadgeMarkup(badgeBaseUrl, baseUrl, url, syntax) {
     badgeImageUrl = window.location.origin + baseUrl + "badge_logo.svg";
   }
 
-  if (syntax === 'markdown') {
+  if (syntax === "markdown") {
     return "[![Binder](" + badgeImageUrl + ")](" + url + ")";
-  } else if (syntax === 'rst') {
+  } else if (syntax === "rst") {
     return ".. image:: " + badgeImageUrl + "\n :target: " + url;
-
   }
 }

--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -1,31 +1,32 @@
 // Cycle through helpful messages on the loading page
 const help_messages = [
-    'New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information.',
-    'You can learn more about building your own Binder repositories in <a target="_blank" href="https://docs.mybinder.org">the Binder community documentation</a>.',
-    'We use the <a target="_blank" href="https://repo2docker.readthedocs.io/">repo2docker</a> tool to automatically build the environment in which to run your code.',
-    'Take a look at the <a target="_blank" href="https://repo2docker.readthedocs.io/en/latest/config_files.html">full list of configuration files supported by repo2docker.</a>',
-    'Need more than just a Jupyter notebook? You can <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/howto/user_interface.html">customize the user interface</a>.',
-    'Take a look at our <a target="_blank" href="https://github.com/binder-examples/">gallery of example repositories</a>.',
-    'If a repository takes a long time to launch, it is usually because Binder needs to create the environment for the first time.',
-    'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that you can deploy yourself.',
-    'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide</a> that talks about what it is like to run a BinderHub.',
-    'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>.',
-    'Empty log? Notebook not loading? Maybe your ad blocker is interfering. Consider adding this site to the list of trusted sources.',
-    'Your launch may take longer the first few times a repository is used. This is because our machine needs to create your environment.',
-    'Read our <a target="_blank" href="https://discourse.jupyter.org/t/how-to-reduce-mybinder-org-repository-startup-time/4956">advice for speeding up your Binder launch</a>.',
-]
+  'New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information.',
+  'You can learn more about building your own Binder repositories in <a target="_blank" href="https://docs.mybinder.org">the Binder community documentation</a>.',
+  'We use the <a target="_blank" href="https://repo2docker.readthedocs.io/">repo2docker</a> tool to automatically build the environment in which to run your code.',
+  'Take a look at the <a target="_blank" href="https://repo2docker.readthedocs.io/en/latest/config_files.html">full list of configuration files supported by repo2docker.</a>',
+  'Need more than just a Jupyter notebook? You can <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/howto/user_interface.html">customize the user interface</a>.',
+  'Take a look at our <a target="_blank" href="https://github.com/binder-examples/">gallery of example repositories</a>.',
+  "If a repository takes a long time to launch, it is usually because Binder needs to create the environment for the first time.",
+  'The tool that powers this page is called <a target="_blank" href="https://binderhub.readthedocs.io">BinderHub</a>. It is an open source tool that you can deploy yourself.',
+  'The Binder team has <a target="_blank" href="https://mybinder-sre.readthedocs.io/en/latest/">a site reliability guide</a> that talks about what it is like to run a BinderHub.',
+  'You can connect with the Binder community in the <a target="_blank" href="https://discourse.jupyter.org/c/binder">Jupyter community forum</a>.',
+  "Empty log? Notebook not loading? Maybe your ad blocker is interfering. Consider adding this site to the list of trusted sources.",
+  "Your launch may take longer the first few times a repository is used. This is because our machine needs to create your environment.",
+  'Read our <a target="_blank" href="https://discourse.jupyter.org/t/how-to-reduce-mybinder-org-repository-startup-time/4956">advice for speeding up your Binder launch</a>.',
+];
 
 // Set a launch timeout beyond-which we'll stop cycling messages
-export function nextHelpText () {
-    const text = $('div#loader-links p.text-center');
-    let msg;
-    if (text !== null) {
-        if (!text.hasClass('longLaunch')) {
-            // Pick a random help message and update
-            msg = help_messages[Math.floor(Math.random() * help_messages.length)];
-        } else {
-            msg = 'Your session is taking longer than usual to start!<br />Check the log messages below to see what is happening.';
-        }
-        text.html(msg);
+export function nextHelpText() {
+  const text = $("div#loader-links p.text-center");
+  let msg;
+  if (text !== null) {
+    if (!text.hasClass("longLaunch")) {
+      // Pick a random help message and update
+      msg = help_messages[Math.floor(Math.random() * help_messages.length)];
+    } else {
+      msg =
+        "Your session is taking longer than usual to start!<br />Check the log messages below to see what is happening.";
     }
+    text.html(msg);
+  }
 }

--- a/binderhub/static/loading.css
+++ b/binderhub/static/loading.css
@@ -2,61 +2,63 @@
 https://ihatetomatoes.net for initial code templates.*/
 
 #loader {
-    display: block;
-    position: relative;
-    left: 50%;
-    top: 50%;
-    width: 150px;
-    height: 150px;
-    margin: -20px 0 0 -75px;
-    border-radius: 50%;
-    border: 7px solid transparent;
-    border-top-color: #f5a252;
-    animation: spin 2s linear infinite;
-    z-index: 1001;
+  display: block;
+  position: relative;
+  left: 50%;
+  top: 50%;
+  width: 150px;
+  height: 150px;
+  margin: -20px 0 0 -75px;
+  border-radius: 50%;
+  border: 7px solid transparent;
+  border-top-color: #f5a252;
+  animation: spin 2s linear infinite;
+  z-index: 1001;
 }
 
-    #loader:before {
-        content: "";
-        position: absolute;
-        top: 5px;
-        left: 5px;
-        right: 5px;
-        bottom: 5px;
-        border-radius: 50%;
-        border: 7px solid transparent;
-        border-top-color: #579aca;
-        animation: spin 3s linear infinite;
-    }
+#loader:before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  right: 5px;
+  bottom: 5px;
+  border-radius: 50%;
+  border: 7px solid transparent;
+  border-top-color: #579aca;
+  animation: spin 3s linear infinite;
+}
 
-    #loader:after {
-        content: "";
-        position: absolute;
-        top: 15px;
-        left: 15px;
-        right: 15px;
-        bottom: 15px;
-        border-radius: 50%;
-        border: 7px solid transparent;
-        border-top-color: #e66581;
-        animation: spin 1.5s linear infinite;
-    }
+#loader:after {
+  content: "";
+  position: absolute;
+  top: 15px;
+  left: 15px;
+  right: 15px;
+  bottom: 15px;
+  border-radius: 50%;
+  border: 7px solid transparent;
+  border-top-color: #e66581;
+  animation: spin 1.5s linear infinite;
+}
 
-    @keyframes spin {
-        0%   {
-            transform: rotateZ(0deg);
-        }
-        100% {
-            transform: rotateZ(360deg);
-        }
-    }
+@keyframes spin {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
 
-.error, .error:after, .error:before {
-    border-top-color: red !important;
+.error,
+.error:after,
+.error:before {
+  border-top-color: red !important;
 }
 
 .error {
-    animation: spin 30s linear infinite !important;
+  animation: spin 30s linear infinite !important;
 }
 
 .error:after {
@@ -67,47 +69,49 @@ https://ihatetomatoes.net for initial code templates.*/
   animation: spin 20s linear infinite !important;
 }
 
-.paused, .paused:after, .paused:before {
-   animation-play-state: paused !important;
+.paused,
+.paused:after,
+.paused:before {
+  animation-play-state: paused !important;
 }
 
 #demo-content {
-	padding-top: 100px;
+  padding-top: 100px;
 }
 
 div#loader-text {
-    min-height: 3em;
+  min-height: 3em;
 }
 
 #loader-text p {
-    z-index: 1002;
-    max-width: 750px;
-    text-align: center;
-    margin: 0px auto 10px auto;
+  z-index: 1002;
+  max-width: 750px;
+  text-align: center;
+  margin: 0px auto 10px auto;
 }
 
 #loader-text p.launching {
-    font-size: 2em;
+  font-size: 2em;
 }
 
 div#loader-links {
-    min-height: 6em;
+  min-height: 6em;
 }
 
 #loader-links p {
-    font-size: 1.5em;
-    text-align: center;
-    max-width:700px;
-    margin: 0px auto 10px auto;
+  font-size: 1.5em;
+  text-align: center;
+  max-width: 700px;
+  margin: 0px auto 10px auto;
 }
 
 div#log-container {
-    width: 80%;
-    margin: 0% 10%;
+  width: 80%;
+  margin: 0% 10%;
 }
 
 .hidden {
-    display: none;
+  display: none;
 }
 
 .preview {

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,25 +1,25 @@
 .right-next {
-    float: right;
-    max-width: 45%;
-    overflow: auto;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  float: right;
+  max-width: 45%;
+  overflow: auto;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.right-next::after{
-    content: ' »';
+.right-next::after {
+  content: " »";
 }
 
 .left-prev {
-    float: left;
-    max-width: 45%;
-    overflow: auto;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  float: left;
+  max-width: 45%;
+  overflow: auto;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.left-prev::before{
-    content: '« ';
+.left-prev::before {
+  content: "« ";
 }
 
 .prev-next-bottom {
@@ -30,7 +30,6 @@
   margin-bottom: 1em;
 }
 
-
 /* Federation page CSS */
 .contrib_entry p {
   margin: 2px;
@@ -38,12 +37,12 @@
 }
 
 p.contrib_affiliation {
-  font-size: .7em;
+  font-size: 0.7em;
   font-weight: bold;
 }
 
 .contribs_text {
-  font-size: .8em;
+  font-size: 0.8em;
 }
 
 .contrib_entry p.contribs {

--- a/examples/appendix/static/custom.js
+++ b/examples/appendix/static/custom.js
@@ -1,35 +1,48 @@
 function copy_link_into_clipboard(b) {
-    var $temp = $("<input>");
-    $(b).parent().append($temp);
-    $temp.val($(b).data('url')).select();
-    document.execCommand("copy");
-    $temp.remove();
+  var $temp = $("<input>");
+  $(b).parent().append($temp);
+  $temp.val($(b).data("url")).select();
+  document.execCommand("copy");
+  $temp.remove();
 }
 
 function add_binder_buttons() {
-    var copy_button = '<button id="copy-{name}-link" ' +
-            '                 title="Copy {name} link to clipboard" ' +
-            '                 class="btn btn-default btn-sm navbar-btn" ' +
-            '                 style="margin-right: 4px; margin-left: 2px;" ' +
-            '                 data-url="{url}" ' +
-            '                 onclick="copy_link_into_clipboard(this);">' +
-            '         Copy {name} link</button>';
+  var copy_button =
+    '<button id="copy-{name}-link" ' +
+    '                 title="Copy {name} link to clipboard" ' +
+    '                 class="btn btn-default btn-sm navbar-btn" ' +
+    '                 style="margin-right: 4px; margin-left: 2px;" ' +
+    '                 data-url="{url}" ' +
+    '                 onclick="copy_link_into_clipboard(this);">' +
+    "         Copy {name} link</button>";
 
-    var link_button = '<a id="copy-{name}-link" ' +
-        '                 href="{url}" ' +
-        '                 class="btn btn-default btn-sm navbar-btn" ' +
-        '                 style="margin-right: 4px; margin-left: 2px;" ' +
-        '                 target="_blank">' +
-        '              Go to {name}</a>';
+  var link_button =
+    '<a id="copy-{name}-link" ' +
+    '                 href="{url}" ' +
+    '                 class="btn btn-default btn-sm navbar-btn" ' +
+    '                 style="margin-right: 4px; margin-left: 2px;" ' +
+    '                 target="_blank">' +
+    "              Go to {name}</a>";
 
-    var s = $("<span id='binder-buttons'></span>");
-    s.append(link_button.replace(/{name}/g, 'repo').replace('{url}', '{repo_url}'));
-    s.append(copy_button.replace(/{name}/g, 'binder').replace('{url}', '{binder_url}'));
-    if ($("#ipython_notebook").length && $("#ipython_notebook>a").length) {
-        s.append(copy_button.replace(/{name}/g, 'session').replace('{url}', window.location.origin.concat($("#ipython_notebook>a").attr('href'))));
-    }
-    // add buttons at the end of header-container
-    $("#header-container").append(s);
+  var s = $("<span id='binder-buttons'></span>");
+  s.append(
+    link_button.replace(/{name}/g, "repo").replace("{url}", "{repo_url}"),
+  );
+  s.append(
+    copy_button.replace(/{name}/g, "binder").replace("{url}", "{binder_url}"),
+  );
+  if ($("#ipython_notebook").length && $("#ipython_notebook>a").length) {
+    s.append(
+      copy_button
+        .replace(/{name}/g, "session")
+        .replace(
+          "{url}",
+          window.location.origin.concat($("#ipython_notebook>a").attr("href")),
+        ),
+    );
+  }
+  // add buttons at the end of header-container
+  $("#header-container").append(s);
 }
 
 add_binder_buttons();

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -1,4 +1,4 @@
-import { NativeEventSource, EventSourcePolyfill } from 'event-source-polyfill';
+import { NativeEventSource, EventSourcePolyfill } from "event-source-polyfill";
 
 // Use native browser EventSource if available, and use the polyfill if not available
 const EventSource = NativeEventSource || EventSourcePolyfill;
@@ -27,14 +27,14 @@ export class BinderRepository {
   fetch() {
     let apiUrl = this.baseUrl + "build/" + this.providerSpec;
     if (this.buildToken) {
-        apiUrl = apiUrl + `?build_token=${this.buildToken}`;
+      apiUrl = apiUrl + `?build_token=${this.buildToken}`;
     }
 
     this.eventSource = new EventSource(apiUrl);
     this.eventSource.onerror = (err) => {
       console.error("Failed to construct event stream", err);
       this._changeState("failed", {
-        message: "Failed to connect to event stream\n"
+        message: "Failed to connect to event stream\n",
       });
     };
     this.eventSource.addEventListener("message", (event) => {
@@ -93,7 +93,6 @@ export class BinderRepository {
     window.location.href = url;
   }
 
-
   /**
    * Add callback whenever state of the current build changes
    *
@@ -130,7 +129,7 @@ export class BinderRepository {
   }
 
   _changeState(state, data) {
-    [state, "*"].map(key => {
+    [state, "*"].map((key) => {
       const callbacks = this.callbacks[key];
       if (callbacks) {
         for (let i = 0; i < callbacks.length; i++) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,58 +1,58 @@
-const webpack = require('webpack');
-const path = require('path');
+const webpack = require("webpack");
+const path = require("path");
 
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
-    mode: 'production',
-    context: path.resolve(__dirname, 'binderhub/static'),
-    entry: "./js/index.js",
-    output: {
-        path: path.resolve(__dirname, 'binderhub/static/dist/'),
-        filename: "bundle.js",
-        publicPath: '/static/dist/'
-    },
-    plugins: [
-        new webpack.ProvidePlugin({
-            $: 'jquery',
-            jQuery: 'jquery',
-        }),
-        new MiniCssExtractPlugin({
-            filename: 'styles.css'
-        }),
+  mode: "production",
+  context: path.resolve(__dirname, "binderhub/static"),
+  entry: "./js/index.js",
+  output: {
+    path: path.resolve(__dirname, "binderhub/static/dist/"),
+    filename: "bundle.js",
+    publicPath: "/static/dist/",
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery",
+    }),
+    new MiniCssExtractPlugin({
+      filename: "styles.css",
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /(node_modules|bower_components)/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env"],
+          },
+        },
+      },
+      {
+        test: /\.css$/i,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              // Set publicPath as relative path ("./").
+              // By default it uses the `output.publicPath` ("/static/dist/"), when it rewrites the URLs in styles.css.
+              // And it causes these files unavailabe if BinderHub has a different base_url than "/".
+              publicPath: "./",
+            },
+          },
+          "css-loader",
+        ],
+      },
+      {
+        test: /\.(eot|woff|ttf|woff2|svg)$/,
+        type: "asset/resource",
+      },
     ],
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                exclude: /(node_modules|bower_components)/,
-                use: {
-                  loader: 'babel-loader',
-                  options: {
-                    presets: ['@babel/preset-env'],
-                  }
-                }
-            },
-            {
-                test: /\.css$/i,
-                use: [
-                    {
-                        loader: MiniCssExtractPlugin.loader,
-                        options: {
-                            // Set publicPath as relative path ("./").
-                            // By default it uses the `output.publicPath` ("/static/dist/"), when it rewrites the URLs in styles.css.
-                            // And it causes these files unavailabe if BinderHub has a different base_url than "/".
-                            publicPath: "./",
-                        },
-                    },
-                    'css-loader'
-                ],
-            },
-            {
-                test: /\.(eot|woff|ttf|woff2|svg)$/,
-                type: 'asset/resource'
-            }
-        ]
-    },
-    devtool: 'source-map',
-}
+  },
+  devtool: "source-map",
+};


### PR DESCRIPTION
While the pre-existing comment suggested using 4-space indents, prettier ships by default with 2 space indents for JS & CSS. I looked at the JS code shipped in JupyterHub as well as JupyterLab, and found they are also using 2 space indents. So I would suggest we just use two space indents here.