### PR TITLE
Remove redundant kubernetes version pin

### DIFF
--- a/helm-chart/images/binderhub/requirements.in
+++ b/helm-chart/images/binderhub/requirements.in
@@ -12,9 +12,6 @@ google-cloud-logging==3.*
 #
 jupyterhub==4.*
 
-# https://github.com/kubernetes-client/python
-kubernetes==9.*
-
 # binderhub's dependencies
 #
 # We can't put ".[pycurl]" here directly as when we freeze this into

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -40,7 +40,7 @@ google-auth==2.23.2
     #   google-api-core
     #   google-cloud-core
     #   kubernetes
-google-cloud-appengine-logging==1.3.1
+google-cloud-appengine-logging==1.3.2
     # via google-cloud-logging
 google-cloud-audit-log==0.2.5
     # via google-cloud-logging
@@ -54,7 +54,7 @@ googleapis-common-protos[grpc]==1.60.0
     #   google-cloud-audit-log
     #   grpc-google-iam-v1
     #   grpcio-status
-greenlet==2.0.2
+greenlet==3.0.0
     # via sqlalchemy
 grpc-google-iam-v1==0.12.6
     # via google-cloud-logging
@@ -84,10 +84,8 @@ jupyterhub==4.0.2
     # via
     #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   -r helm-chart/images/binderhub/requirements.in
-kubernetes==9.0.1
-    # via
-    #   -r helm-chart/images/binderhub/../../../requirements.txt
-    #   -r helm-chart/images/binderhub/requirements.in
+kubernetes==28.1.0
+    # via -r helm-chart/images/binderhub/../../../requirements.txt
 mako==1.2.4
     # via alembic
 markupsafe==2.1.3
@@ -97,8 +95,9 @@ markupsafe==2.1.3
 oauthlib==3.2.2
     # via
     #   jupyterhub
+    #   kubernetes
     #   requests-oauthlib
-packaging==23.1
+packaging==23.2
     # via
     #   docker
     #   jupyterhub
@@ -190,7 +189,7 @@ typing-extensions==4.8.0
     # via
     #   alembic
     #   sqlalchemy
-urllib3==2.0.5
+urllib3==1.26.17
     # via
     #   docker
     #   kubernetes
@@ -199,6 +198,3 @@ websocket-client==1.6.3
     # via
     #   docker
     #   kubernetes
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
It's already specified in the requirements.txt in the root of the repo, so everyone developing binderhub locally has probably been using a much newer version anyway.

I've left the `jupyterhub` pin in as it might need to be co-ordinated with the version of z2jh the chart uses.

Fixes https://github.com/jupyterhub/binderhub/issues/1494