### PR TITLE
Add `BuildExecutor.repo2docker_extra_args` config

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -16,7 +16,7 @@ import kubernetes.config
 from kubernetes import client, watch
 from tornado.ioloop import IOLoop
 from tornado.log import app_log
-from traitlets import Any, Bool, Dict, Integer, Unicode, default
+from traitlets import Any, Bool, Dict, Integer, List, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from .utils import KUBE_REQUEST_TIMEOUT, ByteSpecification, rendezvous_rank
@@ -125,6 +125,15 @@ class BuildExecutor(LoggingConfigurable):
         config=True,
     )
 
+    repo2docker_extra_args = List(
+        Unicode,
+        default_value=[],
+        help="""
+        Extra commandline parameters to be passed to jupyter-repo2docker during build
+        """,
+        config=True,
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.main_loop = IOLoop.current()
@@ -155,6 +164,8 @@ class BuildExecutor(LoggingConfigurable):
         if self.memory_limit:
             r2d_options.append("--build-memory-limit")
             r2d_options.append(str(self.memory_limit))
+
+        r2d_options += self.repo2docker_extra_args
 
         return r2d_options
 

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -13,7 +13,7 @@ from kubernetes import client
 from tornado.httputil import url_concat
 from tornado.queues import Queue
 
-from binderhub.build import KubernetesBuildExecutor, ProgressEvent
+from binderhub.build import BuildExecutor, KubernetesBuildExecutor, ProgressEvent
 from binderhub.build_local import LocalRepo2dockerBuild, ProcessTerminated, _execute_cmd
 
 from .utils import async_requests
@@ -415,3 +415,21 @@ def test_execute_cmd_break():
             lines.append(line)
     assert lines == ["1\n"]
     assert str(exc.value) == f"ProcessTerminated: {cmd}"
+
+
+def test_extra_r2d_options():
+    bex = BuildExecutor()
+    bex.repo2docker_extra_args = ["--repo-dir=/srv/repo"]
+    bex.image_name = "test:test"
+    bex.ref = "main"
+
+    assert bex.get_r2d_cmd_options() == [
+        "--ref=main",
+        "--image=test:test",
+        "--no-clean",
+        "--no-run",
+        "--json-logs",
+        "--user-name=jovyan",
+        "--user-id=1000",
+        "--repo-dir=/srv/repo",
+    ]


### PR DESCRIPTION
Very helpful for a specific binderhub instance to customize how images are built. Off the top of my head, two useful things would be to pass `--repo-dir` (so you can have this work with a persistent home directory but still get access to the files in the image), and `--base-image` (so an install can use a different base image than rep2docker default).

As it's a simple passthrough, I've added a unit test only (no integration test).

Fixes https://github.com/jupyterhub/binderhub/issues/1765