### PR TITLE
Make eslint understand modern .js with babel's parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,16 +2,14 @@ module.exports = {
     "env": {
         "browser": true,
         "jquery": true,
-        "es6": true,
-        "jest/globals": true
+        "jest/globals": true,
     },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "sourceType": "module"
-    },
-    "rules": {
-    },
+    "extends": [
+        "eslint:recommended",
+    ],
+    "parser": "@babel/eslint-parser",
     "plugins": [
-        "jest"
-    ]
+        "jest",
+    ],
+    "rules": {},
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@babel/cli": "^7.21.0",
     "@babel/core": "^7.21.4",
+    "@babel/eslint-parser": "^7.22.15",
     "@babel/preset-env": "^7.21.4",
     "@types/jest": "^29.5.5",
     "babel-jest": "^29.7.0",


### PR DESCRIPTION
With this, we can use prettier in pre-commit without getting errors stemming from the formatting changes. Previously we did because the eslint's .js parser was not modern enough to support the formatting changes.

By switching to use the `@babel/eslint-parser` we are fine for now at least, and I think in the future as well, because we end up using a parser that is provided by babel, which is also what we use to transform the .js into something else.