### PR TITLE
Add missing file paths to chartpress monitored paths

### DIFF
--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -27,8 +27,14 @@ charts:
         # changes that should trigger a rebuild of this image.
         paths:
           - images/binderhub
-          - ../setup.py
           - ../binderhub
+          - ../js
+          - ../babel.config.json
+          - ../MANIFEST.in
           - ../package.json
+          - ../pyproject.toml
+          - ../requirements.txt
+          - ../setup.cfg
+          - ../setup.py
           - ../webpack.config.js
         valuesPath: image


### PR DESCRIPTION
PRs which affect only these files won't trigger a dev release of the chart:
https://github.com/jupyterhub/mybinder.org-deploy/pull/2771#issuecomment-1762130085