### PR TITLE
Guarantee that badge_base_url will always have a trailing /

### DIFF
--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -172,6 +172,9 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
         badge_base_url = self.settings["badge_base_url"]
         if callable(badge_base_url):
             badge_base_url = badge_base_url(self)
+            # Make sure the url has a trailing slash
+            if not badge_base_url.endswith("/"):
+                badge_base_url += "/"
         return badge_base_url
 
     def render_template(self, name, **extra_ns):

--- a/binderhub/static/js/src/constants.js
+++ b/binderhub/static/js/src/constants.js
@@ -15,7 +15,9 @@ const badge_base_url = document.getElementById("badge-base-url").dataset.url;
  * Base URL to use for both badge images as well as launch links.
  *
  * If not explicitly set, will default to BASE_URL. Primarily set up different than BASE_URL
- * when used as part of a federation
+ * when used as part of a federation.
+ *
+ * Guaranteed to have a trailing slash by the binderhub python configuration.
  */
 export const BADGE_BASE_URL = badge_base_url
   ? new URL(badge_base_url, document.location.origin)


### PR DESCRIPTION
Before this, the callable could return something without a
trailing slash, and that could break things.
