### PR TITLE
JS: Ensure all variables are camelCased

### DIFF
--- a/binderhub/static/js/src/loading.js
+++ b/binderhub/static/js/src/loading.js
@@ -1,7 +1,7 @@
 /**
  * List of help messages we will cycle through randomly in the loading page
  */
-const help_messages = [
+const helpMessages = [
   'New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information.',
   'You can learn more about building your own Binder repositories in <a target="_blank" href="https://docs.mybinder.org">the Binder community documentation</a>.',
   'We use the <a target="_blank" href="https://repo2docker.readthedocs.io/">repo2docker</a> tool to automatically build the environment in which to run your code.',
@@ -26,7 +26,7 @@ export function nextHelpText() {
   if (text !== null) {
     if (!text.hasClass("longLaunch")) {
       // Pick a random help message and update
-      msg = help_messages[Math.floor(Math.random() * help_messages.length)];
+      msg = helpMessages[Math.floor(Math.random() * helpMessages.length)];
     } else {
       msg =
         "Your session is taking longer than usual to start!<br />Check the log messages below to see what is happening.";

--- a/binderhub/static/js/src/repo.js
+++ b/binderhub/static/js/src/repo.js
@@ -8,15 +8,13 @@ let configDict = {};
 function setLabels() {
   const provider = $("#provider_prefix").val();
   const text = configDict[provider]["text"];
-  const tag_text = configDict[provider]["tag_text"];
-  const ref_prop_disabled = configDict[provider]["ref_prop_disabled"];
-  const label_prop_disabled = configDict[provider]["label_prop_disabled"];
+  const tagText = configDict[provider]["tag_text"];
+  const refPropDisabled = configDict[provider]["ref_prop_disabled"];
+  const labelPropDisabled = configDict[provider]["label_prop_disabled"];
   const placeholder = "HEAD";
 
-  $("#ref")
-    .attr("placeholder", placeholder)
-    .prop("disabled", ref_prop_disabled);
-  $("label[for=ref]").text(tag_text).prop("disabled", label_prop_disabled);
+  $("#ref").attr("placeholder", placeholder).prop("disabled", refPropDisabled);
+  $("label[for=ref]").text(tagText).prop("disabled", labelPropDisabled);
   $("#repository").attr("placeholder", text);
   $("label[for=repository]").text(text);
 }


### PR DESCRIPTION
Some were using underscores, which is more python than JS

Ref https://github.com/jupyterhub/binderhub/issues/774