### PR TITLE
JS: Fix some JSDoc types, and misc details in tests

### DIFF
--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -12,8 +12,8 @@ export class BinderRepository {
    *
    * @param {string} providerSpec Spec of the form <provider>/<repo>/<ref> to pass to the binderhub API.
    * @param {URL} buildEndpointUrl API URL of the build endpoint to talk to
-   * @param {string} buildToken Optional JWT based build token if this binderhub installation requires using build tokens
-   * @param {boolean} buildOnly Opt out of launching built image by default by passing `build_only` param
+   * @param {string} [buildToken] Optional JWT based build token if this binderhub installation requires using build tokens
+   * @param {boolean} [buildOnly] Opt out of launching built image by default by passing `build_only` param
    */
   constructor(providerSpec, buildEndpointUrl, buildToken, buildOnly) {
     this.providerSpec = providerSpec;
@@ -47,24 +47,24 @@ export class BinderRepository {
   /**
    * Call the binderhub API and yield responses as they come in
    *
-   * Returns an Async Generator yielding each item returned by the
+   * Returns an Async iterator yielding each item returned by the
    * server API.
    *
    * @typedef Line
-   * @prop {[string]} phase The phase the build is currently in. One of: building, built, fetching, launching, ready, unknown, waiting
-   * @prop {[string]} message Human readable message to display to the user. Extra newlines must *not* be added
-   * @prop {[string]} imageName (only with built) Full name of the image that has been built
-   * @prop {[string]} binder_launch_host (only with phase=ready) The host this binderhub API request was serviced by.
+   * @prop {string} [phase] The phase the build is currently in. One of: building, built, fetching, launching, ready, unknown, waiting
+   * @prop {string} [message] Human readable message to display to the user. Extra newlines must *not* be added
+   * @prop {string} [imageName] (only with built) Full name of the image that has been built
+   * @prop {string} [binder_launch_host] (only with phase=ready) The host this binderhub API request was serviced by.
    *                                     Could be different than the host the request was made to in federated cases
-   * @prop {[string]} binder_request (only with phase=ready) Request used to construct this image, of form v2/<provider>/<repo>/<ref>
-   * @prop {[string]} binder_persistent_request (only with phase=ready) Same as binder_request, but <ref> is fully resolved
-   * @prop {[string]} binder_ref_url (only with phase=ready) A URL to the repo provider where the repo can be browsed
-   * @prop {[string]} image (only with phase=ready) Full name of the image that has been built
-   * @prop {[string]} token (only with phase=ready) Token to use to authenticate with jupyter server at url
-   * @prop {[string]} url (only with phase=ready) URL where a jupyter server has been started
-   * @prop {[string]} repo_url (only with phase=ready) URL of the repository that is ready to be launched
+   * @prop {string} [binder_request] (only with phase=ready) Request used to construct this image, of form v2/<provider>/<repo>/<ref>
+   * @prop {string} [binder_persistent_request] (only with phase=ready) Same as binder_request, but <ref> is fully resolved
+   * @prop {string} [binder_ref_url] (only with phase=ready) A URL to the repo provider where the repo can be browsed
+   * @prop {string} [image] (only with phase=ready) Full name of the image that has been built
+   * @prop {string} [token] (only with phase=ready) Token to use to authenticate with jupyter server at url
+   * @prop {string} [url] (only with phase=ready) URL where a jupyter server has been started
+   * @prop {string} [repo_url] (only with phase=ready) URL of the repository that is ready to be launched
    *
-   * @returns {AsyncGenerator<Line>} An async generator yielding responses from the API as they come in
+   * @returns {AsyncIterable<Line>} An async iterator yielding responses from the API as they come in
    */
   fetch() {
     this.eventSource = new EventSource(this.buildUrl);
@@ -109,8 +109,8 @@ export class BinderRepository {
 
    * @param {URL} serverUrl URL to the running jupyter server
    * @param {string} token Secret token used to authenticate to the jupyter server
-   * @param {string} path The path of the file or url suffix to launch the user into
-   * @param {string} pathType One of "lab", "file" or "url", denoting what kinda path we are launching the user into
+   * @param {string} [path] The path of the file or url suffix to launch the user into
+   * @param {string} [pathType] One of "lab", "file" or "url", denoting what kinda path we are launching the user into
    *
    * @returns {URL} A URL to redirect the user to
    */
@@ -155,10 +155,10 @@ export class BinderRepository {
  *
  * @param {URL} publicBaseUrl Base URL to use for making public URLs. Must end with a trailing slash.
  * @param {string} providerPrefix prefix denoting what provider was selected
- * @param {string} repo repo to build
+ * @param {string} repository repo to build
  * @param {string} ref optional ref in this repo to build
- * @param {[string]} path Path to launch after this repo has been built
- * @param {[string]} pathType Type of thing to open path with (raw url, notebook file, lab, etc)
+ * @param {string} [path] Path to launch after this repo has been built
+ * @param {string} [pathType] Type of thing to open path with (raw url, notebook file, lab, etc)
  *
  * @returns {URL} A URL that can be shared with others, and clicking which will launch the repo
  */

--- a/js/packages/binderhub-client/tests/utils.js
+++ b/js/packages/binderhub-client/tests/utils.js
@@ -1,4 +1,4 @@
-import http from "node:http";
+import { createServer } from "node:http";
 
 /**
  * Parse an existing stored EventSource response body into an array of JSON objects
@@ -29,7 +29,7 @@ export function parseEventSource(responseBody) {
  */
 export async function simpleEventSourceServer(fakeResponses) {
   return new Promise((resolve) => {
-    const server = http.createServer(async (req, res) => {
+    const server = createServer(async (req, res) => {
       if (fakeResponses[req.url]) {
         res.statusCode = 200;
         res.setHeader("Content-Type", "text/event-stream");


### PR DESCRIPTION
- Optional args get [] around the param name, not the type!
- Remove extra increased timeout for some jest tests, as they are not needed
- Pass actual URL objects to some of the methods, rather than strings. These accidentally worked but shouldn't be relied upon.
- Import just the function used during tests from node modules, rather than the entire module.
- Fix type of `fetch` to indicate that's actually just an *iterator*, not a *generator*.

Ref https://github.com/jupyterhub/binderhub/issues/774