### PR TITLE
Kill singleuser test servers to reduce k3s resource usage

### DIFF
--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -95,6 +95,12 @@ async def test_build(app, needs_build, needs_launch, always_build, slug, pytestc
     r.raise_for_status()
     assert r.url.startswith(final["url"])
 
+    # stop the server
+    stop = await async_requests.post(
+        url_concat(f"{final['url']}api/shutdown", {"token": final["token"]})
+    )
+    stop.raise_for_status()
+
 
 @pytest.mark.asyncio(timeout=900)
 @pytest.mark.parametrize(

--- a/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
+++ b/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
@@ -52,15 +52,8 @@ jupyterhub:
     config:
       BinderSpawner:
         cors_allow_origin: "*"
-      JupyterHub:
-        # Cull servers quickly to free up K3s resources on CI
-        last_activity_interval: 30
     db:
       type: "sqlite-memory"
-
-  cull:
-    every: 30
-    maxAge: 45
 
   proxy:
     service:

--- a/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
+++ b/testing/k8s-binder-k8s-hub/binderhub-chart-config.yaml
@@ -52,8 +52,15 @@ jupyterhub:
     config:
       BinderSpawner:
         cors_allow_origin: "*"
+      JupyterHub:
+        # Cull servers quickly to free up K3s resources on CI
+        last_activity_interval: 30
     db:
       type: "sqlite-memory"
+
+  cull:
+    every: 30
+    maxAge: 45
 
   proxy:
     service:


### PR DESCRIPTION
Closes https://github.com/jupyterhub/binderhub/issues/1754

We build and launch several servers, but we don't shut them down.
https://github.com/jupyterhub/binderhub/blob/af81d7fd53b8fcab78b2f4276bee9828693e677c/binderhub/tests/test_build.py#L52-L96
