### PR TITLE
ci: fetch stable/dev releases using helm show to avoid cache issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,17 +243,23 @@ jobs:
         if: matrix.test-variation == 'upgrade'
         run: |
           . ./ci/common
-          UPGRADE_FROM_VERSION=$(curl -sSL https://jupyterhub.github.io/helm-chart/info.json | jq -er '.binderhub.${{ matrix.upgrade-from }}')
+          # NOTE: We change the directory so binderhub the chart name won't be
+          #       misunderstood as the local folder name.
+          #
+          #       https://github.com/helm/helm/issues/9244
+          cd ci
+
+          if [ ${{ matrix.upgrade-from }} = stable ]; then
+            UPGRADE_FROM_VERSION=$(helm show chart --repo=https://hub.jupyter.org/helm-chart/ binderhub | yq e '.version' -)
+          elif [ ${{ matrix.upgrade-from }} = dev ]; then
+            UPGRADE_FROM_VERSION=$(helm show chart --devel --repo=https://hub.jupyter.org/helm-chart/ binderhub | yq e '.version' -)
+          else
+            UPGRADE_FROM_VERSION=${{ matrix.upgrade-from }}
+          fi
           echo "UPGRADE_FROM_VERSION=$UPGRADE_FROM_VERSION" >> $GITHUB_ENV
 
           echo ""
           echo "Installing already released binderhub version $UPGRADE_FROM_VERSION"
-
-          # FIXME: We change the directory so binderhub the chart name won't be
-          #        misunderstood as the local folder name.
-          #
-          #        https://github.com/helm/helm/issues/9244
-          cd ci
 
           old_config="../testing/k8s-binder-k8s-hub/binderhub-chart-config-old.yaml"
           if [ -f "$old_config" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,6 @@ jobs:
       - name: "(Upgrade) Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test-variation == 'upgrade'
         run: |
-          . ./ci/common
           # NOTE: We change the directory so binderhub the chart name won't be
           #       misunderstood as the local folder name.
           #


### PR DESCRIPTION
- ci: fetch stable/dev releases using helm show to avoid cache issues

> Previously we fetched the latest stable and dev release from metadata we
have maintained, but doing that and then using `helm install` of that
version made us use two sources of data, where one could be relatively
outdated due to hitting a cache while the other may not.
>
>Using `helm show`, we rely on the helm chart repository website
returning a index.yaml listing versions etc both when checking whats the
latest versions, and when installing - like that we avoid a cache issue
I think.

- ci: cleanup unused sourcing of ci/common

---

Sibling PR to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3256
