### PR TITLE
Don't emit message about build_only to end user

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -428,15 +428,6 @@ class BuildHandler(BaseHandler):
                 image_found = True
 
         build_only = self._get_build_only()
-        if build_only:
-            await self.emit(
-                {
-                    "phase": "info",
-                    "imageName": image_name,
-                    "message": "The built image will not be launched "
-                    "because the API only mode was enabled and the query parameter `build_only` was set to true\n",
-                }
-            )
         if image_found:
             if build_only:
                 await self.emit(


### PR DESCRIPTION
This ends up as a mesage to the *end user*, who doesn't actually know anything about these API parameters and is confused.

<img width="690" alt="image" src="https://github.com/jupyterhub/binderhub/assets/30430/a75685af-3a31-472d-8893-ba3e050ab695">

Ref https://github.com/2i2c-org/infrastructure/issues/3286