### PR TITLE
Bump @jupyterhub/binderhub-client version

### DIFF
--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterhub/binderhub-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Simple API client for the BinderHub EventSource API",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
A lot of changes have happened since the last release, let's get them out!

There's no release automation for this for now, and I'd like to *not* block this release on release automation.