### PR TITLE
Make docker-socket optional, build volumes can be overridden

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -299,12 +299,13 @@ class KubernetesBuildExecutor(BuildExecutor):
 
     docker_host = Unicode(
         "/var/run/docker.sock",
+        allow_none=True,
         help=(
             "The docker socket to use for building the image. "
             "Must be a unix domain socket on a filesystem path accessible on the node "
             "in which the build pod is running. "
-            "This is mounted into the build pod, set to empty string to disable, "
-            "e.g. if you are subclassing this builder and don't need the docker socket."
+            "This is mounted into the build pod, set to None to disable, "
+            "e.g. if you are using an alternative builder that doesn't need the docker socket."
         ),
         config=True,
     )
@@ -425,7 +426,7 @@ class KubernetesBuildExecutor(BuildExecutor):
         volume_mounts = []
         volumes = []
 
-        if self.docker_host:
+        if self.docker_host is not None:
             volume_mounts.append(
                 client.V1VolumeMount(
                     mount_path="/var/run/docker.sock", name="docker-socket"


### PR DESCRIPTION
This enables KubernetesBuildExecutor to be subclassed and used with other builders such as Kaniko which doesn't need an mounted host socket.

With this BinderHub change it should be possible to use Kaniko using just the traitlets config using something like the following, instead of overriding the `KubernetesBuildExecutor` as suggested in https://github.com/jupyterhub/repo2docker/issues/560:
```yaml
config:
  BinderHub:
    ....
  KubernetesBuildExecutor:
    docker_host:
    build_image: "ghcr.io/manics/repo2kaniko@sha256:9b2ef803c4c089f40643e2f40d58d0c697b5bdbed16482f7f1fceb3a525355fe"
  BuildExecutor:
    repo2docker_extra_args:
      - --engine=kaniko
      - --debug
      - --KanikoEngine.cache_registry=cache-registry-docker-registry:5000/cache
      - --KanikoEngine.cache_registry_credentials=username=user
      - --KanikoEngine.cache_registry_credentials=password=password
      - --KanikoEngine.cache_registry_insecure=true
```

I've made the volumes into an overridable method so that additional volumes could be added by subclasses.

Related:
- https://github.com/manics/repo2kaniko
- https://github.com/jupyterhub/repo2docker/issues/560
