### PR TITLE
Publish to Docker Hub alongside Quay.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,7 @@ jobs:
         # 3. Putting the robot account's username and password in GitHub actions environment
         run: |
           docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" docker.io
 
       - name: Configure a git user
         # Having a user.email and user.name configured with git is required to

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,20 @@ The minimum Python version is 3.8, and the Helm Chart BinderHub image has been u
 [#1610](https://github.com/jupyterhub/binderhub/pull/1610)
 [#1611](https://github.com/jupyterhub/binderhub/pull/1611).
 
+### Default image registry changed to Quay.io
+
+We now publish the chart's docker images to both [Quay.io] and [Docker Hub] and
+the chart is from now configured to use the images at Quay.io by default.
+
+The change is to ensure that images can be pulled without a [Docker Hub rate
+limit] even if the [JupyterHub organization on Docker Hub] wouldn't be sponsored
+by Docker Hub in the future, something we need to apply for each year.
+
+[docker hub]: https://hub.docker.com
+[docker hub rate limit]: https://docs.docker.com/docker-hub/download-rate-limit/
+[jupyterhub organization on docker hub]: https://hub.docker.com/u/jupyterhub
+[quay.io]: https://quay.io
+
 # 0.2.0
 
 # master@{2019-07-01}...master@{2019-10-01}

--- a/ci/publish
+++ b/ci/publish
@@ -6,10 +6,10 @@
 # Exit on errors, assert env vars, log commands
 set -eux
 
-PUBLISH_ARGS="--push --publish-chart \
+PUBLISH_ARGS="--push \
     --builder docker-buildx \
     --platform linux/amd64 --platform linux/arm64 \
-    "
+"
 
 cd helm-chart
 # chartpress use git to push to our Helm chart repository, which is the gh-pages
@@ -32,11 +32,13 @@ if [[ $GITHUB_REF != refs/tags/* ]]; then
     PR_OR_HASH=$(git log -1 --pretty=%h-%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/' | sed 's/^\([0-9a-f]*\)-.*/@\1/')
     LATEST_COMMIT_TITLE=$(git log -1 --pretty=%B | head -n1)
     EXTRA_MESSAGE="${GITHUB_REPOSITORY}${PR_OR_HASH} ${LATEST_COMMIT_TITLE}"
-    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}"
+    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}" --publish-chart
+    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}" --image-prefix=jupyterhub/k8s-
 else
     # Setting a tag explicitly enforces a rebuild if this tag had already been
     # built and we wanted to override it.
-    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}"
+    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}" --publish-chart
+    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}" --image-prefix=jupyterhub/k8s-
 fi
 
 # Let us log the changes chartpress did, it should include replacements for


### PR DESCRIPTION
This is a follow up to #1789 where we switched to publish to quay.io, and discussed in https://github.com/jupyterhub/team-compass/issues/688#issuecomment-1825672798