### PR TITLE
local-binder-mocked-hub: undo api_only_mode

### DIFF
--- a/testing/local-binder-mocked-hub/binderhub_config.py
+++ b/testing/local-binder-mocked-hub/binderhub_config.py
@@ -20,8 +20,7 @@ c.BinderHub.build_class = FakeBuild
 # Uncomment the following line to enable BinderHub's API only mode
 # With this, we can then use the `build_only` query parameter in the request
 # to not launch the image after build
-
-c.BinderHub.enable_api_only_mode = True
+# c.BinderHub.enable_api_only_mode = True
 
 c.BinderHub.about_message = "<blink>Hello world.</blink>"
 c.BinderHub.banner_message = 'This is headline <a href="#">news.</a>'


### PR DESCRIPTION
local-binder-mocked-hub is intended for local UI testing, but `enable_api_only_mode = true` was set in https://github.com/jupyterhub/binderhub/pull/1647 which means the UI is now disabled.

Reverts 368cad76179f8217b1cf55cc6494d8bfcb14ec16