### PR TITLE
Remove ingress.https with unused kube-lego references, rely on ingress.tls and ingress.annotations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,34 @@ make it easier to track what has changed over time_
 
 ## Breaking changes
 
+### `ingress.https` was removed
+
+Users with `ingress.https.enabled=true` explicitly set will now error during
+template rendering and need to migrate config like examplified below.
+
+```yaml
+# old config to be migrated
+ingress:
+  enabled: true
+  hosts:
+    - example.com
+  https:
+    enabled: true
+    type: kube-lego
+
+# equivalent new config to use instead
+ingress:
+  enabled: true
+  hosts:
+    - example.com
+  annotations:
+    kubernetes.io/tls-acme: "true"
+  tls:
+    - secretName: binderhub-tls-binder-<HELM RELEASE NAME HERE>
+      hosts:
+        - example.com
+```
+
 ### `binderhub_config.py` is mounted at runtime
 
 The `binderhub_config.py` file is now mounted at runtime instead of being built into the BinderHub image

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -519,10 +519,6 @@ properties:
             type: boolean
             description: |
               TODO
-          type:
-            type: string
-            description: |
-              TODO
       annotations:
         type: object
         additionalProperties: false

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -509,16 +509,6 @@ properties:
         description: |
           Enable the creation of a Kubernetes Ingress referencing incoming
           network network traffic to the binder k8s Service.
-      https:
-        type: object
-        additionalProperties: false
-        description: |
-          TODO
-        properties:
-          enabled:
-            type: boolean
-            description: |
-              TODO
       annotations:
         type: object
         additionalProperties: false

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- . | toYaml | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   {{- with .Values.ingress.ingressClassName }}

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -3,12 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: binderhub
-  {{- if or (and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego")) .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   {{- end }}
@@ -31,14 +27,7 @@ spec:
       host: {{ . | quote }}
       {{- end }}
     {{- end }}
-  {{- if and .Values.ingress.https.enabled (eq .Values.ingress.https.type "kube-lego") }}
-  tls:
-    - secretName: kubelego-tls-binder-{{ .Release.Name }}
-      hosts:
-        {{- range .Values.ingress.hosts }}
-        - {{ . | quote }}
-        {{- end }}
-  {{- else if .Values.ingress.tls }}
+  {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
     - hosts:

--- a/helm-chart/binderhub/templates/ingress.yaml
+++ b/helm-chart/binderhub/templates/ingress.yaml
@@ -26,14 +26,8 @@ spec:
       host: {{ . | quote }}
       {{- end }}
     {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -327,9 +327,6 @@ imageCleaner:
 
 ingress:
   enabled: false
-  https:
-    enabled: false
-    type: kube-lego
   hosts: []
   ingressClassName:
   annotations:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -133,9 +133,6 @@ imageCleaner:
 
 ingress:
   enabled: true
-  https:
-    enabled: false
-    type: kube-lego
   hosts: [domain.com]
   annotations: *annotations
   ingressClassName: mock-ingress-class-name


### PR DESCRIPTION
[kube-lego](https://github.com/jetstack/kube-lego) was the precursor to cert-manager, and has been dead for years and years now