### PR TITLE
Remove incorrect docker socket if found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,6 +299,12 @@ jobs:
           timeout: 150
           max-restarts: 1
 
+      - name: Test the workaround for an incorrect docker.sock directory
+        if: matrix.test-variation == 'dind'
+        run: |
+          # {{ .Values.dind.hostSocketDir }}/{{ .Values.dind.hostSocketName }}
+          sudo mkdir -p /var/run/dind/docker.sock
+
       - name: Install the chart
         if: matrix.test == 'helm'
         run: |

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -414,11 +414,6 @@ properties:
             type: array
             description: |
               Additional volume mounts for the Container. Use a k8s native syntax.
-      cleanupIncorrectSocketDir: &cleanupIncorrectSocketDir-spec
-        type: boolean
-        description: |
-          If the container socket has been incorrectly created as a directory
-          remove the directory
       storageDriver:
         type: string
         description: |
@@ -454,7 +449,6 @@ properties:
           lifecycle: *lifecycle-spec
           extraVolumes: *extraVolumes-spec
           extraVolumeMounts: *extraVolumeMounts-spec
-      cleanupIncorrectSocketDir: *cleanupIncorrectSocketDir-spec
       resources: *resources-spec
       hostStorageDir: *hostStorageDir-spec
       hostSocketDir: *hostSocketDir-spec

--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -414,19 +414,28 @@ properties:
             type: array
             description: |
               Additional volume mounts for the Container. Use a k8s native syntax.
+      cleanupIncorrectSocketDir: &cleanupIncorrectSocketDir-spec
+        type: boolean
+        description: |
+          If the container socket has been incorrectly created as a directory
+          remove the directory
       storageDriver:
         type: string
         description: |
-          TODO
+          Docker storage driver
       resources: *resources-spec
-      hostSocketDir:
+      hostSocketDir: &hostSocketDir-spec
         type: string
         description: |
-          TODO
-      hostLibDir:
+          Host directory where the container socket will be located
+      hostLibDir: &hostStorageDir-spec
         type: string
         description: |
-          TODO
+          Host directory where the containers storage will be located
+      hostSocketName: &hostSocketName-spec
+        type: string
+        description: |
+          Name of the container socket file
 
   pink:
     type: object
@@ -445,15 +454,11 @@ properties:
           lifecycle: *lifecycle-spec
           extraVolumes: *extraVolumes-spec
           extraVolumeMounts: *extraVolumeMounts-spec
+      cleanupIncorrectSocketDir: *cleanupIncorrectSocketDir-spec
       resources: *resources-spec
-      hostStorageDir:
-        type: string
-        description: |
-          Host path where the containers storage will be located
-      hostSocketDir:
-        type: string
-        description: |
-          Host path where the podman socket will be located
+      hostStorageDir: *hostStorageDir-spec
+      hostSocketDir: *hostSocketDir-spec
+      hostSocketName: *hostSocketName-spec
 
   imageCleaner:
     type: object

--- a/helm-chart/binderhub/templates/container-builder/daemonset.yaml
+++ b/helm-chart/binderhub/templates/container-builder/daemonset.yaml
@@ -2,6 +2,7 @@
 {{- $builderName := .Values.imageBuilderType -}}
 {{- $builder := index .Values $builderName -}}
 {{- $daemonset := $builder.daemonset -}}
+{{- $hostSocketPath := printf "%s/%s" $builder.hostSocketDir $builder.hostSocketName }}
 
 apiVersion: apps/v1
 kind: DaemonSet
@@ -36,9 +37,32 @@ spec:
         value: user
       nodeSelector: {{ .Values.config.BinderHub.build_node_selector | toJson }}
 
-      {{- with $builder.initContainers }}
+      {{- if or $builder.cleanupIncorrectSocketDir $builder.initContainers }}
       initContainers:
+      {{- if $builder.cleanupIncorrectSocketDir }}
+        - name: filesystem
+          # Reuse the main container image since this is a simple shell command
+          image: {{ $daemonset.image.name }}:{{ $daemonset.image.tag }}
+          {{- with $daemonset.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - >
+              if [ -d "{{ $hostSocketPath }}" ]; then
+                echo "Removing incorrect socket directory {{ $hostSocketPath }}";
+                rmdir "{{ $hostSocketPath }}";
+              fi
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: run-{{ $builderName }}
+            mountPath: {{ $builder.hostSocketDir }}
+      {{- end }}
+      {{- with $builder.initContainers }}
         {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- end }}
 
       containers:
@@ -55,7 +79,7 @@ spec:
           args:
             - dockerd
             - --storage-driver={{ $builder.storageDriver }}
-            - -H unix://{{ $builder.hostSocketDir }}/{{ $builder.hostSocketName }}
+            - -H unix://{{ $hostSocketPath }}
             {{- with $daemonset.extraArgs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
@@ -73,7 +97,7 @@ spec:
             - system
             - service
             - --time=0
-            - unix://{{ $builder.hostSocketDir }}/{{ $builder.hostSocketName }}
+            - unix://{{ $hostSocketPath }}
             {{- with $daemonset.extraArgs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/helm-chart/binderhub/templates/container-builder/daemonset.yaml
+++ b/helm-chart/binderhub/templates/container-builder/daemonset.yaml
@@ -37,9 +37,7 @@ spec:
         value: user
       nodeSelector: {{ .Values.config.BinderHub.build_node_selector | toJson }}
 
-      {{- if or $builder.cleanupIncorrectSocketDir $builder.initContainers }}
       initContainers:
-      {{- if $builder.cleanupIncorrectSocketDir }}
         - name: filesystem
           # Reuse the main container image since this is a simple shell command
           image: {{ $daemonset.image.name }}:{{ $daemonset.image.tag }}
@@ -59,10 +57,8 @@ spec:
           volumeMounts:
           - name: run-{{ $builderName }}
             mountPath: {{ $builder.hostSocketDir }}
-      {{- end }}
       {{- with $builder.initContainers }}
         {{- . | toYaml | nindent 8 }}
-      {{- end }}
       {{- end }}
 
       containers:

--- a/helm-chart/binderhub/templates/container-builder/daemonset.yaml
+++ b/helm-chart/binderhub/templates/container-builder/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
           args:
             - dockerd
             - --storage-driver={{ $builder.storageDriver }}
-            - -H unix://{{ $builder.hostSocketDir }}/docker.sock
+            - -H unix://{{ $builder.hostSocketDir }}/{{ $builder.hostSocketName }}
             {{- with $daemonset.extraArgs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
@@ -73,7 +73,7 @@ spec:
             - system
             - service
             - --time=0
-            - unix://{{ $builder.hostSocketDir }}/podman.sock
+            - unix://{{ $builder.hostSocketDir }}/{{ $builder.hostSocketName }}
             {{- with $daemonset.extraArgs }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -78,7 +78,7 @@ spec:
           type: DirectoryOrCreate
       - name: socket-dind
         hostPath:
-          path: {{ .Values.dind.hostSocketDir }}/docker.sock
+          path: {{ .Values.dind.hostSocketDir }}/{{ .Values.dind.hostSocketName }}
           type: Socket
       {{- end }}
       {{- if eq .Values.imageBuilderType "pink" }}
@@ -88,7 +88,7 @@ spec:
           type: DirectoryOrCreate
       - name: socket-pink
         hostPath:
-          path: {{ .Values.pink.hostSocketDir }}/podman.sock
+          path: {{ .Values.pink.hostSocketDir }}/{{ .Values.pink.hostSocketName }}
           type: Socket
       {{- end }}
 {{- end }}

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.imageCleaner.enabled -}}
+{{- $builderName := .Values.imageBuilderType -}}
+{{- $builder := index .Values $builderName -}}
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -35,15 +38,15 @@ spec:
       serviceAccountName: {{ .Release.Name }}-image-cleaner
       {{- end }}
       containers:
-      - name: image-cleaner-{{ .Values.imageBuilderType }}
+      - name: image-cleaner-{{ $builderName }}
         image: {{ .Values.imageCleaner.image.name }}:{{ .Values.imageCleaner.image.tag }}
         {{- with .Values.imageCleaner.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
         volumeMounts:
-        - name: storage-{{ .Values.imageBuilderType }}
-          mountPath: /var/lib/{{ .Values.imageBuilderType }}
-        - name: socket-{{ .Values.imageBuilderType }}
+        - name: storage-{{ $builderName }}
+          mountPath: /var/lib/{{ $builderName }}
+        - name: socket-{{ $builderName }}
           mountPath: /var/run/docker.sock
         env:
         - name: DOCKER_IMAGE_CLEANER_NODE_NAME
@@ -51,7 +54,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: DOCKER_IMAGE_CLEANER_PATH_TO_CHECK
-          value: /var/lib/{{ .Values.imageBuilderType }}
+          value: /var/lib/{{ $builderName }}
         - name: DOCKER_IMAGE_CLEANER_DELAY_SECONDS
           value: {{ .Values.imageCleaner.delay | quote }}
         - name: DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE
@@ -62,7 +65,7 @@ spec:
           value: {{ .Values.imageCleaner.imageGCThresholdLow | quote }}
       terminationGracePeriodSeconds: 0
       volumes:
-      {{- if eq .Values.imageBuilderType "host" }}
+      {{- if eq $builderName "host" }}
       - name: storage-host
         hostPath:
           path: {{ .Values.imageCleaner.host.dockerLibDir }}
@@ -71,24 +74,14 @@ spec:
           path: {{ .Values.imageCleaner.host.dockerSocket }}
           type: Socket
       {{- end }}
-      {{- if eq .Values.imageBuilderType "dind" }}
-      - name: storage-dind
+      {{- if or (eq $builderName "dind") (eq $builderName "pink") }}
+      - name: storage-{{ $builderName }}
         hostPath:
-          path: {{ .Values.dind.hostLibDir }}
+          path: {{ eq $builderName "dind" | ternary $builder.hostLibDir $builder.hostStorageDir }}
           type: DirectoryOrCreate
-      - name: socket-dind
+      - name: socket-{{ $builderName }}
         hostPath:
-          path: {{ .Values.dind.hostSocketDir }}/{{ .Values.dind.hostSocketName }}
-          type: Socket
-      {{- end }}
-      {{- if eq .Values.imageBuilderType "pink" }}
-      - name: storage-pink
-        hostPath:
-          path: {{ .Values.pink.hostStorageDir }}
-          type: DirectoryOrCreate
-      - name: socket-pink
-        hostPath:
-          path: {{ .Values.pink.hostSocketDir }}/{{ .Values.pink.hostSocketName }}
+          path: {{ $builder.hostSocketDir }}/{{ $builder.hostSocketName }}
           type: Socket
       {{- end }}
 {{- end }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -284,7 +284,6 @@ dind:
     lifecycle: {}
     extraVolumes: []
     extraVolumeMounts: []
-  cleanupIncorrectSocketDir: true
   storageDriver: overlay2
   resources: {}
   hostSocketDir: /var/run/dind
@@ -303,7 +302,6 @@ pink:
     lifecycle: {}
     extraVolumes: []
     extraVolumeMounts: []
-  cleanupIncorrectSocketDir: true
   resources: {}
   hostStorageDir: /var/lib/pink/storage
   hostSocketDir: /var/run/pink

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -284,6 +284,7 @@ dind:
     lifecycle: {}
     extraVolumes: []
     extraVolumeMounts: []
+  cleanupIncorrectSocketDir: true
   storageDriver: overlay2
   resources: {}
   hostSocketDir: /var/run/dind
@@ -302,6 +303,7 @@ pink:
     lifecycle: {}
     extraVolumes: []
     extraVolumeMounts: []
+  cleanupIncorrectSocketDir: true
   resources: {}
   hostStorageDir: /var/lib/pink/storage
   hostSocketDir: /var/run/pink

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -288,6 +288,7 @@ dind:
   resources: {}
   hostSocketDir: /var/run/dind
   hostLibDir: /var/lib/dind
+  hostSocketName: docker.sock
 
 # Podman in Kubernetes
 pink:
@@ -304,6 +305,7 @@ pink:
   resources: {}
   hostStorageDir: /var/lib/pink/storage
   hostSocketDir: /var/run/pink
+  hostSocketName: podman.sock
 
 imageCleaner:
   enabled: true


### PR DESCRIPTION
BinderHub has a well known problem where the docker.socket is created as a directory, which then causes dind to crash:
https://github.com/jupyterhub/mybinder.org-deploy/blob/61c0cbedddee92dbcd252e02d9bd02b5a5b94d58/docs/source/operation_guide/common_problems.md#the-docker-in-docker-socket

Given that this problem has existed for years, occurs on multiple deployments, and can result in a prolonged outage until a manual fix is made (most recently today- both Curvenote nodes were hit by this bug simultaneously blocking all builds), I think we should automate the fix.

I originally made this controllable with parameter `{dind,pink}.cleanupIncorrectSocketDir` but I've removed it in commit d6c66045a0168c8e00f685e1fbf8f21498171392 to reduce the added logic, I'm happy to add it back though.