### PR TITLE
test-local: install pycurl from source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -426,10 +426,12 @@ jobs:
         #        binderhub/static/dist/bundle.js is built, and use "-e" to
         #        ensure code coverage is captured.
         #
+        # https://discourse.jupyter.org/t/suddenly-getting-oath-cert-error/24217/4
+        # pycurl wheels fail to pick up the system CA certs, so install from source
         run: |
           pip install -r dev-requirements.txt -r testing/local-binder-local-hub/requirements.txt
-          pip install ".[pycurl]"
-          pip install -e ".[pycurl]"
+          pip install ".[pycurl]" --no-binary pycurl
+          pip install -e ".[pycurl]" --no-binary pycurl
 
       - name: Setup JupyterHub NPM dependencies
         run: npm install -g configurable-http-proxy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -428,6 +428,7 @@ jobs:
         #
         # https://discourse.jupyter.org/t/suddenly-getting-oath-cert-error/24217/4
         # pycurl wheels fail to pick up the system CA certs, so install from source
+        # until https://github.com/pycurl/pycurl/issues/834 resolves
         run: |
           pip install -r dev-requirements.txt -r testing/local-binder-local-hub/requirements.txt
           pip install ".[pycurl]" --no-binary pycurl


### PR DESCRIPTION
The test-local CI test is currently failing with
```
 binderhub/tests/test_build.py:87: AssertionError
----------------------------- Captured stdout call -----------------------------
failed: Error resolving ref for gh:binderhub-ci-repos/cached-minimal-dockerfile/596b52f10efb0c9befc0c4ae850cc5175297d71c: HTTP 599: error setting certificate verify locations:
  CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
```
@pastram-i worked out it's due to the recent 7.45.3 release of pycurl https://discourse.jupyter.org/t/suddenly-getting-oath-cert-error/24217/4

7.45.2 only has source packages, 7.45.3 introduced binary wheels which seem to be the problem.