### PR TITLE
handle api tokens and xsrf

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -962,8 +962,7 @@ class BinderHub(Application):
                 "enable_api_only_mode": self.enable_api_only_mode,
             }
         )
-        if self.auth_enabled:
-            self.tornado_settings["cookie_secret"] = os.urandom(32)
+        self.tornado_settings["cookie_secret"] = os.urandom(32)
         if self.cors_allow_origin:
             self.tornado_settings.setdefault("headers", {})[
                 "Access-Control-Allow-Origin"

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -142,9 +142,9 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
             static_url=self.static_url,
             banner=self.settings["banner_message"],
             auth_enabled=self.settings["auth_enabled"],
-            xsrf=self.xsrf_token.decode("ascii"),
         )
         if self.settings["auth_enabled"]:
+            ns["xsrf"] = self.xsrf_token.decode("ascii")
             ns["api_token"] = self.hub_auth.get_token(self) or ""
 
         ns.update(

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -137,11 +137,19 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
 
     @property
     def template_namespace(self):
-        return dict(
+
+        ns = dict(
             static_url=self.static_url,
             banner=self.settings["banner_message"],
-            **self.settings.get("template_variables", {}),
+            auth_enabled=self.settings["auth_enabled"],
         )
+        if self.settings["auth_enabled"]:
+            ns["api_token"] = self.hub_auth.get_token(self) or ""
+
+        ns.update(
+            self.settings.get("template_variables", {}),
+        )
+        return ns
 
     def set_default_headers(self):
         headers = self.settings.get("headers", {})

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -142,6 +142,7 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
             static_url=self.static_url,
             banner=self.settings["banner_message"],
             auth_enabled=self.settings["auth_enabled"],
+            xsrf=self.xsrf_token.decode("ascii"),
         )
         if self.settings["auth_enabled"]:
             ns["api_token"] = self.hub_auth.get_token(self) or ""

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -247,6 +247,10 @@ class BuildHandler(BaseHandler):
 
         return build_only
 
+    def redirect(self, *args, **kwargs):
+        # disable redirect to login, which won't work for EventSource
+        raise HTTPError(403)
+
     @authenticated
     async def get(self, provider_prefix, _unescaped_spec):
         """Get a built image for a given spec and repo provider.

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -60,7 +60,7 @@ async function build(providerSpec, log, fitAddon, path, pathType) {
   $(".on-build").removeClass("hidden");
 
   const buildToken = $("#build-token").data("token");
-  let apiToken = $("#api-token").data("token");
+  const apiToken = $("#api-token").data("token");
   const buildEndpointUrl = new URL("build", BASE_URL);
   const image = new BinderRepository(providerSpec, buildEndpointUrl, {
     apiToken,

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -1,7 +1,6 @@
 /* If this file gets over 200 lines of code long (not counting docs / comments), start using a framework
  */
 import ClipboardJS from "clipboard";
-import "event-source-polyfill";
 
 import { BinderRepository } from "@jupyterhub/binderhub-client";
 import { updatePathText } from "./src/path";
@@ -61,11 +60,14 @@ async function build(providerSpec, log, fitAddon, path, pathType) {
   $(".on-build").removeClass("hidden");
 
   const buildToken = $("#build-token").data("token");
+  let apiToken = $("#api-token").data("token");
   const buildEndpointUrl = new URL("build", BASE_URL);
   const image = new BinderRepository(
     providerSpec,
     buildEndpointUrl,
     buildToken,
+    false,
+    { apiToken },
   );
 
   for await (const data of image.fetch()) {

--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -62,13 +62,10 @@ async function build(providerSpec, log, fitAddon, path, pathType) {
   const buildToken = $("#build-token").data("token");
   let apiToken = $("#api-token").data("token");
   const buildEndpointUrl = new URL("build", BASE_URL);
-  const image = new BinderRepository(
-    providerSpec,
-    buildEndpointUrl,
+  const image = new BinderRepository(providerSpec, buildEndpointUrl, {
+    apiToken,
     buildToken,
-    false,
-    { apiToken },
-  );
+  });
 
   for await (const data of image.fetch()) {
     // Write message to the log terminal if there is a message

--- a/binderhub/static/js/src/repo.js
+++ b/binderhub/static/js/src/repo.js
@@ -24,8 +24,16 @@ function setLabels() {
  */
 export function updateRepoText(baseUrl) {
   if (Object.keys(configDict).length === 0) {
+    const xsrf = $("#xsrf-token").data("token");
+    const apiToken = $("#api-token").data("token");
     const configUrl = new URL("_config", baseUrl);
-    fetch(configUrl).then((resp) => {
+    const headers = {};
+    if (apiToken && apiToken.length > 0) {
+      headers["Authorization"] = `Bearer ${apiToken}`;
+    } else if (xsrf && xsrf.length > 0) {
+      headers["X-Xsrftoken"] = xsrf;
+    }
+    fetch(configUrl, { headers }).then((resp) => {
       resp.json().then((data) => {
         configDict = data;
         setLabels();

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -3,6 +3,7 @@
 {% block head %}
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
+<meta id="api-token" data-token="{{ api_token }}">
 <script src="{{static_url("dist/bundle.js")}}"></script>
 {{ super() }}
 {% endblock head %}

--- a/binderhub/templates/index.html
+++ b/binderhub/templates/index.html
@@ -4,6 +4,7 @@
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 <meta id="api-token" data-token="{{ api_token }}">
+<meta id="xsrf-token" data-token="{{ xsrf }}">
 <script src="{{static_url("dist/bundle.js")}}"></script>
 {{ super() }}
 {% endblock head %}

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -15,7 +15,7 @@
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 <meta id="build-token" data-token="{{ build_token }}">
 <meta id="api-token" data-token="{{ api_token }}">
-<meta id="xsrf-token" data-token="{{ xsrf_token }}">
+<meta id="xsrf-token" data-token="{{ xsrf }}">
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("loading.css")}}" rel="stylesheet">

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -14,6 +14,7 @@
 <meta id="base-url" data-url="{{base_url}}">
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 <meta id="build-token" data-token="{{ build_token }}">
+<meta id="api-token" data-token="{{ api_token }}">
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("loading.css")}}" rel="stylesheet">

--- a/binderhub/templates/loading.html
+++ b/binderhub/templates/loading.html
@@ -15,6 +15,7 @@
 <meta id="badge-base-url" data-url="{{badge_base_url}}">
 <meta id="build-token" data-token="{{ build_token }}">
 <meta id="api-token" data-token="{{ api_token }}">
+<meta id="xsrf-token" data-token="{{ xsrf_token }}">
 {{ super() }}
 <script src="{{static_url("dist/bundle.js")}}"></script>
 <link href="{{static_url("loading.css")}}" rel="stylesheet">

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -1,8 +1,6 @@
 import { fetchEventSource } from "@microsoft/fetch-event-source";
 import { EventIterator } from "event-iterator";
 
-// const windowFetch = fetch;
-
 function _getXSRFToken() {
   // from @jupyterlab/services
   // https://github.com/jupyterlab/jupyterlab/blob/69223102d717f3d3e9f976d32e657a4e2456e85d/packages/services/src/contents/index.ts#L1178-L1184

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -111,10 +111,7 @@ export class BinderRepository {
     // setTimeout(() => this.close(), 1000);
     return new EventIterator((queue) => {
       this.eventIteratorQueue = queue;
-      const fail = (e) => {
-        // handle error, either in original fetch, or
-      };
-      const fetchPromise = fetchEventSource(this.buildUrl, {
+      fetchEventSource(this.buildUrl, {
         headers,
         // signal used for closing
         signal: this.abortController.signal,

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -24,17 +24,14 @@ export class BinderRepository {
    *
    * @param {string} providerSpec Spec of the form <provider>/<repo>/<ref> to pass to the binderhub API.
    * @param {URL} buildEndpointUrl API URL of the build endpoint to talk to
-   * @param {string} [buildToken] Optional JWT based build token if this binderhub installation requires using build tokens
-   * @param {boolean} [buildOnly] Opt out of launching built image by default by passing `build_only` param
-   * @param {string} [apiToken] Optional Bearer token for authenticating requests
+   * @param {Object} [options] - optional arguments
+   * @param {string} [options.buildToken] Optional JWT based build token if this binderhub installation requires using build tokens
+   * @param {boolean} [options.buildOnly] Opt out of launching built image by default by passing `build_only` param
+   * @param {string} [options.apiToken] Optional Bearer token for authenticating requests
    */
-  constructor(
-    providerSpec,
-    buildEndpointUrl,
-    buildToken,
-    buildOnly,
-    { apiToken },
-  ) {
+  constructor(providerSpec, buildEndpointUrl, options) {
+    const { apiToken, buildToken, buildOnly } = options || {};
+
     this.providerSpec = providerSpec;
     // Make sure that buildEndpointUrl is a real URL - this ensures hostname is properly set
     if (!(buildEndpointUrl instanceof URL)) {

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -157,7 +157,7 @@ export class BinderRepository {
           if (error.name === "EventStreamRetry") {
             // if we don't re-raise, connection will be retried;
             queue.push({
-              phase: "unkown",
+              phase: "unknown",
               message: `Error in event stream: ${error}\n`,
             });
             return;

--- a/js/packages/binderhub-client/lib/index.js
+++ b/js/packages/binderhub-client/lib/index.js
@@ -5,6 +5,7 @@ import { EventIterator } from "event-iterator";
 
 function _getXSRFToken() {
   // from @jupyterlab/services
+  // https://github.com/jupyterlab/jupyterlab/blob/69223102d717f3d3e9f976d32e657a4e2456e85d/packages/services/src/contents/index.ts#L1178-L1184
   let cookie = "";
   try {
     cookie = document.cookie;
@@ -12,6 +13,9 @@ function _getXSRFToken() {
     // e.g. SecurityError in case of CSP Sandbox
     return null;
   }
+  // extracts the value of the cookie named `_xsrf`
+  // by picking up everything between `_xsrf=` and the next semicolon or end-of-line
+  // `\b` ensures word boundaries, so it doesn't pick up `something_xsrf=`...
   const xsrfTokenMatch = cookie.match("\\b_xsrf=([^;]*)\\b");
   if (xsrfTokenMatch) {
     return xsrfTokenMatch[1];

--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/jupyterhub/binderhub#readme",
   "dependencies": {
-    "event-source-polyfill": "^1.0.31",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "event-iterator": "^2.0.0"
   }
 }

--- a/js/packages/binderhub-client/tests/index.test.js
+++ b/js/packages/binderhub-client/tests/index.test.js
@@ -9,6 +9,16 @@ import {
 import { parseEventSource, simpleEventSourceServer } from "./utils";
 import { readFileSync } from "node:fs";
 
+async function wrapFetch(resource, options) {
+  /* like fetch, but ignore signal input 
+  // abort signal shows up as uncaught in tests, despite  working fine
+  */
+  if (options) {
+    options.signal = null;
+  }
+  return fetch.apply(null, [resource, options]);
+}
+
 beforeAll(() => {
   // inject globals for fetch
   global.TextDecoder = TextDecoder;
@@ -16,13 +26,6 @@ beforeAll(() => {
     global.window = {};
   }
   if (!global.window.fetch) {
-    async function wrapFetch(resource, options) {
-      if (options) {
-        // abort signal shows up as uncaught in tests
-        options.signal = null;
-      }
-      return fetch.apply(null, [resource, options]);
-    }
     global.window.fetch = wrapFetch;
   }
 });

--- a/js/packages/binderhub-client/tests/index.test.js
+++ b/js/packages/binderhub-client/tests/index.test.js
@@ -8,7 +8,9 @@ import { readFileSync } from "node:fs";
 
 test("Passed in URL object is not modified", () => {
   const buildEndpointUrl = new URL("https://test-binder.org/build");
-  const br = new BinderRepository("gh/test/test", buildEndpointUrl, "token");
+  const br = new BinderRepository("gh/test/test", buildEndpointUrl, {
+    buildToken: "token",
+  });
   expect(br.buildEndpointUrl.toString()).not.toEqual(
     buildEndpointUrl.toString(),
   );
@@ -16,13 +18,15 @@ test("Passed in URL object is not modified", () => {
 
 test("Invalid URL errors out", () => {
   expect(() => {
-    new BinderRepository("gh/test/test", "/build", "token");
+    new BinderRepository("gh/test/test", "/build", { buildToken: "token" });
   }).toThrow(TypeError);
 });
 
 test("Passing buildOnly flag works", () => {
   const buildEndpointUrl = new URL("https://test-binder.org/build");
-  const br = new BinderRepository("gh/test/test", buildEndpointUrl, null, true);
+  const br = new BinderRepository("gh/test/test", buildEndpointUrl, {
+    buildOnly: true,
+  });
   expect(br.buildUrl.toString()).toEqual(
     "https://test-binder.org/build/gh/test/test?build_only=true",
   );
@@ -46,7 +50,9 @@ test("Build URL correctly built from Build Endpoint", () => {
 
 test("Build URL correctly built from Build Endpoint when used with token", () => {
   const buildEndpointUrl = new URL("https://test-binder.org/build");
-  const br = new BinderRepository("gh/test/test", buildEndpointUrl, "token");
+  const br = new BinderRepository("gh/test/test", buildEndpointUrl, {
+    buildToken: "token",
+  });
   expect(br.buildUrl.toString()).toEqual(
     "https://test-binder.org/build/gh/test/test?build_token=token",
   );

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/eslint-parser": "^7.22.15",
     "@babel/preset-env": "^7.21.4",
     "@types/jest": "^29.5.5",
+    "@whatwg-node/fetch": "^0.9.17",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.2",
     "css-loader": "^6.7.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "bootstrap": "^3.4.1",
     "clipboard": "^2.0.11",
-    "event-source-polyfill": "^1.0.31",
     "jquery": "^3.6.4",
     "xterm": "^5.1.0",
     "xterm-addon-fit": "^0.7.0"


### PR DESCRIPTION
- When authenticated with JupyterHub, XSRF checks are applied to GET requests, blocking the EventSource
- switch to fetch-based EventSource implementation, since base EventSource doesn't allow headers (like websockets)
- allow api tokens for authenticated requests, which avoids auth issues including enabling cross-origin requests to authenticated servers

fixes #1842