### PR TITLE
local-binder-local-hub: easier testing of auth and non-standard Docker

### DIFF
--- a/testing/local-binder-local-hub/README.md
+++ b/testing/local-binder-local-hub/README.md
@@ -17,3 +17,8 @@ Run JupyterHub in one terminal
 
 BinderHub will be running as a managed JupyterHub service, go to http://localhost:8000
 and you should be redirected to BinderHub.
+
+If you want to test BinderHub with dummy authentication:
+
+    export AUTHENTICATOR=dummy
+    jupyterhub --config=jupyterhub_config.py

--- a/testing/local-binder-local-hub/binderhub_config.py
+++ b/testing/local-binder-local-hub/binderhub_config.py
@@ -42,3 +42,6 @@ c.BinderHub.base_url = os.getenv("JUPYTERHUB_SERVICE_PREFIX")
 # JUPYTERHUB_BASE_URL may not include the host
 # c.BinderHub.hub_url = os.getenv('JUPYTERHUB_BASE_URL')
 c.BinderHub.hub_url = os.getenv("JUPYTERHUB_EXTERNAL_URL") or f"http://{hostip}:8000"
+
+if os.getenv("AUTH_ENABLED") == "1":
+    c.BinderHub.auth_enabled = True


### PR DESCRIPTION
- Forward the `DOCKER_HOST` env-var from JupyterHub to BinderHub/repo2docker to make it easier to test when the docker socket is in a non-standard location (e..g Podman)
- Add an `AUTHENTICATOR=dummy` env-var to make it easier to test BinderHub authentication

This was useful for testing https://github.com/jupyterhub/binderhub/pull/1847