### PR TITLE
Bump version of repo2docker being used

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -557,7 +557,7 @@ class BinderHub(Application):
         return os.environ.get("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2024.06.0",
+        "quay.io/jupyterhub/repo2docker:2024.07.0",
         help="""
         DEPRECATED: Use c.KubernetesBuildExecutor.build_image
 

--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -557,7 +557,7 @@ class BinderHub(Application):
         return os.environ.get("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2023.06.0",
+        "quay.io/jupyterhub/repo2docker:2024.06.0",
         help="""
         DEPRECATED: Use c.KubernetesBuildExecutor.build_image
 

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -288,7 +288,7 @@ class KubernetesBuildExecutor(BuildExecutor):
         return os.getenv("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2024.06.0",
+        "quay.io/jupyterhub/repo2docker:2024.07.0",
         help="Docker image containing repo2docker that is used to spawn the build pods.",
         config=True,
     )

--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -288,7 +288,7 @@ class KubernetesBuildExecutor(BuildExecutor):
         return os.getenv("BUILD_NAMESPACE", "default")
 
     build_image = Unicode(
-        "quay.io/jupyterhub/repo2docker:2023.06.0",
+        "quay.io/jupyterhub/repo2docker:2024.06.0",
         help="Docker image containing repo2docker that is used to spawn the build pods.",
         config=True,
     )


### PR DESCRIPTION
Should pass once https://github.com/jupyterhub/repo2docker/pull/1356 is merged and released