### PR TITLE
Update message about repo not allowed to launch

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -300,7 +300,7 @@ class BuildHandler(BaseHandler):
             await self.emit(
                 {
                     "phase": "failed",
-                    "message": f"Sorry, {spec} has been temporarily disabled from launching. Please contact admins for more info!",
+                    "message": f"Sorry, {spec} is not allowed to launch. Please contact admins for more info!",
                 }
             )
             return


### PR DESCRIPTION
We are checking `is_banned` (really a check if the repo is allowed or not), and if its not allowed we write a message saying "has been temporarily disabled" - but I think its incorrect to include "temporarily" here as we may work against a check of allowed repositories and not just bans (temporary?).

![image](https://github.com/jupyterhub/binderhub/assets/3837114/be09a82a-bbba-47a9-be8c-48a22a002456)
