### PR TITLE
Bump pip-tools to v7 used by ci/refreeze script updating requirements.txt files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,8 @@ repos:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: requirements-txt-fixer
+        # exclude ci/refreeze generated requirements.txt
+        exclude: ^.*images\/.*\/requirements\.txt$
 
   # Lint: Python code
   - repo: https://github.com/PyCQA/flake8

--- a/ci/refreeze
+++ b/ci/refreeze
@@ -11,4 +11,4 @@ docker run --rm \
     --workdir=/io \
     --user=root \
     python:3.11-bullseye \
-    sh -c 'pip install pip-tools==6.* && pip-compile --upgrade helm-chart/images/binderhub/requirements.in'
+    sh -c 'pip install pip-tools==7.* && pip-compile --allow-unsafe --strip-extras --upgrade helm-chart/images/binderhub/requirements.in'

--- a/helm-chart/images/binderhub/requirements.txt
+++ b/helm-chart/images/binderhub/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    Use the "Run workflow" button at https://github.com/jupyterhub/binderhub/actions/workflows/watch-dependencies.yaml
 #
-alembic==1.13.1
+alembic==1.13.2
     # via jupyterhub
 async-generator==1.10
     # via jupyterhub
@@ -24,33 +24,33 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==42.0.5
+cryptography==42.0.8
     # via pyopenssl
-docker==7.0.0
-    # via -r ../../../requirements.txt
+docker==7.1.0
+    # via -r helm-chart/images/binderhub/../../../requirements.txt
 escapism==1.0.1
-    # via -r ../../../requirements.txt
-google-api-core[grpc]==2.18.0
+    # via -r helm-chart/images/binderhub/../../../requirements.txt
+google-api-core==2.19.1
     # via
     #   google-cloud-appengine-logging
     #   google-cloud-core
     #   google-cloud-logging
-google-auth==2.29.0
+google-auth==2.32.0
     # via
     #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-core
     #   google-cloud-logging
     #   kubernetes
-google-cloud-appengine-logging==1.4.3
+google-cloud-appengine-logging==1.4.4
     # via google-cloud-logging
 google-cloud-audit-log==0.2.5
     # via google-cloud-logging
 google-cloud-core==2.4.1
     # via google-cloud-logging
 google-cloud-logging==3.10.0
-    # via -r requirements.in
-googleapis-common-protos[grpc]==1.63.0
+    # via -r helm-chart/images/binderhub/requirements.in
+googleapis-common-protos==1.63.2
     # via
     #   google-api-core
     #   google-cloud-audit-log
@@ -58,39 +58,39 @@ googleapis-common-protos[grpc]==1.63.0
     #   grpcio-status
 greenlet==3.0.3
     # via sqlalchemy
-grpc-google-iam-v1==0.13.0
+grpc-google-iam-v1==0.13.1
     # via google-cloud-logging
-grpcio==1.62.1
+grpcio==1.65.0
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.62.1
+grpcio-status==1.62.2
     # via google-api-core
 idna==3.7
     # via requests
 jinja2==3.1.4
     # via
-    #   -r ../../../requirements.txt
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyterhub
-jsonschema==4.21.1
+jsonschema==4.23.0
     # via
-    #   -r ../../../requirements.txt
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyter-telemetry
 jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter-telemetry==0.1.0
     # via jupyterhub
-jupyterhub==4.1.3
+jupyterhub==4.1.5
     # via
-    #   -r ../../../requirements.txt
-    #   -r requirements.in
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
+    #   -r helm-chart/images/binderhub/requirements.in
 kubernetes==9.0.1
     # via
-    #   -r ../../../requirements.txt
-    #   -r requirements.in
-mako==1.3.2
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
+    #   -r helm-chart/images/binderhub/requirements.in
+mako==1.3.5
     # via alembic
 markupsafe==2.1.5
     # via
@@ -100,17 +100,15 @@ oauthlib==3.2.2
     # via
     #   jupyterhub
     #   requests-oauthlib
-packaging==24.0
-    # via
-    #   docker
-    #   jupyterhub
+packaging==24.1
+    # via jupyterhub
 pamela==1.1.0
     # via jupyterhub
 prometheus-client==0.20.0
     # via
-    #   -r ../../../requirements.txt
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyterhub
-proto-plus==1.23.0
+proto-plus==1.24.0
     # via
     #   google-api-core
     #   google-cloud-appengine-logging
@@ -131,12 +129,12 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pycurl==7.45.3
-    # via -r requirements.in
+    # via -r helm-chart/images/binderhub/requirements.in
 pyjwt==2.8.0
-    # via -r ../../../requirements.txt
+    # via -r helm-chart/images/binderhub/../../../requirements.txt
 pyopenssl==24.1.0
     # via certipy
 python-dateutil==2.9.0.post0
@@ -145,15 +143,15 @@ python-dateutil==2.9.0.post0
     #   kubernetes
 python-json-logger==2.0.7
     # via
-    #   -r ../../../requirements.txt
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyter-telemetry
 pyyaml==6.0.1
     # via kubernetes
-referencing==0.34.0
+referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0
+requests==2.32.3
     # via
     #   docker
     #   google-api-core
@@ -162,7 +160,7 @@ requests==2.31.0
     #   requests-oauthlib
 requests-oauthlib==2.0.0
     # via kubernetes
-rpds-py==0.18.0
+rpds-py==0.19.0
     # via
     #   jsonschema
     #   referencing
@@ -176,20 +174,20 @@ six==1.16.0
     # via
     #   kubernetes
     #   python-dateutil
-sqlalchemy==2.0.29
+sqlalchemy==2.0.31
     # via
     #   alembic
     #   jupyterhub
 tornado==6.4.1
     # via
-    #   -r ../../../requirements.txt
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyterhub
-traitlets==5.14.2
+traitlets==5.14.3
     # via
-    #   -r ../../../requirements.txt
+    #   -r helm-chart/images/binderhub/../../../requirements.txt
     #   jupyter-telemetry
     #   jupyterhub
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via
     #   alembic
     #   sqlalchemy
@@ -198,8 +196,9 @@ urllib3==2.2.2
     #   docker
     #   kubernetes
     #   requests
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools==70.3.0
+    # via kubernetes


### PR DESCRIPTION
The changes in flags are to respect deprecation notices in
https://github.com/jazzband/pip-tools?tab=readme-ov-file#deprecations.
