### PR TITLE
Update python, node, helm

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install helm diff plugin, update local chart dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,12 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - uses: actions/setup-node@v4
         # node required to build wheel
         with:
-          node-version: "16"
+          node-version: "22"
 
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@v3
@@ -58,7 +58,7 @@ jobs:
       - name: Setup helm
         uses: azure/setup-helm@v4
         with:
-          version: "v3.5.4"
+          version: "v3.16.2"
 
       - name: Install chart publishing dependencies (chartpress, etc)
         run: |
@@ -119,7 +119,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install pypa/build
         run: python -mpip install build
       - name: Build a sdist, and a binary wheel from the sdist

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -38,12 +38,12 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - uses: actions/setup-node@v4
         # node required to build wheel
         with:
-          node-version: "16"
+          node-version: "22"
 
       - name: Install chartpress
         run: pip install chartpress build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/setup-node@v4
         id: setup-node
         with:
-          node-version: "18"
+          node-version: "22"
 
       - name: Cache npm
         uses: actions/cache@v4
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -397,7 +397,7 @@ jobs:
       - uses: actions/setup-node@v4
         id: setup-node
         with:
-          node-version: "18"
+          node-version: "22"
 
       - name: Cache npm
         uses: actions/cache@v4
@@ -408,7 +408,7 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Cache pip
         uses: actions/cache@v4


### PR DESCRIPTION
Update GH workflows to use
- Python 3.12
- NodeJS 22
- Helm 3.16.2