### PR TITLE
Add playwright based UI integration tests for existing UI

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,0 +1,97 @@
+name: Playwright Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+      - "docs/**"
+      - "examples/**"
+      - ".github/workflows/**"
+      - "!.github/workflows/playwright.yaml"
+  push:
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+      - "docs/**"
+      - "examples/**"
+      - ".github/workflows/**"
+      - "!.github/workflows/playwright.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+      - "update-*"
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+    env:
+      GITHUB_ACCESS_TOKEN: "${{ secrets.github_token }}"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup OS level dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            build-essential \
+            curl \
+            libcurl4-openssl-dev \
+            libssl-dev
+
+      - uses: actions/setup-node@v4
+        id: setup-node
+        with:
+          node-version: "22"
+
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: node-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('**/package.json') }}-${{ github.job }}
+
+      - name: Run webpack to build static assets
+        run: |
+          npm install
+          npm run webpack
+
+      - uses: actions/setup-python@v5
+        id: setup-python
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/*requirements.txt') }}-${{ github.job }}
+
+      - name: Setup test dependencies
+        run: |
+          npm i -g configurable-http-proxy
+
+          pip install --no-binary pycurl -r dev-requirements.txt
+          pip install -e .
+
+      - name: Install playwright browser
+        run: |
+          playwright install firefox
+
+      - name: Run playwright tests
+        run: |
+          py.test --cov=binderhub -s integration-tests/
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-traces
+          path: test-results/
+
+      # Upload test coverage info to codecov
+      - uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,18 +335,18 @@ jobs:
       - name: Run main tests
         if: matrix.test == 'main'
         # running the "main" tests means "all tests that aren't auth"
-        run: pytest -m "not auth" --cov=binderhub
+        run: pytest -m "not auth" --cov=binderhub binderhub/tests/
 
       - name: Run auth tests
         if: matrix.test == 'auth'
         # running the "auth" tests means "all tests that are marked as auth"
-        run: pytest -m "auth" --cov=binderhub
+        run: pytest -m "auth" --cov=binderhub  binderhub/tests/
 
       - name: Run helm tests
         if: matrix.test == 'helm'
         run: |
           export BINDER_URL=http://localhost:30901
-          pytest --helm -m "remote" --cov=binderhub
+          pytest --helm -m "remote" --cov=binderhub binderhub/tests/
 
       - name: Get BinderHub health and metrics outputs
         if: always()
@@ -449,7 +449,7 @@ jobs:
       - name: Run remote tests
         run: |
           export BINDER_URL=http://localhost:8000/services/binder/
-          pytest -m remote --cov=binderhub
+          pytest -m remote --cov=binderhub binderhub/tests/
 
       - name: Show hub logs
         if: always()

--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -42,8 +42,12 @@ REMOTE_BINDER = bool(BINDER_URL)
 
 
 def pytest_configure(config):
-    """This function has meaning to pytest, for more information, see:
-    https://docs.pytest.org/en/stable/reference.html#pytest.hookspec.pytest_configure
+    """
+    Configure plugins and custom markers
+
+    This function is called by pytest after command line arguments have
+    been parsed. See https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_configure
+    for more information.
     """
     # register our custom markers
     config.addinivalue_line(

--- a/binderhub/tests/test_legacy.py
+++ b/binderhub/tests/test_legacy.py
@@ -1,0 +1,28 @@
+"""Test legacy redirects"""
+
+import pytest
+
+from .utils import async_requests
+
+
+@pytest.mark.parametrize(
+    "old_url, new_url",
+    [
+        (
+            "/repo/binderhub-ci-repos/requirements",
+            "/v2/gh/binderhub-ci-repos/requirements/master",
+        ),
+        (
+            "/repo/binderhub-ci-repos/requirements/",
+            "/v2/gh/binderhub-ci-repos/requirements/master",
+        ),
+        (
+            "/repo/binderhub-ci-repos/requirements/notebooks/index.ipynb",
+            "/v2/gh/binderhub-ci-repos/requirements/master?urlpath=%2Fnotebooks%2Findex.ipynb",
+        ),
+    ],
+)
+async def test_legacy_redirect(app, old_url, new_url):
+    r = await async_requests.get(app.url + old_url, allow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["location"] == new_url

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -61,44 +61,12 @@ def _resolve_url(page_url, url):
 
 
 @pytest.mark.remote
-async def test_main_page(app):
-    """Check the main page and any links on it"""
-    r = await async_requests.get(app.url)
-    assert r.status_code == 200
-    soup = BeautifulSoup(r.text, "html5lib")
-
-    # check src links (style, images)
-    for el in soup.find_all(src=True):
-        url = _resolve_url(app.url, el["src"])
-        r = await async_requests.get(url)
-        assert r.status_code == 200, f"{r.status_code} {url}"
-
-    # check hrefs
-    for el in soup.find_all(href=True):
-        href = el["href"]
-        if href.startswith("#"):
-            continue
-        url = _resolve_url(app.url, href)
-        r = await async_requests.get(url)
-        assert r.status_code == 200, f"{r.status_code} {url}"
-
-
-@pytest.mark.remote
 @pytest.mark.helm
 async def test_custom_template(app):
     """Check that our custom template config is applied via the helm chart"""
     r = await async_requests.get(app.url)
     assert r.status_code == 200
     assert "test-template" in r.text
-
-
-@pytest.mark.remote
-async def test_about_handler(app):
-    # Check that the about page loads
-    r = await async_requests.get(app.url + "/about")
-    assert r.status_code == 200
-    assert "This website is powered by" in r.text
-    assert binder_version.split("+")[0] in r.text
 
 
 @pytest.mark.remote
@@ -119,65 +87,6 @@ async def test_versions_handler(app):
 
     assert data["builder_info"] in allowed_builder_info
     assert data["binderhub"].split("+")[0] == binder_version.split("+")[0]
-
-
-@pytest.mark.parametrize(
-    "provider_prefix,repo,ref,path,path_type,status_code",
-    [
-        ("gh", "binderhub-ci-repos/requirements", "master", "", "", 200),
-        ("gh", "binderhub-ci-repos%2Frequirements", "master", "", "", 400),
-        ("gh", "binderhub-ci-repos/requirements", "master/", "", "", 200),
-        (
-            "gh",
-            "binderhub-ci-repos/requirements",
-            "20c4fe55a9b2c5011d228545e821b1c7b1723652",
-            "index.ipynb",
-            "file",
-            200,
-        ),
-        (
-            "gh",
-            "binderhub-ci-repos/requirements",
-            "20c4fe55a9b2c5011d228545e821b1c7b1723652",
-            "%2Fnotebooks%2Findex.ipynb",
-            "url",
-            200,
-        ),
-        ("gh", "binderhub-ci-repos/requirements", "master", "has%20space", "file", 200),
-        (
-            "gh",
-            "binderhub-ci-repos/requirements",
-            "master/",
-            "%2Fhas%20space%2F",
-            "file",
-            200,
-        ),
-        (
-            "gh",
-            "binderhub-ci-repos/requirements",
-            "master",
-            "%2Fhas%20space%2F%C3%BCnicode.ipynb",
-            "file",
-            200,
-        ),
-    ],
-)
-async def test_loading_page(
-    app, provider_prefix, repo, ref, path, path_type, status_code
-):
-    # repo = f'{org}/{repo_name}'
-    spec = f"{repo}/{ref}"
-    provider_spec = f"{provider_prefix}/{spec}"
-    query = f"{path_type}path={path}" if path else ""
-    uri = f"/v2/{provider_spec}?{query}"
-    r = await async_requests.get(app.url + uri)
-    assert r.status_code == status_code, f"{r.status_code} {uri}"
-    if status_code == 200:
-        soup = BeautifulSoup(r.text, "html5lib")
-        assert soup.find(id="log-container")
-        nbviewer_url = soup.find(id="nbviewer-preview").find("iframe").attrs["src"]
-        r = await async_requests.get(nbviewer_url)
-        assert r.status_code == 200, f"{r.status_code} {nbviewer_url}"
 
 
 @pytest.mark.parametrize(

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -1,7 +1,7 @@
 """Test main handlers"""
 
 import time
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 import jwt
 import pytest
@@ -33,31 +33,6 @@ async def test_legacy_redirect(app, old_url, new_url):
     r = await async_requests.get(app.url + old_url, allow_redirects=False)
     assert r.status_code == 302
     assert r.headers["location"] == new_url
-
-
-def _resolve_url(page_url, url):
-    """Resolve a URL relative to a page"""
-
-    # full URL, nothing to resolve
-    if "://" in url:
-        return url
-
-    parsed = urlparse(page_url)
-
-    if url.startswith("/"):
-        # absolute path
-        return f"{parsed.scheme}://{parsed.netloc}{url}"
-
-    # relative path URL
-
-    if page_url.endswith("/"):
-        # URL is a directory, resolve relative to dir
-        path = parsed.path
-    else:
-        # URL is not a directory, resolve relative to parent
-        path = parsed.path.rsplit("/", 1)[0] + "/"
-
-    return f"{parsed.scheme}://{parsed.netloc}{path}{url}"
 
 
 @pytest.mark.remote

--- a/binderhub/tests/test_main.py
+++ b/binderhub/tests/test_main.py
@@ -7,32 +7,7 @@ import jwt
 import pytest
 from bs4 import BeautifulSoup
 
-from binderhub import __version__ as binder_version
-
 from .utils import async_requests
-
-
-@pytest.mark.parametrize(
-    "old_url, new_url",
-    [
-        (
-            "/repo/binderhub-ci-repos/requirements",
-            "/v2/gh/binderhub-ci-repos/requirements/master",
-        ),
-        (
-            "/repo/binderhub-ci-repos/requirements/",
-            "/v2/gh/binderhub-ci-repos/requirements/master",
-        ),
-        (
-            "/repo/binderhub-ci-repos/requirements/notebooks/index.ipynb",
-            "/v2/gh/binderhub-ci-repos/requirements/master?urlpath=%2Fnotebooks%2Findex.ipynb",
-        ),
-    ],
-)
-async def test_legacy_redirect(app, old_url, new_url):
-    r = await async_requests.get(app.url + old_url, allow_redirects=False)
-    assert r.status_code == 302
-    assert r.headers["location"] == new_url
 
 
 @pytest.mark.remote
@@ -42,26 +17,6 @@ async def test_custom_template(app):
     r = await async_requests.get(app.url)
     assert r.status_code == 200
     assert "test-template" in r.text
-
-
-@pytest.mark.remote
-async def test_versions_handler(app):
-    # Check that the about page loads
-    r = await async_requests.get(app.url + "/versions")
-    assert r.status_code == 200
-
-    data = r.json()
-    # builder_info is different for KubernetesExecutor and LocalRepo2dockerBuild
-    try:
-        import repo2docker
-
-        allowed_builder_info = [{"repo2docker-version": repo2docker.__version__}]
-    except ImportError:
-        allowed_builder_info = []
-    allowed_builder_info.append({"build_image": app.build_image})
-
-    assert data["builder_info"] in allowed_builder_info
-    assert data["binderhub"].split("+")[0] == binder_version.split("+")[0]
 
 
 @pytest.mark.parametrize(

--- a/binderhub/tests/test_version.py
+++ b/binderhub/tests/test_version.py
@@ -1,0 +1,27 @@
+"""Test version handler"""
+
+import pytest
+
+from binderhub import __version__ as binder_version
+
+from .utils import async_requests
+
+
+@pytest.mark.remote
+async def test_versions_handler(app):
+    # Check that the about page loads
+    r = await async_requests.get(app.url + "/versions")
+    assert r.status_code == 200
+
+    data = r.json()
+    # builder_info is different for KubernetesExecutor and LocalRepo2dockerBuild
+    try:
+        import repo2docker
+
+        allowed_builder_info = [{"repo2docker-version": repo2docker.__version__}]
+    except ImportError:
+        allowed_builder_info = []
+    allowed_builder_info.append({"build_image": app.build_image})
+
+    assert data["builder_info"] in allowed_builder_info
+    assert data["binderhub"].split("+")[0] == binder_version.split("+")[0]

--- a/binderhub/tests/utils.py
+++ b/binderhub/tests/utils.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import io
+import socket
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
 
@@ -149,3 +150,12 @@ class _AsyncRequests:
 
 # async_requests.get = requests.get returning a Future, etc.
 async_requests = _AsyncRequests()
+
+
+def random_port() -> int:
+    """Get a single random port."""
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,13 +2,16 @@ beautifulsoup4[html5lib]
 build
 chartpress>=2.1
 click
+dockerspawner
 jsonschema
 jupyter-repo2docker>=2021.08.0
 jupyter_packaging>=0.10.4,<2
 jupyterhub
+nest-asyncio
 pytest
 pytest-asyncio
 pytest-cov
 pytest-timeout
+pytest_playwright
 requests
 ruamel.yaml>=0.17.30

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,6 @@
+import nest_asyncio
+
+
+def pytest_configure(config):
+    # Required for playwright to be run from within pytest
+    nest_asyncio.apply()

--- a/integration-tests/test_ui.py
+++ b/integration-tests/test_ui.py
@@ -1,0 +1,187 @@
+"""
+Integration tests using playwright
+"""
+
+import subprocess
+import sys
+import time
+
+import pytest
+import requests
+import requests.exceptions
+from playwright.sync_api import Page
+
+from binderhub import __version__ as binder_version
+from binderhub.tests.utils import async_requests, random_port
+
+
+@pytest.fixture(scope="module")
+async def local_hub_local_binder(request):
+    """
+    Set up a local docker based binder based on testing/local-binder-local-hub
+
+    Requires docker to be installed and available
+    """
+    port = random_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "jupyterhub",
+            "--config",
+            "testing/local-binder-local-hub/jupyterhub_config.py",
+            f"--port={port}",
+        ]
+    )
+
+    url = f"http://127.0.0.1:{port}/services/binder/"
+    for i in range(10):
+        try:
+            resp = await async_requests.get(url)
+            if resp.status_code == 200:
+                break
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+    yield url
+
+    proc.terminate()
+    proc.wait()
+
+
+@pytest.mark.parametrize(
+    ("provider_prefix", "repo", "ref", "path", "path_type", "status_code"),
+    [
+        ("gh", "binderhub-ci-repos/requirements", "master", "", "", 200),
+        ("gh", "binderhub-ci-repos%2Frequirements", "master", "", "", 400),
+        ("gh", "binderhub-ci-repos/requirements", "master/", "", "", 200),
+        (
+            "gh",
+            "binderhub-ci-repos/requirements",
+            "20c4fe55a9b2c5011d228545e821b1c7b1723652",
+            "index.ipynb",
+            "file",
+            200,
+        ),
+        (
+            "gh",
+            "binderhub-ci-repos/requirements",
+            "20c4fe55a9b2c5011d228545e821b1c7b1723652",
+            "%2Fnotebooks%2Findex.ipynb",
+            "url",
+            200,
+        ),
+        ("gh", "binderhub-ci-repos/requirements", "master", "has%20space", "file", 200),
+        (
+            "gh",
+            "binderhub-ci-repos/requirements",
+            "master/",
+            "%2Fhas%20space%2F",
+            "file",
+            200,
+        ),
+        (
+            "gh",
+            "binderhub-ci-repos/requirements",
+            "master",
+            "%2Fhas%20space%2F%C3%BCnicode.ipynb",
+            "file",
+            200,
+        ),
+    ],
+)
+async def test_loading_page(
+    local_hub_local_binder,
+    provider_prefix,
+    repo,
+    ref,
+    path,
+    path_type,
+    status_code,
+    page: Page,
+):
+    spec = f"{repo}/{ref}"
+    provider_spec = f"{provider_prefix}/{spec}"
+    query = f"{path_type}path={path}" if path else ""
+    uri = f"/v2/{provider_spec}?{query}"
+    r = page.goto(local_hub_local_binder + uri)
+
+    assert r.status == status_code
+
+    if status_code == 200:
+        assert page.query_selector("#log-container")
+        iframe = page.query_selector("#nbviewer-preview iframe")
+        assert iframe is not None
+        nbviewer_url = iframe.get_attribute("src")
+        r = await async_requests.get(nbviewer_url)
+        assert r.status_code == 200, f"{r.status_code} {nbviewer_url}"
+
+
+@pytest.mark.parametrize(
+    ("repo", "ref", "path", "path_type", "shared_url"),
+    [
+        (
+            "binder-examples/requirements",
+            "",
+            "",
+            "",
+            "v2/gh/binder-examples/requirements/HEAD",
+        ),
+        (
+            "binder-examples/requirements",
+            "master",
+            "",
+            "",
+            "v2/gh/binder-examples/requirements/master",
+        ),
+        (
+            "binder-examples/requirements",
+            "master",
+            "some file with spaces.ipynb",
+            "file",
+            "v2/gh/binder-examples/requirements/master?labpath=some+file+with+spaces.ipynb",
+        ),
+        (
+            "binder-examples/requirements",
+            "master",
+            "/some url with spaces?query=something",
+            "url",
+            "v2/gh/binder-examples/requirements/master?urlpath=%2Fsome+url+with+spaces%3Fquery%3Dsomething",
+        ),
+    ],
+)
+async def test_main_page(
+    local_hub_local_binder, page: Page, repo, ref, path, path_type, shared_url
+):
+    resp = page.goto(local_hub_local_binder)
+    assert resp.status == 200
+
+    page.get_by_placeholder("GitHub repository name or URL").type(repo)
+
+    if ref:
+        page.locator("#ref").type(ref)
+
+    if path_type:
+        page.query_selector("#url-or-file-btn").click()
+        if path_type == "file":
+            page.locator("a:text-is('File')").click()
+        elif path_type == "url":
+            page.locator("a:text-is('URL')").click()
+        else:
+            raise ValueError(f"Unknown path_type {path_type}")
+    if path:
+        page.locator("#filepath").type(path)
+
+    assert (
+        page.query_selector("#basic-url-snippet").inner_text()
+        == f"{local_hub_local_binder}{shared_url}"
+    )
+
+
+async def test_about_page(local_hub_local_binder, page: Page):
+    r = page.goto(f"{local_hub_local_binder}about")
+
+    assert r.status == 200
+
+    assert "This website is powered by" in page.content()
+    assert binder_version.split("+")[0] in page.content()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,6 @@ build-backend = "setuptools.build_meta"
 
 
 # black is used for autoformatting Python code
-#
-# ref: https://black.readthedocs.io/en/stable/
-#
 [tool.black]
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
@@ -18,27 +15,20 @@ target-version = ["py38", "py39", "py310", "py311"]
 
 
 # isort is used for autoformatting Python code
-#
-# ref: https://pycqa.github.io/isort/
-#
 [tool.isort]
 profile = "black"
 
 
 # pytest is used for running Python based tests
-#
-# ref: https://docs.pytest.org/en/stable/
-#
 [tool.pytest.ini_options]
-addopts = "--verbose --color=yes --durations=10"
+# Run playwright tests only on firefox
+# Retain playwright traces after failing tests, to help with debugging
+addopts = "--verbose --color=yes --durations=10 --browser firefox --tracing retain-on-failure"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 timeout = "60"
 
 # pytest-cov / coverage is used to measure code coverage of tests
-#
-# ref: https://coverage.readthedocs.io/en/stable/config.html
-#
 [tool.coverage.run]
 omit = [
   "binderhub/tests/*",

--- a/testing/local-binder-local-hub/binderhub_config.py
+++ b/testing/local-binder-local-hub/binderhub_config.py
@@ -33,14 +33,11 @@ c.BinderHub.banner_message = (
     'See <a href="https://github.com/jupyterhub/binderhub">BinderHub on GitHub</a>'
 )
 
-c.BinderHub.hub_url_local = "http://localhost:8000"
-
 # Assert that we're running as a managed JupyterHub service
 # (otherwise c.BinderHub.hub_api_token is needed)
 assert os.getenv("JUPYTERHUB_API_TOKEN")
 c.BinderHub.base_url = os.getenv("JUPYTERHUB_SERVICE_PREFIX")
-# JUPYTERHUB_BASE_URL may not include the host
-# c.BinderHub.hub_url = os.getenv('JUPYTERHUB_BASE_URL')
+
 c.BinderHub.hub_url = os.getenv("JUPYTERHUB_EXTERNAL_URL") or f"http://{hostip}:8000"
 
 if os.getenv("AUTH_ENABLED") == "1":

--- a/testing/local-binder-local-hub/jupyterhub_config.py
+++ b/testing/local-binder-local-hub/jupyterhub_config.py
@@ -12,6 +12,16 @@ from dockerspawner import DockerSpawner
 
 from binderhub.binderspawner_mixin import BinderSpawnerMixin
 
+
+def random_port() -> int:
+    """Get a single random port."""
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 s.connect(("8.8.8.8", 80))
 hostip = s.getsockname()[0]
@@ -60,12 +70,20 @@ for env_var in ["JUPYTERHUB_EXTERNAL_URL", "GITHUB_ACCESS_TOKEN", "DOCKER_HOST"]
         binderhub_environment[env_var] = os.getenv(env_var)
     if auth_enabled:
         binderhub_environment["AUTH_ENABLED"] = "1"
+
+binderhub_port = random_port()
+
 c.JupyterHub.services = [
     {
         "name": binderhub_service_name,
         "admin": True,
-        "command": ["python", "-mbinderhub", f"--config={binderhub_config}"],
-        "url": "http://localhost:8585",
+        "command": [
+            "python",
+            "-mbinderhub",
+            f"--config={binderhub_config}",
+            f"--port={binderhub_port}",
+        ],
+        "url": f"http://localhost:{binderhub_port}",
         "environment": binderhub_environment,
     }
 ]


### PR DESCRIPTION
Primarily written to make UI testing easier in https://github.com/jupyterhub/binderhub/pull/1856, and
steals code from there

- Add a new 'integration-tests' directory that does white box
  UI testing
- Install dockerspawner in dev-requirements, as the playwright
  integration tests now need it
- Move loading and about page tests to use playwright
- Add some tests for the home page
- Use a single instance of local-binder-local-hub for doing thes
  integration tests
- Upload playwright traces (https://playwright.dev/python/docs/trace-viewer)
  on failure as a github artifact so we can debug things better 
- Split some more tests out of `test_main.py`, so we can get rid of it as part of #1856 