### PR TITLE
Don't stop when 2 tests fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ profile = "black"
 # ref: https://docs.pytest.org/en/stable/
 #
 [tool.pytest.ini_options]
-addopts = "--verbose --color=yes --durations=10 --maxfail=2"
+addopts = "--verbose --color=yes --durations=10"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 timeout = "60"


### PR DESCRIPTION
This gives the false impression that only two tests are failing, and is very surprising behavior to have as default. Users who want this can pass the commandline arg to `py.test` when they want it.