### PR TITLE
pytest-asyncio 0.25.1 breaks our playwright tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ jupyter_packaging>=0.10.4,<2
 jupyterhub
 nest-asyncio
 pytest
-pytest-asyncio
+pytest-asyncio<=0.25.0
 pytest-cov
 pytest-timeout
 pytest_playwright


### PR DESCRIPTION
Temporary fix for https://github.com/jupyterhub/binderhub/issues/1902