### PR TITLE
Allow Access-Control-Allow-Origin=* on `/versions` API

### DIFF
--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -217,9 +217,9 @@ class VersionHandler(BaseHandler):
     skip_check_request_ip = True
 
     def set_default_headers():
-        if 'Access-Control-Allow-Origin' not in self.settings.get("headers", {}):
+        if "Access-Control-Allow-Origin" not in self.settings.get("headers", {}):
             # allow CORS requests to this endpoint by default
-            self.set_header('Access-Control-Allow-Origin', '*')
+            self.set_header("Access-Control-Allow-Origin", "*")
 
         super().set_default_headers()
 

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -216,7 +216,7 @@ class VersionHandler(BaseHandler):
     # (e.g. mybinder.org federation when blocking cloud datacenters)
     skip_check_request_ip = True
 
-    def set_default_headers():
+    def set_default_headers(self):
         if "Access-Control-Allow-Origin" not in self.settings.get("headers", {}):
             # allow CORS requests to this endpoint by default
             self.set_header("Access-Control-Allow-Origin", "*")

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -216,6 +216,13 @@ class VersionHandler(BaseHandler):
     # (e.g. mybinder.org federation when blocking cloud datacenters)
     skip_check_request_ip = True
 
+    def set_default_headers():
+        if 'Access-Control-Allow-Origin' not in self.settings.get("headers", {}):
+            # allow CORS requests to this endpoint by default
+            self.set_header('Access-Control-Allow-Origin', '*')
+
+        super().set_default_headers()
+
     async def get(self):
         self.set_header("Content-type", "application/json")
         r = {


### PR DESCRIPTION
This PR is the BinderHub counterpart to https://github.com/jupyterhub/jupyterhub/pull/4966/. It is intended to expose the unauthenticated `/versions` API call to cross-origin queries, enabling use in contexts where CORS would otherwise prohibit the fetch. 

By merging this PR, all BinderHub deployments will now be able to answer a question of the form "are you a BinderHub", which is useful for us over in the Jupyter Book ecosystem (see the above PR!)

I took the same approach here as JupyterHub, so I hope it's not a contentious PR!