### PR TITLE
fix: handle deprecation of `datetime.utcnow()`

### DIFF
--- a/binderhub/events.py
+++ b/binderhub/events.py
@@ -2,9 +2,9 @@
 Emit structured, discrete events when various actions happen.
 """
 
+import datetime
 import json
 import logging
-import datetime
 
 import jsonschema
 from jupyterhub.traitlets import Callable

--- a/binderhub/events.py
+++ b/binderhub/events.py
@@ -100,7 +100,7 @@ class EventLog(Configurable):
 
         now_utc = datetime.datetime.now(tz=datetime.timezone.utc)
         capsule = {
-            "timestamp": now_utc.isoformat() + "Z",
+            "timestamp": now_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "schema": schema_name,
             "version": version,
         }

--- a/binderhub/events.py
+++ b/binderhub/events.py
@@ -4,7 +4,7 @@ Emit structured, discrete events when various actions happen.
 
 import json
 import logging
-from datetime import datetime
+import datetime
 
 import jsonschema
 from jupyterhub.traitlets import Callable
@@ -98,8 +98,9 @@ class EventLog(Configurable):
         schema = self.schemas[(schema_name, version)]
         jsonschema.validate(event, schema)
 
+        now_utc = datetime.datetime.now(tz=datetime.timezone.utc)
         capsule = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": now_utc.isoformat() + "Z",
             "schema": schema_name,
             "version": version,
         }


### PR DESCRIPTION
I saw this warning in the logging of another PR.

I have not been able to test this locally (or rather, I didn't want to spin up a minikube cluster). 

Hopefully the CI catches any regressions.