### PR TITLE
image cleaner: expose option to control cordoning

### DIFF
--- a/helm-chart/binderhub/schema.yaml
+++ b/helm-chart/binderhub/schema.yaml
@@ -457,13 +457,19 @@ properties:
   imageCleaner:
     type: object
     additionalProperties: false
-    required: [enabled]
+    required:
+      - enabled
     properties:
       enabled:
         type: boolean
         description: |
           TODO
       image: *image-spec
+      cordon:
+        type: boolean
+        description: |
+          Whether to cordon the node while cleaning its images.
+          Disable, e.g. for single-node clusters.
       delay:
         type: integer
         description: |
@@ -480,6 +486,12 @@ properties:
         type: integer
         description: |
           TODO
+      extraEnv:
+        type: [object, array]
+        additionalProperties: true
+        description: |
+          see binderhub.deployment.extraEnv
+
       host:
         type: object
         additionalProperties: false

--- a/helm-chart/binderhub/templates/image-cleaner.yaml
+++ b/helm-chart/binderhub/templates/image-cleaner.yaml
@@ -49,10 +49,12 @@ spec:
         - name: socket-{{ $builderName }}
           mountPath: /var/run/docker.sock
         env:
+        {{- if .Values.imageCleaner.cordon }}
         - name: DOCKER_IMAGE_CLEANER_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        {{- end }}
         - name: DOCKER_IMAGE_CLEANER_PATH_TO_CHECK
           value: /var/lib/{{ $builderName }}
         - name: DOCKER_IMAGE_CLEANER_DELAY_SECONDS
@@ -63,6 +65,9 @@ spec:
           value: {{ .Values.imageCleaner.imageGCThresholdHigh | quote }}
         - name: DOCKER_IMAGE_CLEANER_THRESHOLD_LOW
           value: {{ .Values.imageCleaner.imageGCThresholdLow | quote }}
+        {{- with .Values.imageCleaner.extraEnv }}
+        {{- include "jupyterhub.extraEnv" . | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: 0
       volumes:
       {{- if eq $builderName "host" }}

--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -313,11 +313,14 @@ pink:
 
 imageCleaner:
   enabled: true
+  extraEnv: {}
   image:
     name: quay.io/jupyterhub/docker-image-cleaner
     tag: "1.0.0-beta.3"
     pullPolicy: ""
     pullSecrets: []
+  # whether to cordon nodes while cleaning
+  cordon: true
   # delete an image at most every 5 seconds
   delay: 5
   # Interpret threshold values as percentage or bytes


### PR DESCRIPTION
cordoning [doesn't happen if $DOCKER_IMAGE_CLEANER_NODE_NAME is undefined](https://github.com/jupyterhub/docker-image-cleaner/blob/3e46326e25ffb2f8a0cc78a8b9ba19859d82c78c/docker_image_cleaner/cleaner.py#L111-L112).

single-node clusters (k3s) maybe don't want to be unavailable while cleaning

adds extraEnv passthrough for good measure, in case of future/other options from the cleaner image not exposed explicitly in the chart