### PR TITLE
Require Python >= 3.10 (broken on older versions)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -411,7 +411,8 @@ jobs:
       - uses: actions/setup-python@v5
         id: setup-python
         with:
-          python-version: "3.12"
+          # Set this to the oldest Python version supported by BinderHub
+          python-version: "3.8"
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -412,7 +412,7 @@ jobs:
         id: setup-python
         with:
           # Set this to the oldest Python version supported by BinderHub
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -412,7 +412,7 @@ jobs:
         id: setup-python
         with:
           # Set this to the oldest Python version supported by BinderHub
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 # target-version should be all supported versions, see
 # https://github.com/psf/black/issues/751#issuecomment-473066811
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py310", "py311", "py312"]
 
 
 # The default isort output conflicts with black autoformatting.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     name="binderhub",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(cmdclass),
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     author="Project Jupyter Contributors",
     author_email="jupyter@googlegroups.com",
     license="BSD",


### PR DESCRIPTION
The BinderHub Python metadata claims to support Python 3.8, but this isn't tested, and the code base now contains some syntax that requires Python 3.10.

The alternative to bumping the minimum version is to ensure the code is compatible with 3.8 (or 3.9).