### PR TITLE
Set btn-secondary on dropdown selectors

### DIFF
--- a/binderhub/static/js/components/LinkGenerator.jsx
+++ b/binderhub/static/js/components/LinkGenerator.jsx
@@ -18,7 +18,7 @@ function ProviderSelector({
   return (
     <>
       <button
-        className="btn border border-2 border-end-0 dropdown-toggle"
+        className="btn btn-secondary border border-2 border-end-0 dropdown-toggle"
         type="button"
         data-bs-toggle="dropdown"
         aria-expanded="false"
@@ -92,7 +92,7 @@ function UrlSelector({ setUrlPath }) {
           onChange={(e) => setPath(e.target.value)}
         />
         <button
-          className="btn border border-2 border-start-0 dropdown-toggle"
+          className="btn btn-secondary border border-2 border-start-0 dropdown-toggle"
           type="button"
           data-bs-toggle="dropdown"
           aria-expanded="false"


### PR DESCRIPTION
This ensures you receive visual feedback when you use the keyboard TAB to move between form fields. At present there is no visual indication when you get to a dropdown.

https://github.com/user-attachments/assets/194d7ec2-018c-4dc3-8245-327d0ce8df01

