### PR TITLE
GitHub: only show "master" branch message if master branch is requested

### DIFF
--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -325,11 +325,11 @@ class BuildHandler(BaseHandler):
             ]
 
             if provider.name == "GitHub":
-                error_message.append(
-                    'GitHub recently changed default branches from "master" to "main".'
-                )
-
                 if provider.unresolved_ref in {"master", "main"}:
+                    if provider.unresolved_ref == "master":
+                        error_message.append(
+                            'GitHub has changed default branches from "master" to "main".'
+                        )
                     error_message.append(
                         "Tip: HEAD will always resolve to a repository's default branch."
                     )


### PR DESCRIPTION
rather than showing it on every unresolved GitHub ref

and remove 'recently' because it's not so recent anymore