### PR TITLE
Only mount ~/.docker/config.json, not ~/.docker

### DIFF
--- a/binderhub/build.py
+++ b/binderhub/build.py
@@ -448,7 +448,11 @@ class KubernetesBuildExecutor(BuildExecutor):
 
         if not self.registry_credentials and self.push_secret:
             volume_mounts.append(
-                client.V1VolumeMount(mount_path="/root/.docker", name="docker-config")
+                client.V1VolumeMount(
+                    mount_path="/root/.docker/config.json",
+                    name="docker-config",
+                    sub_path="config.json",
+                )
             )
             volumes.append(
                 client.V1Volume(


### PR DESCRIPTION
docker buildx wants to write to ~/.docker/buildx, but since we mount the secret *entirely* (to ~/.docker/buildx), it can not. I think mounting *just* the subpath should work.

Follow-up to https://github.com/jupyterhub/repo2docker/pull/1402