### PR TITLE
Append / to Docker Hub auth URL

### DIFF
--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -46,7 +46,7 @@ class DockerRegistry(LoggingConfigurable):
             # which assumes https
             auth_config_url = "https://" + auth_config_url
 
-        if auth_config_url.rstrip("/") == DEFAULT_DOCKER_AUTH_URL:
+        if auth_config_url == DEFAULT_DOCKER_AUTH_URL:
             # default docker config key is the v1 registry,
             # but we will talk to the v2 api
             return DEFAULT_DOCKER_REGISTRY_URL

--- a/binderhub/registry.py
+++ b/binderhub/registry.py
@@ -14,7 +14,7 @@ from traitlets import Bool, Dict, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 DEFAULT_DOCKER_REGISTRY_URL = "https://registry-1.docker.io"
-DEFAULT_DOCKER_AUTH_URL = "https://index.docker.io/v1"
+DEFAULT_DOCKER_AUTH_URL = "https://index.docker.io/v1/"
 
 
 class DockerRegistry(LoggingConfigurable):

--- a/binderhub/tests/test_registry.py
+++ b/binderhub/tests/test_registry.py
@@ -15,7 +15,7 @@ from binderhub.registry import DockerRegistry, ExternalRegistryHelper
 def test_registry_defaults(tmpdir):
     registry = DockerRegistry(docker_config_path=str(tmpdir.join("doesntexist.json")))
     assert registry.url == "https://registry-1.docker.io"
-    assert registry.auth_config_url == "https://index.docker.io/v1"
+    assert registry.auth_config_url == "https://index.docker.io/v1/"
     assert (
         registry.token_url == "https://auth.docker.io/token?service=registry.docker.io"
     )
@@ -29,7 +29,7 @@ def test_registry_username_password(tmpdir):
         json.dump(
             {
                 "auths": {
-                    "https://index.docker.io/v1": {
+                    "https://index.docker.io/v1/": {
                         "auth": base64.encodebytes(b"user:pass").decode("ascii")
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/jupyterhub/binderhub/issues/1943

On a Linux bare metal machine, when I run

```
docker login
```

the `~/.docker/config.json` is

```json
{
  "auths": {
    "https://index.docker.io/v1/": {
      "auth": "****"
    }
  }
}
```

This is very similar to the file being generated except for the trailing slash.

This might be a regression on Docker client.