### PR TITLE
Add extra_css for custom css injection

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -188,6 +188,16 @@ class BinderHub(Application):
         config=True,
     )
 
+    extra_css = Unicode(
+        {},
+        help="""
+        Extra bits of CSS that should be loaded in each page.
+
+        Omit the <style> tag.
+        """,
+        config=True,
+    )
+
     base_url = Unicode("/", help="The base URL of the entire application", config=True)
 
     @validate("base_url")
@@ -959,6 +969,7 @@ class BinderHub(Application):
                 "about_message": self.about_message,
                 "banner_message": self.banner_message,
                 "extra_footer_scripts": self.extra_footer_scripts,
+                "extra_css": self.extra_css,
                 "jinja2_env": jinja_env,
                 "build_docker_config": self.build_docker_config,
                 "base_url": self.base_url,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -41,6 +41,7 @@ class UIHandler(BaseHandler):
         self.render_template(
             "page.html",
             page_config=self.page_config,
+            extra_css=self.settings["extra_css"],
             extra_footer_scripts=self.settings["extra_footer_scripts"],
             opengraph_title=self.opengraph_title,
         )

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -16,6 +16,9 @@
   <link id="favicon" rel="shortcut icon" type="image/png" href="{{static_url("favicon.ico")}}" />
   <link href="{{static_url("dist/styles.css")}}" rel="stylesheet"></link>
 
+  <style>
+    {{extra_css}};
+  </style>
   <script>
     window.pageConfig = {{page_config|tojson}};
   </script>


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/binderhub/issues/1949.

I tested this locally by adding the following to `testing/local-binder-mocked-hub/binderhub_config.py`:

```
c.BinderHub.banner_message = 'This is headline <a href="#">news.</a>'
c.BinderHub.extra_css = """
.p-3.bg-light.shadow-sm.text-center {
    color: red;
}
"""
```

the style was loaded and the headline color changed.
