### PR TITLE
Bundle CSS and SASS together

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,13 +49,15 @@ module.exports = {
         test: /\.(scss)$/,
         use: [
           {
-            // Adds CSS to the DOM by injecting a `<style>` tag
-            loader: "style-loader",
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              // Set publicPath as relative path ("./").
+              // By default it uses the `output.publicPath` ("/static/dist/"), when it rewrites the URLs in styles.css.
+              // And it causes these files unavailabe if BinderHub has a different base_url than "/".
+              publicPath: "./",
+            },
           },
-          {
-            // Interprets `@import` and `url()` like `import/require()` and will resolve them
-            loader: "css-loader",
-          },
+          "css-loader",
           {
             // Loader for webpack to process CSS with PostCSS
             loader: "postcss-loader",


### PR DESCRIPTION
This changes `binderhub/static/dist/styles.css` generated by [webpack](https://webpack.js.org).

Before, `binderhub/static/dist/styles.css` only includes https://github.com/jupyterhub/binderhub/blob/1a445a2903910670bbc654b66eae870f96ad65c1/binderhub/static/js/components/BuilderLauncher.jsx#L5

With this PR, `binderhub/static/dist/styles.css` now also includes https://github.com/jupyterhub/binderhub/blob/1a445a2903910670bbc654b66eae870f96ad65c1/binderhub/static/js/App.jsx#L5

With this change, it is expected to enable https://github.com/jupyterhub/binderhub/issues/1949.

Closes https://github.com/jupyterhub/binderhub/issues/1952