### PR TITLE
Add id to buttons in launch form

### DIFF
--- a/js/packages/binderhub-react-components/package.json
+++ b/js/packages/binderhub-react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterhub/binderhub-react-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Collection of React components for BinderHub",
   "exports": {
     "./*.jsx": "./src/*.jsx"

--- a/js/packages/binderhub-react-components/src/BuilderLauncher.jsx
+++ b/js/packages/binderhub-react-components/src/BuilderLauncher.jsx
@@ -140,6 +140,7 @@ function ImageLogs({
       <div className="card-header d-flex align-items-baseline">
         <span className="flex-fill">Build Logs</span>
         <button
+          id="btn-show-log"
           ref={toggleLogsButton}
           className="btn btn-link"
           type="button"
@@ -151,6 +152,7 @@ function ImageLogs({
           {logsVisible ? "hide" : "show"}
         </button>
         <button
+          id="btn-view-raw-log"
           className="btn btn-link"
           type="button"
           onClick={(ev) => {

--- a/js/packages/binderhub-react-components/src/LinkGenerator.jsx
+++ b/js/packages/binderhub-react-components/src/LinkGenerator.jsx
@@ -238,6 +238,7 @@ export function LinkGenerator({
         </div>
         <div className="col-2">
           <button
+            id="btn-launch"
             className="btn btn-primary col-2 w-100"
             disabled={isLaunching}
             onClick={() => setIsLaunching(true)}
@@ -259,7 +260,7 @@ export function LinkGenerator({
           <button
             className="btn btn-outline-secondary border border-2 border-start-0"
             type="button"
-            id="copy-url"
+            id="btn-copy-url"
             onClick={() => copy(launchUrl)}
             disabled={launchUrl === ""}
           >
@@ -272,6 +273,7 @@ export function LinkGenerator({
         <div className="card-header d-flex align-items-baseline">
           <span className="flex-fill">Badges for your README</span>
           <button
+            id="btn-show-badge"
             className="btn btn-link"
             type="button"
             aria-controls="badge-container"
@@ -333,7 +335,7 @@ export function LinkGenerator({
             <button
               className="btn btn-outline-secondary"
               type="button"
-              id="copy-url"
+              id="btn-copy-badge"
               onClick={() => copy(badgeMarkup)}
               disabled={badgeMarkup === ""}
             >


### PR DESCRIPTION
When working on https://github.com/jupyterhub/mybinder.org-deploy/issues/3264, I was having problems to apply the CSS to the buttons. Because we only have a very limited number of buttons, I added a `id` to each one of the buttons. This helped me to apply the CSS because the `id` has priority over `class`.