### PR TITLE
test: add random seed in conftest

### DIFF
--- a/binderhub/tests/conftest.py
+++ b/binderhub/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import secrets
 import subprocess
 import time
+import random
 from collections import defaultdict
 from unittest import mock
 from urllib.parse import urlparse
@@ -63,6 +64,9 @@ def pytest_configure(config):
         "markers",
         "helm: mark test to only run when BinderHub is launched with our k8s-binderhub test config.",
     )
+
+    # add the random seed for reproducibility of tests that uses random
+    random.seed(42)
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
This PR adds a fixed `random.seed(42)` to `pytest_configure` in `conftest.py` to ensure deterministic behavior for tests that rely on Python’s random module.

This change was motivated by the `test test_registry`, which includes logic that uses random. Without setting a seed, test outcomes could vary between runs, making it harder to debug or reproduce issues. By setting the seed once at the start of the test session, we improve consistency and test reliability.