### PR TITLE
Fix f-string syntax in test_ui.py for python<3.12

### DIFF
--- a/integration-tests/test_ui.py
+++ b/integration-tests/test_ui.py
@@ -108,7 +108,7 @@ async def test_loading_page(
     if status_code == 200:
         nbviewer_url = page.get_by_test_id("nbviewer-iframe").get_attribute("src")
         expected_url = (
-            f"https://nbviewer.jupyter.org/github/{repo}/tree/{ref.replace("/", "")}"
+            f"https://nbviewer.jupyter.org/github/{repo}/tree/{ref.replace('/', '')}"
         )
         assert nbviewer_url == expected_url
 


### PR DESCRIPTION
The `expected_url` f-string was incorrectly using strong quotes inside the brackets, while using strong quotes itself (which can only be done since python 3.12 IIRC).