### PR TITLE
Add missing steps to kubernetes integration

### DIFF
--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -106,6 +106,22 @@ chart](develop-helm-chart).
 ## Develop Kubernetes integration
 
 ```{important}
+This requires you create the JS and CSS bundles BinderHub serves to visitors.
+
+1. Install the NodeJS dependencies from `package.json`.
+
+   ```bash
+   npm install
+   ```
+
+1. Create the JS and CSS bundles.
+
+   ```bash
+   npm run webpack
+   ```
+```
+
+```{important}
 This requires `helm` and a functional Kubernetes cluster. Please do
 [preliminary Kubernetes setup](kubernetes-setup) if you haven't already
 before continuing here.

--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -110,15 +110,15 @@ This requires you create the JS and CSS bundles BinderHub serves to visitors.
 
 1. Install the NodeJS dependencies from `package.json`.
 
-   ```bash
+   ~~~bash
    npm install
-   ```
+   ~~~
 
 1. Create the JS and CSS bundles.
 
-   ```bash
+   ~~~bash
    npm run webpack
-   ```
+   ~~~
 ```
 
 ```{important}


### PR DESCRIPTION
I followed the [Develop Kubernetes integration](https://binderhub.readthedocs.io/en/latest/contribute.html#develop-kubernetes-integration) and I noticed that the JavaScript and CSS bundles were missing.

```
[E 250725 15:04:51 web:3194] Could not open static file '/home/raniere/github.com/jupyterhub/binderhub/binderhub/static/dist/styles.css'
[E 250725 15:04:51 web:3194] Could not open static file '/home/raniere/github.com/jupyterhub/binderhub/binderhub/static/dist/bundle.js'
```

Although the bundles are **not** required to develop the Kubernetes integration, the last step

> Visit http://localhost:8585/

will not work as expected if the user does not have the bundles.

This PR adds a note regarding the creation of the bundles.