### PR TITLE
Make local binder config Kubernetes distribution agnostic

### DIFF
--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -134,6 +134,20 @@ before continuing here.
    ./testing/local-binder-k8s-hub/install-jupyterhub-chart
    ```
 
+1. Export the location of your JupyterHub to the environment variable `LOCAL_BINDER_JUPYTERHUB_IP`.
+
+   If using `minikube`,
+
+   ```bash
+   export LOCAL_BINDER_JUPYTERHUB_IP=$(minikube ip)
+   ```
+
+   If using Docker Desktop,
+
+   ```bash
+   export LOCAL_BINDER_JUPYTERHUB_IP='kubernetes.docker.internal'
+   ```
+
 1. Configure `docker` using environment variables to use the same Docker daemon
    as your local Kubernetes cluster. This means images you build are directly
    available to the cluster.

--- a/testing/local-binder-k8s-hub/binderhub_config.py
+++ b/testing/local-binder-k8s-hub/binderhub_config.py
@@ -5,8 +5,10 @@
 # - BinderHub:  standalone local installation
 # - JupyterHub: standalone k8s installation
 
+import logging
 import os
-import subprocess
+
+logger = logging.getLogger(__name__)
 
 # We need to find out the IP at which BinderHub can reach the JupyterHub API
 # For local development we recommend the use of minikube, but on GitHub
@@ -19,10 +21,13 @@ if in_github_actions:
     jupyterhub_ip = "localhost"
 
 else:
-    try:
-        jupyterhub_ip = subprocess.check_output(["minikube", "ip"], text=True).strip()
-    except (subprocess.SubprocessError, FileNotFoundError):
-        jupyterhub_ip = "192.168.1.100"
+    jupyterhub_ip = os.getenv("LOCAL_BINDER_JUPYTERHUB_IP", None)
+
+    if jupyterhub_ip is None:
+        logger.warning(
+            "LOCAL_BINDER_JUPYTERHUB_IP environment variable is missing. Using 'localhost' as JupyterHub's domain."
+        )
+        jupyterhub_ip = "localhost"
 
 c.BinderHub.debug = True
 c.BinderHub.hub_url = f"http://{jupyterhub_ip}:30902"


### PR DESCRIPTION
This implements the proposal in https://github.com/jupyterhub/binderhub/issues/1992.

Developers using [minikube] will be required to export the IP address used by their [minikube] into the environment variable `LOCAL_BINDER_JUPYTERHUB_IP`.

[minikube]: https://minikube.sigs.k8s.io/