### PR TITLE
Remove / from BINDER_URL used in test-local

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -455,7 +455,7 @@ jobs:
 
       - name: Run remote tests
         run: |
-          export BINDER_URL=http://localhost:8000/services/binder/
+          export BINDER_URL=http://localhost:8000/services/binder
           pytest -m remote --cov=binderhub binderhub/tests/
 
       - name: Show hub logs


### PR DESCRIPTION
As mentioned in https://github.com/jupyterhub/binderhub/issues/1983#issuecomment-3139087640, the `test-local` are calling

```
http://localhost:8000/services/binder//build/git/https%3A%2F%2Fgithub.com%2Fbinderhub-ci-repos%2Fcached-minimal-dockerfile/HEAD
```

instead of

```
http://localhost:8000/services/binder/build/git/https%3A%2F%2Fgithub.com%2Fbinderhub-ci-repos%2Fcached-minimal-dockerfile/HEAD
```

Please note the double slash (`/`). It is causing BinderHub to return `404: Not Found`.

Given that all the other tests are passing, remove the extra slash (`/`) from the `BINDER_URL` environment variable sounds to me the correct way to fix the failing tests.

Closes https://github.com/jupyterhub/binderhub/issues/1983