### PR TITLE
Replace time.sleep() with asyncio.sleep()

### DIFF
--- a/integration-tests/test_ui.py
+++ b/integration-tests/test_ui.py
@@ -2,9 +2,9 @@
 Integration tests using playwright
 """
 
+import asyncio
 import subprocess
 import sys
-import time
 
 import pytest
 import requests
@@ -42,7 +42,7 @@ async def local_hub_local_binder(request):
                 break
         except requests.exceptions.ConnectionError:
             pass
-        time.sleep(1)
+        await asyncio.sleep(1)
     yield url
 
     proc.terminate()


### PR DESCRIPTION
This is based on the answer from ChatGPG:

> 🚨 Problem: time.sleep(1) blocks the event loop
> 
> Inside an async def function (like your fixture), calling time.sleep(1) blocks the entire event loop, which prevents other async tasks (like your server startup or the test scheduler) from running properly. This can result in:
> 
> - The fixture yielding before the server is truly ready, because the event loop is starved during the wait.
> - Race conditions in which the test starts using the url before the server responds.
> 
> ✅ Solution: Replace time.sleep(1) with await asyncio.sleep(1)
> 
> That way, the event loop can continue processing while waiting, allowing the server time to start up properly.

Closes https://github.com/jupyterhub/binderhub/issues/1998