### PR TITLE
Fix race condition in test_loading_page

### DIFF
--- a/integration-tests/test_ui.py
+++ b/integration-tests/test_ui.py
@@ -42,7 +42,12 @@ async def local_hub_local_binder(request):
                 break
         except requests.exceptions.ConnectionError:
             pass
-        time.sleep(1)
+        # We use a increased linear time between requests
+        # because BinderHub server might require more than 10s to start.
+        time.sleep(i)
+    else:
+        print("BinderHub server is down! Tests will probably fail.")
+    # PyTest requires the yield instruction here!
     yield url
 
     proc.terminate()

--- a/integration-tests/test_ui.py
+++ b/integration-tests/test_ui.py
@@ -2,9 +2,9 @@
 Integration tests using playwright
 """
 
-import asyncio
 import subprocess
 import sys
+import time
 
 import pytest
 import requests
@@ -42,7 +42,7 @@ async def local_hub_local_binder(request):
                 break
         except requests.exceptions.ConnectionError:
             pass
-        await asyncio.sleep(1)
+        time.sleep(1)
     yield url
 
     proc.terminate()


### PR DESCRIPTION
Closes https://github.com/jupyterhub/binderhub/issues/1998

This is based on https://github.com/rgaiacs/binderhub/actions/runs/16830429222/job/47676539438.

The call https://github.com/jupyterhub/binderhub/blob/457ce23a0b6c7f7da56bd15810cc12032e565b32/.github/workflows/playwright.yaml#L88 starts the execution of https://github.com/jupyterhub/binderhub/blob/457ce23a0b6c7f7da56bd15810cc12032e565b32/integration-tests/test_ui.py#L92 that has as dependency the fixture https://github.com/jupyterhub/binderhub/blob/457ce23a0b6c7f7da56bd15810cc12032e565b32/integration-tests/test_ui.py#L19 responsible to start the JupyterHub and BinderHub server as a subprocess https://github.com/jupyterhub/binderhub/blob/457ce23a0b6c7f7da56bd15810cc12032e565b32/integration-tests/test_ui.py#L26 A for-loop is used to force the test to wait for the JupyterHub and BinderHub to be running https://github.com/jupyterhub/binderhub/blob/457ce23a0b6c7f7da56bd15810cc12032e565b32/integration-tests/test_ui.py#L37-L45 The for-loop assumes that the JupyterHub and BinderHub will be running in less than 10 seconds. This assumption is valid as usually takes less than 5 seconds for JupyterHub and BinderHub to be running.

```
2025-08-08T12:30:43.9693623Z [I 2025-08-08 12:30:43.968 JupyterHub app:3354] Running JupyterHub version 5.3.0
2025-08-08T12:30:44.7843121Z [I 2025-08-08 12:30:44.784 JupyterHub service:423] Starting service 'binder': ['python', '-mbinderhub', '--config=/home/runner/work/binderhub/binderhub/testing/local-binder-local-hub/binderhub_config.py', '--port=50087']
2025-08-08T12:30:47.6670578Z [I 250808 12:30:47 app:1120] BinderHub starting on port 50087
2025-08-08T12:30:47.8608506Z [W 2025-08-08 12:30:47.860 JupyterHub proxy:445] Adding missing route for binder (Server(url=http://localhost:50087/services/binder/, bind_url=http://localhost:50087/services/binder/))
2025-08-08T12:30:47.8674210Z [I 2025-08-08 12:30:47.867 JupyterHub app:3778] JupyterHub is now running at http://:55483/
2025-08-08T12:30:47.8694761Z [D 2025-08-08 12:30:47.868 JupyterHub app:3347] It took 3.945 seconds for the Hub to start
```

 Unfortunately, the tests to check if JupyterHub and BinderHub are running happens 10 seconds before the server is ready.

```
2025-08-08T12:30:36.1494173Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #0 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:37.1557788Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #1 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:38.1586443Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #2 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:39.1624992Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #3 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:40.1651928Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #4 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:41.1686785Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #5 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:42.1713366Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #6 to http://127.0.0.1:55483/services/binder/
2025-08-08T12:30:43.1739505Z [35mDEBUG   [0m test_ui:test_ui.py:43 Debugging 1998. Making request #7 to http://127.0.0.1:55483/services/binder/
```

This pull request changes the `time.sleep()` strategy to a increased time instead of a linear one. This will make the tests to take longer to run but will reduce the changes of having problems with race condition.

A `print()` statement was included to aid similar problems in the future.