### PR TITLE
Clean-up dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 beautifulsoup4[html5lib]
 build
 chartpress>=2.1
-click
 dockerspawner
 jupyter-repo2docker>=2021.08.0
 jupyter_packaging>=0.10.4,<2


### PR DESCRIPTION
If a dependency is in requirements.txt it doesn't need to be repeated in dev-requirements.txt

Remove click dependency that isn't imported anywhere