### PR TITLE
Export BinderHub JavaScript client as default

### DIFF
--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.0",
   "description": "Simple API client for the BinderHub EventSource API",
   "exports": {
+    ".": "./lib/client.js",
     "./*.js": "./lib/*.js"
   },
   "repository": {


### PR DESCRIPTION
Closes https://github.com/jupyterhub/binderhub/issues/2006

This should avoid breaking change in the [binderhub-client](https://www.npmjs.com/package/@jupyterhub/binderhub-client).

The previous way is

```
import { BinderRepository } from "@jupyterhub/binderhub-client";
```

and the new way is

```
import { BinderRepository } from "@jupyterhub/binderhub-client/client.js";
```

The new way is preferable as it is clear to the reader.