### PR TITLE
Update the commands of the helm post install notes to map helm chart fields correctly:

### DIFF
--- a/helm-chart/binderhub/templates/NOTES.txt
+++ b/helm-chart/binderhub/templates/NOTES.txt
@@ -159,9 +159,10 @@ config:
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP"  .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component=binder" -o name)
+  export POD_PORT=$(kubectl get svc binder -o jsonpath="{.spec.ports[0].targetPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+  kubectl port-forward $POD_NAME 8080:$POD_PORT
 {{- end }}
 
 {{- $breaking := "" }}


### PR DESCRIPTION
When binder is installed with the helm chart, and is only exposed via a ClusterIP Kubernetes Service, the `kubectl` commands of the post install notes are erroring in subtle ways:

~~~
kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}"
 ~~~

can fail because `{{ template "fullname" . }}` does not always match the hardcoded labels we set in https://github.com/jupyterhub/binderhub/blob/33bcc37c2fd18573d19a13c5a41b1d8d563c3663/helm-chart/binderhub/templates/deployment.yaml#L20

and

~~~
kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }} 
~~~

always fails because we don't expose set or expose an  externalPort field in https://github.com/jupyterhub/binderhub/blob/33bcc37c2fd18573d19a13c5a41b1d8d563c3663/helm-chart/binderhub/values.yaml#L34

This commit fixes the two errors by using immutables, non-overridables values from the helm templates.