### PR TITLE
Revert "Update library/docker version from 27.5.1-dind to 28.3.3-dind"

### DIFF
--- a/helm-chart/binderhub/values.yaml
+++ b/helm-chart/binderhub/values.yaml
@@ -280,7 +280,7 @@ dind:
   daemonset:
     image:
       name: docker.io/library/docker
-      tag: "28.3.3-dind" # ref: https://hub.docker.com/_/docker/tags
+      tag: "27.5.1-dind" # ref: https://hub.docker.com/_/docker/tags
       pullPolicy: ""
       pullSecrets: []
     # Additional command line arguments to pass to dockerd


### PR DESCRIPTION
Reverts jupyterhub/binderhub#1937

Investigating problems with pushing to a registry on mybinder:
https://github.com/jupyterhub/mybinder.org-deploy/issues/3387#issuecomment-3239287733