### PR TITLE
add BinderHub.extra_header_html

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -174,6 +174,19 @@ class BinderHub(Application):
         config=True,
     )
 
+    extra_header_html = Dict(
+        help="""
+        Extra bits of HTML that should be loaded in the HTML <head> tag of each page.
+
+        Values are included exactly as-is at the end of the `<head>` element.
+        Only the values are set up as snippets.
+        Keys are used only for sorting.
+
+        This should be primarily used for analytics code.
+        """,
+        config=True,
+    )
+
     extra_footer_scripts = Dict(
         {},
         help="""
@@ -959,6 +972,7 @@ class BinderHub(Application):
                 "about_message": self.about_message,
                 "banner_message": self.banner_message,
                 "extra_footer_scripts": self.extra_footer_scripts,
+                "extra_header_html": self.extra_header_html,
                 "jinja2_env": jinja_env,
                 "build_docker_config": self.build_docker_config,
                 "base_url": self.base_url,

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -42,6 +42,7 @@ class UIHandler(BaseHandler):
             "page.html",
             page_config=self.page_config,
             extra_footer_scripts=self.settings["extra_footer_scripts"],
+            extra_header_html=self.settings["extra_header_html"],
             opengraph_title=self.opengraph_title,
         )
 

--- a/binderhub/templates/page.html
+++ b/binderhub/templates/page.html
@@ -19,6 +19,13 @@
   <script>
     window.pageConfig = {{page_config|tojson}};
   </script>
+  {%- block extra_header %}
+  {%- if extra_header_html %}
+  {%- for _, snippet in extra_header_html | dictsort %}
+  {{ snippet | trim | safe }}
+  {%- endfor %}
+  {%- endif %}
+  {%- endblock extra_header %}
 </head>
 <body>
 <div id="root"></div>


### PR DESCRIPTION
allows extra head elements (mainly analytics such as plausible)

same as `extra_footer_scripts`, but for the cases where a tag should be in the `<head> instead. Not script source, because these scripts may need to set attributes (e.g. plausible).

xref: https://github.com/jupyterhub/team-compass/issues/803