### PR TITLE
Increase patch in version number of @jupyterhub/binderhub-client

### DIFF
--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterhub/binderhub-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Simple API client for the BinderHub EventSource API",
   "exports": {
     ".": "./lib/client.js",


### PR DESCRIPTION
This is to fix a **minor** problem that I created yesterday. Sorry.

https://github.com/jupyterhub/binderhub/pull/1978 was merged on 20 August 2025. Yuvi said

> I would love for us to not have a breaking change in the binderhub client if we can!

I created https://github.com/jupyterhub/binderhub/pull/2007 but merge was pending until 8 September 2025.

Before https://github.com/jupyterhub/binderhub/pull/2007 was reviewed and merged, I created https://github.com/jupyterhub/binderhub/pull/2013 and pushed the new version of the JavaScript packages to NPM. **Unfortunately**, https://github.com/jupyterhub/binderhub/pull/2007 was not included when I pushed the packages to NPM.

This pull request increases the patch in the version number of the NPM package `@jupyterhub/binderhub-client`. `@jupyterhub/binderhub-client` version 0.5.0 will have a break change regarding how to import the package. `@jupyterhub/binderhub-client` version 0.5.1 will fix this break change.

Sorry again for this. Given this pull request only changes the version number, I will merge it so that I can push to NPM sooner.