### PR TITLE
Import noxfile.py from team-compass

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,38 @@
+import os.path
+
+import nox
+
+nox.options.reuse_existing_virtualenvs = True
+
+
+@nox.session(default=False)
+def docs(session):
+    """
+    Build the documentation and, optionally with '-- live', run a web server.
+    """
+    docs_dir = "docs"
+    source_dir = os.path.join(docs_dir, "source")  # where conf.py is located
+    data_dir = os.path.join(source_dir, "_data")
+    output_dir = os.path.join(docs_dir, "_build")
+
+    session.install("-r", os.path.join(docs_dir, "requirements.txt"))
+
+    doc_build_default_args = ["-b", "dirhtml", source_dir, output_dir]
+
+    if "live" in session.posargs:
+        # For live preview, sphinx-autobuild is used.
+        # To avoid sphinx-autobuild be missing,
+        # sphinx-autobuild is installed explicitly.
+        session.install("sphinx-autobuild")
+        cmd = ["sphinx-autobuild"]
+
+        # Add relative paths to this if we ever need to ignore them
+        autobuild_ignore = [output_dir, os.path.join(data_dir, "generated")]
+
+        for folder in autobuild_ignore:
+            cmd.extend(["--ignore", f"*/{folder}/*"])
+
+        cmd.extend(doc_build_default_args)
+        session.run(*cmd)
+    else:
+        session.run("sphinx-build", *doc_build_default_args)


### PR DESCRIPTION
This is related to https://github.com/jupyterhub/team-compass/issues/819.

This pull request adds a copy of `noxfile.py` similar to https://github.com/jupyterhub/team-compass/pull/821.

```bash
nox -s docs
```

shows some warnings, e.g.

```
docstring of binderhub.app.BinderHub.enable_api_only_mode:3: ERROR: Unexpected indentation. [docutils]
docstring of binderhub.app.BinderHub.google_analytics_code:3: WARNING: Literal block expected; none found. [docutils]
docstring of binderhub.app.BinderHub.google_analytics_domain:3: WARNING: Literal block expected; none found. [docutils]
WARNING: autodoc: failed to import class 'Build' from module 'binderhub.build'; the following exception was raised:
Traceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/util/inspect.py", line 461, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'binderhub.build' has no attribute 'Build'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 288, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/__init__.py", line 384, in get_attr
    return autodoc_attrgetter(obj, name, *defargs, registry=self.env._registry)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/__init__.py", line 3149, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/util/inspect.py", line 477, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: Build
 [autodoc.import_object]
WARNING: autodoc: failed to import class 'MainHandler' from module 'binderhub.main'; the following exception was raised:
Traceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/util/inspect.py", line 461, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'binderhub.main' has no attribute 'MainHandler'. Did you mean: 'BaseHandler'?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 288, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/__init__.py", line 384, in get_attr
    return autodoc_attrgetter(obj, name, *defargs, registry=self.env._registry)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/__init__.py", line 3149, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/util/inspect.py", line 477, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: MainHandler
 [autodoc.import_object]
WARNING: autodoc: failed to import class 'ParameterizedMainHandler' from module 'binderhub.main'; the following exception was raised:
Traceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/util/inspect.py", line 461, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'binderhub.main' has no attribute 'ParameterizedMainHandler'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/importer.py", line 288, in import_object
    obj = attrgetter(obj, mangled_name)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/__init__.py", line 384, in get_attr
    return autodoc_attrgetter(obj, name, *defargs, registry=self.env._registry)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/ext/autodoc/__init__.py", line 3149, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/home/raniere/github.com/jupyterhub/binderhub/.nox/docs/lib/python3.13/site-packages/sphinx/util/inspect.py", line 477, in safe_getattr
    raise AttributeError(name) from exc
AttributeError: ParameterizedMainHandler
 [autodoc.import_object]
/home/raniere/github.com/jupyterhub/binderhub/docs/source/zero-to-binderhub/setup-binderhub.rst:64: WARNING: Title underline too short.

If you are using Google Artifact Registry
~~~~~~~~~~~~~~~~~~~~~~~~~~~ [docutils]
/home/raniere/github.com/jupyterhub/binderhub/docs/source/zero-to-binderhub/setup-binderhub.rst:64: WARNING: Title underline too short.

If you are using Google Artifact Registry
~~~~~~~~~~~~~~~~~~~~~~~~~~~ [docutils]
/home/raniere/github.com/jupyterhub/binderhub/docs/source/zero-to-binderhub/setup-binderhub.rst:188: WARNING: Title underline too short.

If you are using Google Artifact Registry
~~~~~~~~~~~~~~~~~~~~~~~~~~~ [docutils]
/home/raniere/github.com/jupyterhub/binderhub/docs/source/zero-to-binderhub/setup-binderhub.rst:188: WARNING: Title underline too short.

If you are using Google Artifact Registry
~~~~~~~~~~~~~~~~~~~~~~~~~~~ [docutils]
```