### PR TITLE
Replace https://demo.ckan.org/dataset/sample-dataset-1 with https://demo.ckan.org/dataset/my-sample-dataset-001

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -506,7 +506,7 @@ class CKANProvider(RepoProvider):
         "spec": {"validateRegex": r"[^/]+"},
         "repo": {
             "label": "CKAN dataset URL",
-            "placeholder": "https://demo.ckan.org/dataset/sample-dataset-1",
+            "placeholder": "https://demo.ckan.org/dataset/my-sample-dataset-001",
             "urlEncode": True,
         },
         "ref": {"enabled": False},

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -207,11 +207,11 @@ async def test_dataverse(
     "spec,resolved_spec,resolved_ref,resolved_ref_url,build_slug",
     [
         [
-            "https://demo.ckan.org/dataset/sample-dataset-1",
-            "https://demo.ckan.org/dataset/sample-dataset-1",
-            "sample-dataset-1.v",
-            "https://demo.ckan.org/dataset/sample-dataset-1",
-            "ckan-sample-dataset-1",
+            "https://demo.ckan.org/dataset/my-sample-dataset-001",
+            "https://demo.ckan.org/dataset/my-sample-dataset-001",
+            "my-sample-dataset-001.v",
+            "https://demo.ckan.org/dataset/my-sample-dataset-001",
+            "ckan-my-sample-dataset-001",
         ],
         [
             "https://data.depositar.io/dataset/binder-example-sea-turtle-sightings-in-taiwan/?activity_id=93df7fd0-0edc-4ebf-bac7-fbf5f78de90b",


### PR DESCRIPTION
Closes https://github.com/jupyterhub/binderhub/issues/2035

Is this new dataset identifier stable?