### PR TITLE
feat: support Node.js for `@jupyterhub/binderhub-client`

### DIFF
--- a/js/packages/binderhub-client/lib/client.js
+++ b/js/packages/binderhub-client/lib/client.js
@@ -144,9 +144,10 @@ export class BinderRepository {
       };
 
       const onError = (error) => {
+        const reason = error.message === undefined ? "" : `: ${error.message}`;
         queue.push({
           phase: "failed",
-          message: `Error in event stream: ${error.message}\n`,
+          message: `Error in event stream${reason}\n`,
         });
         queue.stop();
       };

--- a/js/packages/binderhub-client/lib/client.js
+++ b/js/packages/binderhub-client/lib/client.js
@@ -145,8 +145,8 @@ export class BinderRepository {
 
       const onError = (error) => {
         queue.push({
-          phase: "unknown",
-          message: `Error in event stream: ${error}\n`,
+          phase: "failed",
+          message: `Error in event stream: ${error.message}\n`,
         });
         queue.stop();
       };

--- a/js/packages/binderhub-client/package.json
+++ b/js/packages/binderhub-client/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/jupyterhub/binderhub#readme",
   "dependencies": {
-    "@microsoft/fetch-event-source": "^2.0.1",
+    "eventsource": "^4.1.0",
     "event-iterator": "^2.0.0"
   }
 }

--- a/js/packages/binderhub-client/tests/index.test.js
+++ b/js/packages/binderhub-client/tests/index.test.js
@@ -1,30 +1,6 @@
-// fetch polyfill (only needed for node tests)
-import { fetch, TextDecoder } from "@whatwg-node/fetch";
-
 import { BinderRepository } from "@jupyterhub/binderhub-client/client.js";
 import { parseEventSource, simpleEventSourceServer } from "./utils";
 import { readFileSync } from "node:fs";
-
-async function wrapFetch(resource, options) {
-  /* like fetch, but ignore signal input
-  // abort signal shows up as uncaught in tests, despite  working fine
-  */
-  if (options) {
-    options.signal = null;
-  }
-  return fetch.apply(null, [resource, options]);
-}
-
-beforeAll(() => {
-  // inject globals for fetch
-  global.TextDecoder = TextDecoder;
-  if (!global.window) {
-    global.window = {};
-  }
-  if (!global.window.fetch) {
-    global.window.fetch = wrapFetch;
-  }
-});
 
 test("Passed in URL object is not modified", () => {
   const buildEndpointUrl = new URL("https://test-binder.org/build");

--- a/js/packages/binderhub-client/tests/index.test.js
+++ b/js/packages/binderhub-client/tests/index.test.js
@@ -65,7 +65,6 @@ describe("Iterate over full output from calling the binderhub API", () => {
     [serverUrl, closeServer] = await simpleEventSourceServer({
       "/build/gh/test/test": responseContents,
     });
-    console.log(serverUrl);
   });
 
   afterEach(() => closeServer());
@@ -104,7 +103,7 @@ describe("Invalid eventsource response causes failure", () => {
     expect(messages).toStrictEqual([
       {
         phase: "failed",
-        message: "Event stream closed unexpectedly\n",
+        message: "Error in event stream\n",
       },
     ]);
   });

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "@babel/preset-env": "^7.21.4",
     "@babel/preset-react": "^7.26.3",
     "@types/react": "^19.0.0",
+    "@happy-dom/jest-environment": "^20.8.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
     "configurable-http-proxy": "^4.6.2",
     "@types/jest": "^29.5.5",
-    "@whatwg-node/fetch": "^0.9.17",
     "autoprefixer": "^10.4.19",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.2",
@@ -57,7 +57,7 @@
     "test": "jest"
   },
   "jest": {
-    "testEnvironment": "jsdom",
+    "testEnvironment": "@happy-dom/jest-environment",
     "collectCoverage": true,
     "coverageReporters": [
       "text",


### PR DESCRIPTION
This PR switches out [`@microsoft/fetch-event-source`](https://www.npmjs.com/package/@microsoft/fetch-event-source) in favour of [`eventsource`](https://www.npmjs.com/package/eventsource). This package is both newer (and maintained) and explicitly supports the Node.js runtime.

I'm consuming a vendored version of these changes in https://github.com/2i2c-org/clinder/tree/main/packages/binderhub-client-next, which is Node.js only.

---

- closes https://github.com/jupyterhub/binderhub/issues/2111