### PR TITLE
Update Jupyter Server token documentation link

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -147,10 +147,10 @@ event or failing and emitting a 'failed' event.
 Ready
 ~~~~~
 
-When your notebook is ready! You get a endpoint URL and a token used to
-access it. You can access the notebook / API by using the token in one
-of the ways the `notebook accepts security
-tokens <https://jupyter-notebook.readthedocs.io/en/stable/security.html>`__.
+When your notebook is ready! You get an endpoint URL and a token used to
+access it. You can access the Jupyter server / API by using the token
+in one of the ways that `Jupyter Server accepts security
+tokens <https://jupyter-server.readthedocs.io/en/stable/operators/security.html>`__.
 
 ::
 


### PR DESCRIPTION
## Summary
- replace a broken Jupyter Notebook security-token link with the current Jupyter Server security documentation
- update the wording from notebook/API to Jupyter server/API
- fix the nearby "a endpoint" grammar issue

Fixes #1841.

## Validation
- `git diff --check`
- verified the replacement URL returns HTTP 200