### PR TITLE
Add some bot-blocking config, block many bots by default

### DIFF
--- a/binderhub/app.py
+++ b/binderhub/app.py
@@ -32,6 +32,7 @@ from traitlets import (
     Bytes,
     Dict,
     Integer,
+    List,
     TraitError,
     Type,
     Unicode,
@@ -310,6 +311,26 @@ class BinderHub(Application):
 
         Set to false to use only local docker images. Useful when running
         in a single node.
+        """,
+        config=True,
+    )
+
+    block_build_user_agents = List(
+        Unicode(),
+        default_value=[
+            ".*bot.*",
+            ".*gpt.*",
+            ".*crawler.*",
+            ".*spider.*",
+        ],
+        help="""
+        Prevent self-identified bots and crawlers from triggering builds.
+
+        List of user-agent regular expressions which will not be allowed to build.
+
+        Expressions will be case-insensitive.
+
+        Default: broad block of any user agent containing bot/gpt/crawler/spider
         """,
         config=True,
     )
@@ -945,6 +966,11 @@ class BinderHub(Application):
         # Construct a Builder so that we can extract parameters such as the
         # configuration or the version string to pass to /version and /health handlers
         example_builder = self.build_class(parent=self)
+
+        block_build_user_agent_patterns = [
+            re.compile(pattern, re.IGNORECASE)
+            for pattern in self.block_build_user_agents
+        ]
         self.tornado_settings.update(
             {
                 "log_function": log_request,
@@ -953,6 +979,7 @@ class BinderHub(Application):
                 "default_opengraph_title": self.default_opengraph_title,
                 "launcher": self.launcher,
                 "ban_networks": self.ban_networks,
+                "block_build_user_agents": block_build_user_agent_patterns,
                 "build_pool": self.build_pool,
                 "build_token_check_origin": self.build_token_check_origin,
                 "build_token_secret": self.build_token_secret,

--- a/binderhub/base.py
+++ b/binderhub/base.py
@@ -157,14 +157,17 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
             self.set_header(header, value)
         self.set_header("access-control-allow-headers", "cache-control")
 
-    def get_spec_from_request(self, prefix):
+    def get_spec_from_request(self):
         """Re-extract spec from request.path.
         Get the original, raw spec, without tornado's unquoting.
         This is needed because tornado converts 'foo%2Fbar/ref' to 'foo/bar/ref'.
         """
+        # Handler.spec_prefix must be defined
+        prefix = self.spec_prefix
         idx = self.request.path.index(prefix)
-        spec = self.request.path[idx + len(prefix) + 1 :]
-        return spec
+        provider_spec = self.request.path[idx + len(prefix) :]
+        provider_id, _, spec = provider_spec.partition("/")
+        return provider_id, spec
 
     def get_provider(self, provider_prefix, spec):
         """Construct a provider object"""

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -262,7 +262,7 @@ class BuildHandler(BaseHandler):
 
         # check Accept header to make sure it's a real EventSource request
         accept_header = self.request.headers.get("Accept", "")
-        accept = {s.strip().lower() for s in accept_header.split(";")}
+        accept = {s.strip().lower() for s in accept_header.split(",")}
 
         user_agent = self.request.headers.get("User-Agent", "")
         block_build_user_agents = self.settings.get("block_build_user_agents", [])

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -195,6 +195,8 @@ class BuildHandler(BaseHandler):
 
     def send_error(self, status_code, **kwargs):
         """event stream cannot set an error code, so send an error event"""
+        # make sure status is set (not usually on event-stream requests)
+        self.set_status(status_code)
         exc_info = kwargs.get("exc_info")
         message = ""
         if exc_info:

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -264,9 +264,23 @@ class BuildHandler(BaseHandler):
         accept_header = self.request.headers.get("Accept", "")
         accept = {s.strip().lower() for s in accept_header.split(";")}
 
+        user_agent = self.request.headers.get("User-Agent", "")
+        block_build_user_agents = self.settings.get("block_build_user_agents", [])
+        for pattern in block_build_user_agents:
+            if pattern.match(user_agent):
+                app_log.warning(
+                    "Not allowing user agent %s matching %s to build %s",
+                    user_agent,
+                    pattern,
+                    self.request.uri,
+                )
+                raise HTTPError(403, "Bots not allowed")
+
         if "text/event-stream" not in accept:
             app_log.warning(
-                "Bad accept header: %s, missing text/event-stream", accept_header
+                "Bad accept header: %s, missing text/event-stream, User-Agent=%s",
+                accept_header,
+                user_agent,
             )
             raise HTTPError(400, "Missing Accept header: text/event-stream")
 

--- a/binderhub/builder.py
+++ b/binderhub/builder.py
@@ -55,6 +55,12 @@ BUILDS_INPROGRESS = Gauge("binderhub_inprogress_builds", "Builds currently in pr
 LAUNCHES_INPROGRESS = Gauge(
     "binderhub_inprogress_launches", "Launches currently in progress"
 )
+BUILDS_REJECTED = Counter(
+    "binderhub_builds_rejected",
+    "Counter of rejected build requests",
+    # often rejected before spec is resolved to repo, so use spec
+    ["reason", "spec", "user_agent"],
+)
 
 
 def _get_image_basename_and_tag(full_name):
@@ -146,6 +152,7 @@ class BuildHandler(BaseHandler):
     # emit keepalives every 25 seconds to avoid idle connections being closed
     KEEPALIVE_INTERVAL = 25
     build = None
+    spec_prefix = "/build/"
 
     async def emit(self, data):
         """Emit an eventstream event"""
@@ -259,6 +266,36 @@ class BuildHandler(BaseHandler):
         # disable redirect to login, which won't work for EventSource
         raise HTTPError(403)
 
+    def check_request_ip(self):
+        try:
+            super().check_request_ip()
+        except HTTPError:
+            self._record_rejected_build(reason="banned_ip")
+            raise
+
+    def check_rate_limit(self):
+        try:
+            super().check_rate_limit()
+        except HTTPError:
+            self._record_rejected_build(reason="rate_limit")
+            raise
+
+    def _record_rejected_build(self, reason, msg=""):
+        provider_id, spec = self.get_spec_from_request()
+        spec = f"{provider_id}/{spec}"
+
+        user_agent = self.request.headers.get("User-Agent", "")
+        ip = self.request.remote_ip
+        app_log.warning(
+            "Rejecting build: %s reason=%s spec=%s ip=%s user_agent=%r",
+            msg,
+            reason,
+            spec,
+            ip,
+            user_agent,
+        )
+        BUILDS_REJECTED.labels(reason=reason, spec=spec, user_agent=user_agent).inc()
+
     async def prepare(self):
         super().prepare()
 
@@ -270,19 +307,14 @@ class BuildHandler(BaseHandler):
         block_build_user_agents = self.settings.get("block_build_user_agents", [])
         for pattern in block_build_user_agents:
             if pattern.match(user_agent):
-                app_log.warning(
-                    "Not allowing user agent %s matching %s to build %s",
-                    user_agent,
-                    pattern,
-                    self.request.uri,
+                self._record_rejected_build(
+                    reason="user_agent", msg=f"user agent matching {pattern}"
                 )
                 raise HTTPError(403, "Bots not allowed")
 
         if "text/event-stream" not in accept:
-            app_log.warning(
-                "Bad accept header: %s, missing text/event-stream, User-Agent=%s",
-                accept_header,
-                user_agent,
+            self._record_rejected_build(
+                reason="accept_header", msg=f"Accept={accept_header!r}"
             )
             raise HTTPError(400, "Missing Accept header: text/event-stream")
 
@@ -302,8 +334,7 @@ class BuildHandler(BaseHandler):
                 repo, ref, etc.)
 
         """
-        prefix = "/build/" + provider_prefix
-        spec = self.get_spec_from_request(prefix)
+        _, spec = self.get_spec_from_request()
 
         # verify the build token and rate limit
         build_token = self.get_argument("build_token", None)
@@ -331,6 +362,7 @@ class BuildHandler(BaseHandler):
             return
 
         if provider.is_banned():
+            self._record_rejected_build(reason="banned_repo")
             await self.emit(
                 {
                     "phase": "failed",

--- a/binderhub/main.py
+++ b/binderhub/main.py
@@ -58,10 +58,11 @@ class RepoLaunchUIHandler(UIHandler):
         self.repo_provider = repo_provider
         return super().initialize()
 
+    spec_prefix = "/v2/"
+
     @authenticated
     def get(self, provider_id, _escaped_spec):
-        prefix = "/v2/" + provider_id
-        spec = self.get_spec_from_request(prefix)
+        _, spec = self.get_spec_from_request()
 
         build_token = jwt.encode(
             {

--- a/binderhub/static/robots.txt
+++ b/binderhub/static/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /

--- a/binderhub/tests/test_auth.py
+++ b/binderhub/tests/test_auth.py
@@ -78,7 +78,7 @@ async def test_auth(app, path, authenticated, use_session):
             "/build/gh/binderhub-ci-repos/requirements/d687a7f9e6946ab01ef2baa7bd6d5b73c6e904fd",
             True,
             24,
-            200,  # due to event-stream, status is always 200 even when rejected
+            403,
         ),
         # ban_networks shouldn't affect health endpoint
         ("/health", True, 32, (200, 503)),

--- a/binderhub/tests/test_bots.py
+++ b/binderhub/tests/test_bots.py
@@ -1,0 +1,43 @@
+from urllib.parse import quote
+
+import pytest
+
+from .utils import async_requests
+
+default_robots_txt = """
+User-Agent: *
+Disallow: /
+""".strip()
+
+
+async def test_robots_txt(app):
+    r = await async_requests.get(app.url + "/robots.txt")
+    assert r.text.strip() == default_robots_txt.strip()
+
+
+@pytest.mark.parametrize(
+    "user_agent",
+    [
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 (Applebot/0.1; +http://www.apple.com/go/applebot)",
+        "meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)",
+        "Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)",
+        "Mozilla/5.0 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html)",
+        "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; TikTokSpider; ttspider-feedback@tiktok.com)",
+        "Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0",
+        "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/136.0.0.0 Safari/537.36 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/116.0.1938.76 Safari/537.36",
+        "Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html)",
+    ],
+)
+async def test_blocked_bot_build(app, user_agent):
+    provider_spec = "git/{}/HEAD".format(
+        quote(
+            "https://neverused.example.org/sample-repo",
+            safe="",
+        )
+    )
+    r = await async_requests.get(
+        f"{app.url}/build/{provider_spec}", headers={"User-Agent": user_agent}
+    )
+    assert r.status_code == 403
+    assert "Bots not allowed" in r.text

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -251,7 +251,7 @@ async def test_build_only_fail(
         params={"build_only": build_only_query_param},
         headers={"Accept": "text/event-stream"},
     )
-    r.raise_for_status()
+    assert r.status_code == 400
     failed_events = 0
     async for line in async_requests.iter_lines(r):
         line = line.decode("utf8", "replace")

--- a/binderhub/tests/test_build.py
+++ b/binderhub/tests/test_build.py
@@ -115,7 +115,7 @@ async def test_build_check_accept(app):
         stream=True,
     )
     # even though we raised 400, the EventStream actually gets 200
-    assert r.status_code == 200
+    assert r.status_code == 400
     events = []
     async for line in async_requests.iter_lines(r):
         line = line.decode("utf8", "replace")


### PR DESCRIPTION
- defines default robots.txt that disallows all activity (trusts bots to obey robots.txt, 🤷 )
- adds `BinderHub.block_build_user_agents` config which blocks user agent patterns for build requests only. Default: block any UA containing a common bot/crawler/spider keywords (trusts bots to identify themselves in user agents)

This is based on recent traffic to mybinder.org, where a large number of builds (roughly 1/3) appear to be being launched by self-identified bots according to user-agent logs. Who knows how much traffic is bots that pretend to be regular browsers, but this appears to catch a lot and should help with load.

I think we didn't expect crawlers to hit the event-stream endpoint, but they definitely do. I'm not sure for how long they have done, either.