### PR TITLE
Prevent URI traversal for GitHub refs

### DIFF
--- a/binderhub/repoproviders.py
+++ b/binderhub/repoproviders.py
@@ -1054,11 +1054,13 @@ class GitHubRepoProvider(RepoProvider):
         if hasattr(self, "resolved_ref"):
             return self.resolved_ref
 
+        # Encode the ref (safe="" so its slashes can't inject extra path
+        # segments) to prevent traversal, see GHSA-q276-fxp7-xhx3.
         api_url = "{api_base_path}/repos/{user}/{repo}/commits/{ref}".format(
             api_base_path=self.api_base_path.format(hostname=self.hostname),
             user=self.user,
             repo=self.repo,
-            ref=self.unresolved_ref,
+            ref=urllib.parse.quote(self.unresolved_ref, safe=""),
         )
         self.log.debug("Fetching %s", api_url)
         cached = self.cache.get(api_url)

--- a/binderhub/tests/test_repoproviders.py
+++ b/binderhub/tests/test_repoproviders.py
@@ -1,6 +1,6 @@
 import re
 from unittest import TestCase
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import pytest
 from tornado.ioloop import IOLoop
@@ -415,6 +415,26 @@ def test_github_missing_ref():
     )
     ref = IOLoop().run_sync(provider.get_resolved_ref)
     assert ref is None
+
+
+async def test_github_ref_is_url_encoded(monkeypatch):
+    """An attacker-controlled ref must not inject extra GitHub API path segments."""
+    ref = "HEAD/../../../../owner/private/contents/README.md"
+    provider = GitHubRepoProvider(spec=f"user/repo/{ref}")
+
+    captured = {}
+
+    async def fake_request(api_url, etag=None):
+        captured["url"] = api_url
+        return None  # short-circuit before any network call
+
+    monkeypatch.setattr(provider, "github_api_request", fake_request)
+    await provider.get_resolved_ref()
+
+    path = urlparse(captured["url"]).path
+    # the ref's slashes are encoded, so the ".." cannot climb out of /commits/
+    assert path == f"/repos/user/repo/commits/{quote(ref, safe='')}"
+    assert "/../" not in path
 
 
 class TestSpecErrorHandling(TestCase):


### PR DESCRIPTION
This defect exposes an oracle for existence of private repos or refs through the Binder operator's github token.

Fixes
https://github.com/jupyterhub/binderhub/security/advisories/GHSA-q276-fxp7-xhx3.

I am sending this fix through a regular PR and not a private GHSA fork, because the vulnerability is not severe, and private forks have a lot of friction (no CI, 500 errors, easy to miss when releasing).

<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

https://github.com/jupyterhub/binderhub/security/advisories/GHSA-q276-fxp7-xhx3

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

No

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->
<details>
<summary>Claude-generated end to end test procedure</summary>

File 1 — listener.py (fake api.github.com)

```python
from http.server import BaseHTTPRequestHandler, HTTPServer

class H(BaseHTTPRequestHandler):
    def do_GET(self):
        print(">>> WIRE PATH :", self.path, flush=True)
        print(">>> AUTH HDR  :", self.headers.get("Authorization"), flush=True)
        self.send_response(404); self.end_headers()
        self.wfile.write(b'{"message":"Not Found"}')
    def log_message(self, *a): pass

HTTPServer(("127.0.0.1", 8000), H).serve_forever()
```

File 2 — bhub_config.py (standalone BinderHub, GitHub provider aimed at the listener)

```python
from binderhub.build import FakeBuild
from binderhub.registry import FakeRegistry
from binderhub.repoproviders import GitHubRepoProvider

c.BinderHub.builder_required = False
c.BinderHub.use_registry = True
c.BinderHub.registry_class = FakeRegistry
c.BinderHub.build_class = FakeBuild
c.BinderHub.repo_providers = {"gh": GitHubRepoProvider}

c.GitHubRepoProvider.hostname = "127.0.0.1:8000"
c.GitHubRepoProvider.api_base_path = "http://{hostname}"
c.GitHubRepoProvider.access_token = "SECRET-OPERATOR-TOKEN"
```

(Auth is off by default → the route is anonymous, exactly the default deployment mode.)

Run

```bash
python listener.py &                              # terminal 1
python -m binderhub -f bhub_config.py &            # terminal 2  (serves on :8585)
# wait until up:
until curl -s -o /dev/null http://127.0.0.1:8585/health; do sleep 1; done
```

Fire the two attacks

`--path-as-is` is required so curl doesn't collapse the .. itself — we want BinderHub's tornado to receive the raw path. The Accept: text/event-stream header is required or the build handler 400s.

```bash
# 1) ref injection
curl -s --path-as-is -H "Accept: text/event-stream" \
  "http://127.0.0.1:8585/build/gh/a/b/HEAD/../../../../OWNER/PRIVREPO/contents/README.md"

# 2) ".." owner pivot
curl -s --path-as-is -H "Accept: text/event-stream" \
  "http://127.0.0.1:8585/build/gh/../x/HEAD"
````

Expected results

Fixed (current HEAD):
- Attack 1 → listener logs WIRE PATH : /repos/a/b/commits/HEAD%2F..%2F..%2F..%2F..%2FOWNER%2FPRIVREPO%2Fcontents%2FREADME.md — slashes %2F-encoded, .. inert, request stays on a/b.
- Attack 2 → BinderHub replies "Invalid GitHub user: '..'", listener sees nothing (rejected at construction).

</details>


### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
You can use bullet points "-" if it helps.
-->

### Other information
<!--
Please provide any other information you think is relevant
-->

AI disclosure: tests generated by Claude Code (pytest and end to end)